### PR TITLE
Address field updates

### DIFF
--- a/dist/edu-benefits-schema.json
+++ b/dist/edu-benefits-schema.json
@@ -30,9 +30,9 @@
                 "YT"
               ]
             },
-            "zipcode": {
+            "postalCode": {
               "type": "string",
-              "maxLength": 50
+              "maxLength": 10
             }
           }
         },
@@ -79,9 +79,9 @@
                 "zacatecas"
               ]
             },
-            "zipcode": {
+            "postalCode": {
               "type": "string",
-              "maxLength": 50
+              "maxLength": 10
             }
           }
         },
@@ -155,9 +155,9 @@
                 "WY"
               ]
             },
-            "zipcode": {
+            "postalCode": {
               "type": "string",
-              "maxLength": 50
+              "maxLength": 10
             }
           }
         },
@@ -172,7 +172,7 @@
                 ]
               }
             },
-            "provinceCode": {
+            "state": {
               "type": "string",
               "maxLength": 51
             },

--- a/src/edu-benefits/schema.js
+++ b/src/edu-benefits/schema.js
@@ -12,9 +12,9 @@ const countryStateProperites = _.map(constants.states, (value, key) => ({
     state: {
       'enum': value.map(x => x.value)
     },
-    zipcode: {
+    postalCode: {
       type: 'string',
-      maxLength: 50
+      maxLength: 10
     }
   }
 }));
@@ -26,7 +26,7 @@ countryStateProperites.push(
           'enum': countriesWithAnyState
         }
       },
-      provinceCode: {
+      state: {
         type: 'string',
         maxLength: 51
       },


### PR DESCRIPTION
We're simplifying the address field into the same set of fields regardless of country. 

Now we have:

street
street2 (not used on front end right now)
city
state
postalCode

I've also limited postal code to 10 characters for USA/CAN/MEX, since that's the max for any of those countries.