### PR TITLE
Allow ranges without a from date

### DIFF
--- a/dist/edu-benefits-schema.json
+++ b/dist/edu-benefits-schema.json
@@ -236,10 +236,7 @@
             }
           ]
         }
-      },
-      "required": [
-        "from"
-      ]
+      }
     },
     "fullName": {
       "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/edu-benefits/schema.js
+++ b/src/edu-benefits/schema.js
@@ -93,8 +93,7 @@ module.exports = {
             }
           ]
         }
-      },
-      required: ['from']
+      }
     },
     fullName: {
       type: 'object',


### PR DESCRIPTION
I noticed this when working on another bug. I don't think we've seen this schema error yet, but it is possible that we'll send a dateRange with just a to date now. This removes `from` from the required fields.

Shouldn't require a front end change, but could require a backend one.