### PR TITLE
Remove active duty na option

### DIFF
--- a/dist/edu-benefits-schema.json
+++ b/dist/edu-benefits-schema.json
@@ -569,8 +569,7 @@
             "type": "string",
             "enum": [
               "yes",
-              "no",
-              "n/a"
+              "no"
             ]
           }
         },

--- a/src/edu-benefits/schema.js
+++ b/src/edu-benefits/schema.js
@@ -386,7 +386,7 @@ module.exports = {
           },
           involuntarilyCalledToDuty: {
             type: 'string',
-            'enum': ['yes', 'no', 'n/a']
+            'enum': ['yes', 'no']
           }
         },
         required: ['dateRange', 'serviceBranch']


### PR DESCRIPTION
No longer need n/a as an option for the active duty question. Haven't made schema changes before, so let me know if I also need to do something in the vets-website or vets-api repos @lihanli.