### PR TITLE
Use education program on 1990e

### DIFF
--- a/dist/definitions.json
+++ b/dist/definitions.json
@@ -517,5 +517,19 @@
         "serviceBranch"
       ]
     }
+  },
+  "educationProgram": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "address": {
+        "$ref": "#/definitions/address"
+      },
+      "educationType": {
+        "$ref": "#/definitions/educationType"
+      }
+    }
   }
 }

--- a/dist/dependents-benefits-schema.json
+++ b/dist/dependents-benefits-schema.json
@@ -485,6 +485,20 @@
           }
         }
       }
+    },
+    "educationProgram": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "educationType": {
+          "$ref": "#/definitions/educationType"
+        }
+      }
     }
   },
   "properties": {
@@ -753,20 +767,6 @@
     "remarks": {
       "type": "string"
     },
-    "educationProgram": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "address": {
-          "$ref": "#/definitions/address"
-        },
-        "educationType": {
-          "$ref": "#/definitions/educationType"
-        }
-      }
-    },
     "eduBenefitsPamphlet": {
       "type": "boolean"
     },
@@ -832,6 +832,9 @@
     },
     "nonMilitaryJobs": {
       "$ref": "#/definitions/nonMilitaryJobs"
+    },
+    "educationProgram": {
+      "$ref": "#/definitions/educationProgram"
     }
   },
   "required": [

--- a/dist/transfer-benefits-schema.json
+++ b/dist/transfer-benefits-schema.json
@@ -298,7 +298,7 @@
         "tuitionTopUp"
       ]
     },
-    "school": {
+    "educationProgram": {
       "type": "object",
       "properties": {
         "name": {
@@ -306,6 +306,9 @@
         },
         "address": {
           "$ref": "#/definitions/address"
+        },
+        "educationType": {
+          "$ref": "#/definitions/educationType"
         }
       }
     },
@@ -491,11 +494,8 @@
         "chapter30"
       ]
     },
-    "educationType": {
-      "$ref": "#/definitions/educationType"
-    },
-    "school": {
-      "$ref": "#/definitions/school"
+    "educationProgram": {
+      "$ref": "#/definitions/educationProgram"
     },
     "educationObjective": {
       "type": "string"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "1.6.3",
+  "version": "1.7.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/common/definitions.js
+++ b/src/common/definitions.js
@@ -293,6 +293,21 @@ const toursOfDuty = {
       },
     },
     required: ['dateRange', 'serviceBranch']
+  },
+};
+
+const educationProgram = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string'
+    },
+    address: {
+      $ref: '#/definitions/address'
+    },
+    educationType: {
+      $ref: '#/definitions/educationType'
+    }
   }
 };
 
@@ -315,5 +330,6 @@ export default {
   secondaryContact,
   vaFileNumber,
   relationship,
-  toursOfDuty
+  toursOfDuty,
+  educationProgram
 };

--- a/src/schemas/dependents-benefits/schema.js
+++ b/src/schemas/dependents-benefits/schema.js
@@ -110,16 +110,6 @@ let schema = {
     remarks: {
       type: 'string'
     },
-    educationProgram: {
-      type: 'object',
-      properties: {
-        name: {
-          type: 'string'
-        },
-        address: schemaHelpers.getDefinition('address'),
-        educationType: schemaHelpers.getDefinition('educationType')
-      }
-    },
     eduBenefitsPamphlet: {
       type: 'boolean'
     }
@@ -152,7 +142,8 @@ let schema = {
   ['toursOfDuty'],
   ['date', 'highSchool.highSchoolOrGedCompletionDate'],
   ['postHighSchoolTrainings'],
-  ['nonMilitaryJobs']
+  ['nonMilitaryJobs'],
+  ['educationProgram']
 ].forEach((args) => {
   schemaHelpers.addDefinitionToSchema(schema, ...args);
 });

--- a/src/schemas/transfer-benefits/schema.js
+++ b/src/schemas/transfer-benefits/schema.js
@@ -17,7 +17,7 @@ let schema = {
     'phone',
     'bankAccount',
     'educationType',
-    'school',
+    'educationProgram',
     'postHighSchoolTrainings',
     'dateRange',
     'nonMilitaryJobs'
@@ -61,11 +61,8 @@ let schema = {
       type: 'string',
       enum: ['chapter33', 'chapter30']
     },
-    educationType: {
-      $ref: '#/definitions/educationType'
-    },
-    school: {
-      $ref: '#/definitions/school'
+    educationProgram: {
+      $ref: '#/definitions/educationProgram'
     },
     educationObjective: {
       type: 'string'

--- a/test/schemas/dependents-benefits/schema.spec.js
+++ b/test/schemas/dependents-benefits/schema.spec.js
@@ -19,6 +19,7 @@ describe('dependents benefits schema', () => {
     'bankAccount',
     'secondaryContact',
     'vaFileNumber',
+    'educationProgram',
     'relationship',
     'toursOfDuty',
     'postHighSchoolTrainings',

--- a/test/schemas/transfer-benefits/schema.spec.js
+++ b/test/schemas/transfer-benefits/schema.spec.js
@@ -17,8 +17,7 @@ describe('transfer benefits schema', () => {
     'phone',
     'email',
     'bankAccount',
-    'educationType',
-    'school',
+    'educationProgram',
     'postHighSchoolTrainings',
     'nonMilitaryJobs',
     'relationship'

--- a/test/support/test-data.js
+++ b/test/support/test-data.js
@@ -101,6 +101,24 @@ export default {
       invalid: ['foo', 'cooperativeTraining']
     }
   },
+  educationProgram: {
+    data: {
+      valid: [{
+        educationType: 'college',
+        name: 'Test',
+        address: {
+          country: 'USA',
+          state: 'MT',
+          street: '123',
+          city: 'Test'
+        }
+      }],
+      invalid: [{
+        educationType: 'blahblah',
+        name: 'Test'
+      }]
+    }
+  },
   school: {
     data: {
       valid: [{


### PR DESCRIPTION
Related to [642](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/642)

This updates the 1990e schema to use the educationProgram definition from the 5490, since the form is accepting the same data with the same data on both.