### PR TITLE
Tweaks for 1995 front end

### DIFF
--- a/dist/change-of-program-schema.json
+++ b/dist/change-of-program-schema.json
@@ -7,9 +7,6 @@
     "fullName": {
       "type": "object",
       "properties": {
-        "salutation": {
-          "type": "string"
-        },
         "first": {
           "type": "string",
           "minLength": 1,
@@ -24,6 +21,7 @@
           "maxLength": 30
         },
         "suffix": {
+          "type": "string",
           "enum": [
             "Jr.",
             "Sr.",
@@ -312,17 +310,7 @@
           "$ref": "#/definitions/date"
         },
         "to": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/date"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "present"
-              ]
-            }
-          ]
+          "$ref": "#/definitions/date"
         }
       }
     },
@@ -337,6 +325,14 @@
         "licensingReimbursement",
         "tuitionTopUp",
         "cooperativeTraining"
+      ]
+    },
+    "preferredContactMethod": {
+      "type": "string",
+      "enum": [
+        "mail",
+        "email",
+        "phone"
       ]
     }
   },
@@ -354,11 +350,15 @@
       "$ref": "#/definitions/phone"
     },
     "vaFileNumber": {
-      "type": "string"
+      "type": "string",
+      "pattern": "^[cC]{0,1}\\d{8}$"
     },
     "email": {
       "type": "string",
       "format": "email"
+    },
+    "preferredContactMethod": {
+      "$ref": "#/definitions/preferredContactMethod"
     },
     "veteranSocialSecurityNumber": {
       "$ref": "#/definitions/ssn"
@@ -368,8 +368,8 @@
       "enum": [
         "chapter33",
         "chapter30",
-        "chapter32",
         "chapter1606",
+        "chapter32",
         "chapter1607",
         "transferOfEntitlement"
       ]
@@ -420,11 +420,7 @@
           "dateRange": {
             "$ref": "#/definitions/dateRange"
           }
-        },
-        "required": [
-          "dateRange",
-          "serviceBranch"
-        ]
+        }
       }
     },
     "civilianBenefitsAssistance": {

--- a/dist/definitions.json
+++ b/dist/definitions.json
@@ -2,9 +2,6 @@
   "fullName": {
     "type": "object",
     "properties": {
-      "salutation": {
-        "type": "string"
-      },
       "first": {
         "type": "string",
         "minLength": 1,
@@ -19,6 +16,7 @@
         "maxLength": 30
       },
       "suffix": {
+        "type": "string",
         "enum": [
           "Jr.",
           "Sr.",
@@ -303,17 +301,7 @@
         "$ref": "#/definitions/date"
       },
       "to": {
-        "oneOf": [
-          {
-            "$ref": "#/definitions/date"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "present"
-            ]
-          }
-        ]
+        "$ref": "#/definitions/date"
       }
     }
   },
@@ -332,6 +320,14 @@
       "licensingReimbursement",
       "tuitionTopUp",
       "cooperativeTraining"
+    ]
+  },
+  "preferredContactMethod": {
+    "type": "string",
+    "enum": [
+      "mail",
+      "email",
+      "phone"
     ]
   }
 }

--- a/dist/edu-benefits-schema.json
+++ b/dist/edu-benefits-schema.json
@@ -328,6 +328,14 @@
         "licensingReimbursement",
         "tuitionTopUp"
       ]
+    },
+    "preferredContactMethod": {
+      "type": "string",
+      "enum": [
+        "mail",
+        "email",
+        "phone"
+      ]
     }
   },
   "additionalProperties": false,
