### PR TITLE
Set additionalProperties: false in edu-benefits

### DIFF
--- a/dist/edu-benefits-schema.json
+++ b/dist/edu-benefits-schema.json
@@ -278,6 +278,7 @@
       "pattern": "^[0-9]{9}$"
     }
   },
+  "additionalProperties": false,
   "properties": {
     "chapter33": {
       "type": "object",

--- a/src/edu-benefits/schema.js
+++ b/src/edu-benefits/schema.js
@@ -128,6 +128,7 @@ module.exports = {
       pattern: '^[0-9]{9}$'
     },
   },
+  additionalProperties: false,
   properties: {
     chapter33: {
       type: 'object',


### PR DESCRIPTION
`additionalProperties: false` is a middle ground between having to explicitly set everything as `optional` or `required`, letting us verify we don't have any unaccounted-for data being submitted.