### PR TITLE
Remove top up from education type options on 1990n

### DIFF
--- a/dist/22-1990N-schema.json
+++ b/dist/22-1990N-schema.json
@@ -12,8 +12,7 @@
         "apprenticeship",
         "flightTraining",
         "testReimbursement",
-        "licensingReimbursement",
-        "tuitionTopUp"
+        "licensingReimbursement"
       ]
     },
     "dateRange": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/22-1990N/schema.js
+++ b/src/schemas/22-1990N/schema.js
@@ -1,13 +1,19 @@
 import definitions from '../../common/definitions';
 import schemaHelpers from '../../common/schema-helpers';
 import _ from 'lodash';
+import set from 'lodash/fp/set';
+
+const updatedDefinitions = set('educationType.enum', 
+  definitions.educationType.enum.filter(x => x !== 'tuitionTopUp'),
+  definitions
+);
 
 let schema = {
   $schema: 'http://json-schema.org/draft-04/schema#',
   title: "APPLICATION FOR VA EDUCATION BENEFITS UNDER THE NATIONAL CALL TO SERVICE (NCS) PROGRAM (22-1990N)",
   type: 'object',
   additionalProperties: false,
-  definitions: _.pick(definitions, [
+  definitions: _.pick(updatedDefinitions, [
     'educationType',
     'dateRange'
   ]),


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2317

We don't want the tuitionTopUp option in the ed types dropdown on the 1990n.