@@ -383,12 +391,7 @@
       "$ref": "#/definitions/phone"
     },
     "preferredContactMethod": {
-      "type": "string",
-      "enum": [
-        "mail",
-        "email",
-        "phone"
-      ]
+      "$ref": "#/definitions/preferredContactMethod"
     },
     "secondaryContact": {
       "type": "object",

--- a/dist/edu-benefits-schema.json
+++ b/dist/edu-benefits-schema.json
@@ -216,9 +216,6 @@
     "fullName": {
       "type": "object",
       "properties": {
-        "salutation": {
-          "type": "string"
-        },
         "first": {
           "type": "string",
           "minLength": 1,
@@ -233,6 +230,7 @@
           "maxLength": 30
         },
         "suffix": {
+          "type": "string",
           "enum": [
             "Jr.",
             "Sr.",
@@ -315,17 +313,7 @@
           "$ref": "#/definitions/date"
         },
         "to": {
-          "oneOf": [
-            {
-              "$ref": "#/definitions/date"
-            },
-            {
-              "type": "string",
-              "enum": [
-                "present"
-              ]
-            }
-          ]
+          "$ref": "#/definitions/date"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/change-of-program/schema.js
+++ b/src/change-of-program/schema.js
@@ -19,7 +19,7 @@ export default {
     'date',
     'dateRange',
     'educationType',
-    'preferredContactMethod',
+    'preferredContactMethod'
   ]),
   properties: {
     veteranFullName: {

--- a/src/change-of-program/schema.js
+++ b/src/change-of-program/schema.js
@@ -18,7 +18,8 @@ export default {
     'serviceBefore1977',
     'date',
     'dateRange',
-    'educationType'
+    'educationType',
+    'preferredContactMethod',
   ]),
   properties: {
     veteranFullName: {
@@ -34,18 +35,22 @@ export default {
       $ref: '#/definitions/phone'
     },
     vaFileNumber: {
-      type: 'string'
+      type: 'string',
+      pattern: '^[cC]{0,1}\\d{8}$'
     },
     email: {
       type: 'string',
       format: 'email'
+    },
+    preferredContactMethod: {
+      $ref: '#/definitions/preferredContactMethod'
     },
     veteranSocialSecurityNumber: {
       $ref: '#/definitions/ssn'
     },
     benefit: {
       type: 'string',
-      enum: ['chapter33', 'chapter30', 'chapter32', 'chapter1606', 'chapter1607', 'transferOfEntitlement']
+      enum: ['chapter33', 'chapter30', 'chapter1606', 'chapter32', 'chapter1607', 'transferOfEntitlement']
     },
     educationType: {
       $ref: '#/definitions/educationType'
@@ -89,8 +94,7 @@ export default {
           dateRange: {
             $ref: '#/definitions/dateRange'
           }
-        },
-        required: ['dateRange', 'serviceBranch']
+        }
       }
     },
     civilianBenefitsAssistance: {

--- a/src/common/definitions.js
+++ b/src/common/definitions.js
@@ -4,9 +4,6 @@ import _ from 'lodash';
 const fullName = {
   type: 'object',
   properties: {
-    salutation: {
-      type: 'string'
-    },
     first: {
       type: 'string',
       minLength: 1,
@@ -21,6 +18,7 @@ const fullName = {
       maxLength: 30
     },
     suffix: {
+      type: 'string',
       'enum': constants.suffixes
     },
   },
@@ -155,15 +153,7 @@ const dateRange = {
       $ref: '#/definitions/date'
     },
     to: {
-      oneOf: [
-        {
-          $ref: '#/definitions/date'
-        },
-        {
-          type: 'string',
-          enum: ['present']
-        }
-      ]
+      $ref: '#/definitions/date'
     }
   }
 };
@@ -178,6 +168,15 @@ const educationType = {
   enum: ['college', 'correspondence', 'apprenticeship', 'flightTraining', 'testReimbursement', 'licensingReimbursement', 'tuitionTopUp']
 };
 
+const preferredContactMethod = {
+  type: 'string',
+  enum: [
+    'mail',
+    'email',
+    'phone'
+  ]
+};
+
 export default {
   fullName,
   address,
@@ -188,5 +187,6 @@ export default {
   serviceBefore1977,
   dateRange,
   date,
-  educationType
+  educationType,
+  preferredContactMethod
 };

--- a/src/edu-benefits/schema.js
+++ b/src/edu-benefits/schema.js
@@ -23,7 +23,8 @@ export default {
     'serviceBefore1977',
     'date',
     'dateRange',
-    'educationType'
+    'educationType',
+    'preferredContactMethod'
   ])),
   additionalProperties: false,
   properties: {
@@ -70,8 +71,7 @@ export default {
       $ref: '#/definitions/phone'
     },
     preferredContactMethod: {
-      type: 'string',
-      enum: ['mail', 'email', 'phone']
+      $ref: '#/definitions/preferredContactMethod'
     },
     secondaryContact: {
       type: 'object',

--- a/test/change-of-program/schema.spec.js
+++ b/test/change-of-program/schema.spec.js
@@ -122,10 +122,10 @@ describe('change of program json schema', () => {
 
       [
         { veteranSocialSecurityNumber: '123456789' },
-        { vaFileNumber: '123' },
+        { vaFileNumber: '12345678' },
         {
           veteranSocialSecurityNumber: '123456789',
-          vaFileNumber: '123'
+          vaFileNumber: '12345678'
         }
       ].forEach((schemaData) => {
         fullSchemaTestHelper.schemaExpect(true, schemaData);

--- a/test/common/definitions.spec.js
+++ b/test/common/definitions.spec.js
@@ -105,7 +105,7 @@ describe('schema definitions', () => {
       fixtures.dateRange,
       {
         from: '2000-01-01',
-        to: 'present'
+        to: '2001-03-02'
       },
       {
         from: '2000-01-01'

--- a/test/edu-benefits/schema.spec.js
+++ b/test/edu-benefits/schema.spec.js
@@ -92,7 +92,7 @@ describe('education benefits json schema', () => {
         validDateRange,
         {
           from: '2000-01-01',
-          to: 'present'
+          to: '2001-03-30'
         },
         {
           from: '2000-01-01'


### PR DESCRIPTION
These are the schema changes I made for the 1995 front end. Some of them affect common components. I don't think they'll have a significant impact on the backend, but let me know if they do.

Changes:

- Removed `present` as option for end of date range. We don't ever use this.
- Removed `salutation` from name. Also not ever used.
- Added a pattern for file number, since we're validating this on the front end.
- Added `type` to enum fields, since this is required for the front end.
- Changed the order of some fields/enums because it affects the front end.
- Added preferredContactMethod field (same as 1990 form).