### PR TITLE
Remove anyOf check from previous benefits

### DIFF
--- a/dist/22-5490-schema.json
+++ b/dist/22-5490-schema.json
@@ -563,19 +563,7 @@
         "veteranSocialSecurityNumber": {
           "$ref": "#/definitions/ssn"
         }
-      },
-      "anyOf": [
-        {
-          "required": [
-            "vaFileNumber"
-          ]
-        },
-        {
-          "required": [
-            "veteranSocialSecurityNumber"
-          ]
-        }
-      ]
+      }
     },
     "highSchool": {
       "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/22-5490/schema.js
+++ b/src/schemas/22-5490/schema.js
@@ -70,7 +70,7 @@ let schema = {
       type: 'string',
       enum: ['chapter35', 'chapter33']
     },
-    previousBenefits: Object.assign({
+    previousBenefits: {
       type: 'object',
       properties: {
         disability: {
@@ -98,7 +98,7 @@ let schema = {
           type: 'string'
         }
       }
-    }, fileNumOrSsn),
+    },
     highSchool: {
       type: 'object',
       properties: _.merge(

--- a/test/schemas/22-5490/schema.spec.js
+++ b/test/schemas/22-5490/schema.spec.js
@@ -98,13 +98,13 @@ describe('dependents benefits schema', () => {
         Object.assign(
           { veteranSocialSecurityNumber: '123456789' },
           previousBenefitsFixture
-        )
+        ),
+        previousBenefitsFixture
       ],
       invalid: [
         {
           disability: 1
-        },
-        previousBenefitsFixture
+        }
       ]
     });
   });


### PR DESCRIPTION
Sorry for the barrage of PRs today.

The `anyOf` check that was added to the 5490 schema isn't accurate. We only force users to pick an ssn or file number if they pick a particular option on this page in the form ("Veterans education assistance based on someone else’s service", which isn't sent to the backend). 

It seems like the easiest fix for this is to remove the `anyOf` check, but if there's a way to send our flag that forces users to enter an ssn or file number and have the `anyOf` check use that somehow, I'm open to suggestions.