### PR TITLE
Change FAA field back to string

### DIFF
--- a/dist/edu-benefits-schema.json
+++ b/dist/edu-benefits-schema.json
@@ -474,15 +474,7 @@
       "$ref": "#/definitions/date"
     },
     "faaFlightCertificatesInformation": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          }
-        }
-      }
+      "type": "string"
     },
     "serviceAcademyGraduationYear": {
       "$ref": "#/definitions/year"

--- a/src/edu-benefits/schema.js
+++ b/src/edu-benefits/schema.js
@@ -300,15 +300,7 @@ module.exports = {
       $ref: '#/definitions/date'
     },
     faaFlightCertificatesInformation: {
-      type: "array",
-      items: {
-        type: 'object',
-        properties: {
-          name: {
-            type: 'string'
-          }
-        }
-      }
+      type: 'string'
     },
     serviceAcademyGraduationYear: {
       $ref: '#/definitions/year'


### PR DESCRIPTION
The wireframe has changed back to having FAA certificates as a textarea, so this should be a string again.