### PR TITLE
Require the privacy flag to be true

### DIFF
--- a/dist/edu-benefits-schema.json
+++ b/dist/edu-benefits-schema.json
@@ -646,7 +646,10 @@
       "$ref": "#/definitions/date"
     },
     "privacyAgreementAccepted": {
-      "type": "boolean"
+      "type": "boolean",
+      "enum": [
+        true
+      ]
     }
   }
 }

--- a/dist/edu-benefits-schema.json
+++ b/dist/edu-benefits-schema.json
@@ -651,5 +651,8 @@
         true
       ]
     }
-  }
+  },
+  "required": [
+    "privacyAgreementAccepted"
+  ]
 }

--- a/dist/healthcare-application-schema.json
+++ b/dist/healthcare-application-schema.json
@@ -1720,7 +1720,10 @@
       "type": "boolean"
     },
     "privacyAgreementAccepted": {
-      "type": "boolean"
+      "type": "boolean",
+      "enum": [
+        true
+      ]
     }
   },
   "required": [

--- a/dist/healthcare-application-schema.json
+++ b/dist/healthcare-application-schema.json
@@ -1727,6 +1727,7 @@
     }
   },
   "required": [
+    "privacyAgreementAccepted",
     "veteranFullName",
     "veteranSocialSecurityNumber",
     "veteranDateOfBirth",

--- a/src/edu-benefits/schema.js
+++ b/src/edu-benefits/schema.js
@@ -398,7 +398,8 @@ module.exports = {
       '$ref': '#/definitions/date'
     },
     privacyAgreementAccepted: {
-      type: "boolean"
+      type: "boolean",
+      enum: [true]
     }
   }
 };

--- a/src/edu-benefits/schema.js
+++ b/src/edu-benefits/schema.js
@@ -401,5 +401,6 @@ module.exports = {
       type: "boolean",
       enum: [true]
     }
-  }
+  },
+  required: ['privacyAgreementAccepted']
 };

--- a/src/healthcare-application/schema.js
+++ b/src/healthcare-application/schema.js
@@ -384,7 +384,8 @@ module.exports = {
       type: 'boolean'
     },
     privacyAgreementAccepted: {
-      type: "boolean"
+      type: "boolean",
+      enum: [true]
     }
   },
   required: [

--- a/src/healthcare-application/schema.js
+++ b/src/healthcare-application/schema.js
@@ -389,6 +389,7 @@ module.exports = {
     }
   },
   required: [
+    'privacyAgreementAccepted',
     'veteranFullName',
     'veteranSocialSecurityNumber',
     'veteranDateOfBirth',

--- a/test/edu-benefits/schema.spec.js
+++ b/test/edu-benefits/schema.spec.js
@@ -33,6 +33,7 @@ describe('education benefits json schema', () => {
       }
     });
 
+    object['privacyAgreementAccepted'] = true
     return object;
   };
   const testValidAndInvalid = (parentKey, fields) => {


### PR DESCRIPTION
This change will cause our controllers to submissions that have the `privacyAgreementAccepted=false` as invalidly formatted submissions. Tests will be written in each application to ensure that this behavior isn't changed in the future.