### PR TITLE
Modified toursOfDuty for 5490

### DIFF
--- a/dist/dependents-benefits-schema.json
+++ b/dist/dependents-benefits-schema.json
@@ -338,33 +338,6 @@
         "child"
       ]
     },
-    "toursOfDuty": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "dateRange": {
-            "$ref": "#/definitions/dateRange"
-          },
-          "serviceBranch": {
-            "type": "string"
-          },
-          "serviceStatus": {
-            "type": "string"
-          },
-          "applyPeriodToSelected": {
-            "type": "boolean"
-          },
-          "benefitsToApplyTo": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "dateRange",
-          "serviceBranch"
-        ]
-      }
-    },
     "postHighSchoolTrainings": {
       "type": "array",
       "items": {
@@ -702,6 +675,30 @@
         }
       }
     },
+    "toursOfDuty": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "dateRange": {
+            "$ref": "#/definitions/dateRange"
+          },
+          "serviceBranch": {
+            "type": "string"
+          },
+          "serviceStatus": {
+            "type": "string"
+          },
+          "applyPeriodToSelected": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "dateRange",
+          "serviceBranch"
+        ]
+      }
+    },
     "civilianBenefitsAssistance": {
       "type": "boolean"
     },
@@ -767,9 +764,6 @@
     },
     "benefitsRelinquishedDate": {
       "$ref": "#/definitions/date"
-    },
-    "toursOfDuty": {
-      "$ref": "#/definitions/toursOfDuty"
     },
     "postHighSchoolTrainings": {
       "$ref": "#/definitions/postHighSchoolTrainings"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/dependents-benefits/schema.js
+++ b/src/schemas/dependents-benefits/schema.js
@@ -4,6 +4,8 @@ import _ from 'lodash';
 
 let definitions = _.cloneDeep(originalDefinitions);
 definitions.educationType.enum.push('farmCoop');
+const modifiedToursOfDuty = definitions.toursOfDuty;
+delete modifiedToursOfDuty.items.properties.benefitsToApplyTo;
 
 let schema = {
   $schema: 'http://json-schema.org/draft-04/schema#',
@@ -99,6 +101,7 @@ let schema = {
         }
       )
     },
+    toursOfDuty: modifiedToursOfDuty,
     civilianBenefitsAssistance: {
       type: 'boolean'
     },
@@ -137,7 +140,7 @@ let schema = {
   ['date', 'benefitsRelinquishedDate'],
   ['fullName', 'previousBenefits.veteranFullName'],
   ['ssn', 'previousBenefits.veteranSocialSecurityNumber'],
-  ['toursOfDuty'],
+  // ['toursOfDuty'],
   ['date', 'highSchool.highSchoolOrGedCompletionDate'],
   ['postHighSchoolTrainings'],
   ['nonMilitaryJobs'],

--- a/src/schemas/dependents-benefits/schema.js
+++ b/src/schemas/dependents-benefits/schema.js
@@ -140,7 +140,6 @@ let schema = {
   ['date', 'benefitsRelinquishedDate'],
   ['fullName', 'previousBenefits.veteranFullName'],
   ['ssn', 'previousBenefits.veteranSocialSecurityNumber'],
-  // ['toursOfDuty'],
   ['date', 'highSchool.highSchoolOrGedCompletionDate'],
   ['postHighSchoolTrainings'],
   ['nonMilitaryJobs'],

--- a/test/schemas/dependents-benefits/schema.spec.js
+++ b/test/schemas/dependents-benefits/schema.spec.js
@@ -21,7 +21,6 @@ describe('dependents benefits schema', () => {
     'vaFileNumber',
     'educationProgram',
     'relationship',
-    'toursOfDuty',
     'postHighSchoolTrainings',
     'nonMilitaryJobs',
     'preferredContactMethod'
@@ -78,6 +77,18 @@ describe('dependents benefits schema', () => {
     invalid: [{
       disability: 1
     }]
+  });
+
+  schemaTestHelper.testValidAndInvalid('toursOfDuty', {
+    valid: [[{
+      dateRange: fixtures.dateRange,
+      serviceBranch: 'Army',
+      serviceStatus: 'Honorable',
+      applyPeriodToSelected: true
+    }]],
+    invalid: [[{
+      dateRange: 'foo'
+    }]]
   });
 
   schemaTestHelper.testValidAndInvalid('highSchool.status', {


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/1532

Removes `benefitsToApplyTo` from the 5490. This also means it doesn't use a definition, but I didn't want to remove it from the definition in case it's used somewhere else. If not, that can be addressed later.