### PR TITLE
Add back previous claims

### DIFF
--- a/dist/edu-benefits-schema.json
+++ b/dist/edu-benefits-schema.json
@@ -381,6 +381,55 @@
         }
       }
     },
+    "previouslyFiledClaimWithVa": {
+      "type": "boolean"
+    },
+    "previousVaClaims": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "claimType": {
+            "type": "string",
+            "enum": [
+              "chapter30",
+              "chapter32",
+              "chapter33",
+              "chapter34",
+              "chapter35",
+              "chapter1606",
+              "chapter1607",
+              "nationalService",
+              "transferredBenefits",
+              "vocationalRehab"
+            ]
+          },
+          "previouslyAppliedWithSomeoneElsesService": {
+            "type": "boolean"
+          },
+          "fileNumber": {
+            "type": "string"
+          },
+          "sponsorVeteran": {
+            "type": "object",
+            "properties": {
+              "fullName": {
+                "$ref": "#/definitions/fullName"
+              },
+              "fileNumber": {
+                "type": "string"
+              },
+              "payeeNumber": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "claimType"
+        ]
+      }
+    },
     "school": {
       "type": "object",
       "properties": {

--- a/src/edu-benefits/schema.js
+++ b/src/edu-benefits/schema.js
@@ -217,6 +217,53 @@ module.exports = {
         }
       }
     },
+    previouslyFiledClaimWithVa: {
+      type: 'boolean'
+    },
+    previousVaClaims: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          claimType: {
+            type: 'string',
+            'enum': [
+              'chapter30',
+              'chapter32',
+              'chapter33',
+              'chapter34',
+              'chapter35',
+              'chapter1606',
+              'chapter1607',
+              'nationalService',
+              'transferredBenefits',
+              'vocationalRehab',
+            ]
+          },
+          previouslyAppliedWithSomeoneElsesService: {
+            type: 'boolean'
+          },
+          fileNumber: {
+            type: 'string'
+          },
+          sponsorVeteran: {
+            type: 'object',
+            properties: {
+              fullName: {
+                $ref: '#/definitions/fullName'
+              },
+              fileNumber: {
+                type: 'string'
+              },
+              payeeNumber: {
+                type: 'string'
+              }
+            }
+          }
+        },
+        required: ['claimType']
+      }
+    },
     school: {
       type: 'object',
       properties: {

--- a/test/edu-benefits/schema.spec.js
+++ b/test/edu-benefits/schema.spec.js
@@ -305,4 +305,26 @@ describe('education benefits json schema', () => {
       }]
     });
   });
+
+  context('previous va claims validation', () => {
+    testValidAndInvalid('previousVaClaims', {
+      valid: [
+        [{
+          claimType: 'vocationalRehab'
+        }],
+        [{
+          claimType: 'vocationalRehab',
+          fileNumber: 'blah',
+          sponsorVeteran: {
+            fileNumber: 'number'
+          }
+        }]
+      ],
+      invalid: [
+        [{
+          fileNumber: 'blah',
+        }]
+      ]
+    });
+  });
 });


### PR DESCRIPTION
Previous claims is back in the wireframes, so I've pulled what was there earlier and tweaked it to fit the wireframed pages.

The list of claim types is from the fields spreadsheet.