### PR TITLE
WIP: Switch farmCoop to cooperativeTraining for 5490

### DIFF
--- a/dist/22-5490-schema.json
+++ b/dist/22-5490-schema.json
@@ -25,7 +25,7 @@
         "testReimbursement",
         "licensingReimbursement",
         "tuitionTopUp",
-        "farmCoop"
+        "cooperativeTraining"
       ]
     },
     "privacyAgreementAccepted": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/22-5490/schema.js
+++ b/src/schemas/22-5490/schema.js
@@ -3,7 +3,7 @@ import schemaHelpers from '../../common/schema-helpers';
 import _ from 'lodash';
 
 let definitions = _.cloneDeep(originalDefinitions);
-definitions.educationType.enum.push('farmCoop');
+definitions.educationType.enum.push('cooperativeTraining');
 const modifiedToursOfDuty = definitions.toursOfDuty;
 delete modifiedToursOfDuty.items.properties.benefitsToApplyTo;
 

--- a/test/schemas/22-5490/schema.spec.js
+++ b/test/schemas/22-5490/schema.spec.js
@@ -50,8 +50,8 @@ describe('dependents benefits schema', () => {
   sharedTests.runTest('address', ['relativeAddress', 'educationProgram.address']);
 
   schemaTestHelper.testValidAndInvalid('educationProgram.educationType', {
-    valid: ['farmCoop'],
-    invalid: ['cooperativeTraining']
+    valid: ['cooperativeTraining'],
+    invalid: ['farmCoop']
   });
 
   schemaTestHelper.testValidAndInvalid('educationProgram', {


### PR DESCRIPTION
Closes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2043

All forms that used `farmCoop` should now be using `cooperativeTraining` instead. This currently only applied to the 5490.