### PR TITLE
Reorganized financials and dependents

### DIFF
--- a/dist/21-527-schema.json
+++ b/dist/21-527-schema.json
@@ -15,14 +15,72 @@
         }
       }
     },
-    "netWorthAccount": {
+    "netWorth": {
       "type": "object",
       "properties": {
-        "amount": {
+        "bank": {
           "type": "integer"
         },
-        "interest": {
-          "type": "boolean"
+        "ira": {
+          "type": "integer"
+        },
+        "stocks": {
+          "type": "integer"
+        },
+        "business": {
+          "type": "integer"
+        },
+        "realProperty": {
+          "type": "integer"
+        },
+        "otherProperty": {
+          "type": "integer"
+        },
+        "additionalSources": {
+          "$ref": "#/definitions/additionalSources"
+        }
+      }
+    },
+    "additionalSources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer"
+          }
+        }
+      }
+    },
+    "monthlyIncome": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "salary": {
+            "type": "integer"
+          },
+          "socialSecurity": {
+            "type": "integer"
+          },
+          "civilService": {
+            "type": "integer"
+          },
+          "railroad": {
+            "type": "integer"
+          },
+          "military": {
+            "type": "integer"
+          },
+          "blackLung": {
+            "type": "integer"
+          },
+          "ssi": {
+            "type": "integer"
+          }
         }
       }
     },
@@ -332,33 +390,6 @@
         }
       }
     },
-    "relationshipAndChildName": {
-      "type": "object",
-      "properties": {
-        "relationship": {
-          "type": "string",
-          "enum": [
-            "spouse",
-            "child",
-            "self"
-          ]
-        },
-        "childFullName": {
-          "$ref": "#/definitions/fullName"
-        }
-      }
-    },
-    "otherIncome": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "amount": {
-          "type": "integer"
-        }
-      }
-    },
     "bankAccount": {
       "type": "object",
       "properties": {
@@ -499,13 +530,16 @@
         "college4+"
       ]
     },
-    "childrenNotInHousehold": {
+    "children": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
           "childFullName": {
             "$ref": "#/definitions/fullName"
+          },
+          "childDateOfBirth": {
+            "$ref": "#/definitions/date"
           },
           "childAddress": {
             "$ref": "#/definitions/address"
@@ -515,6 +549,39 @@
           },
           "monthlyPayment": {
             "type": "integer"
+          },
+          "monthlyIncome": {
+            "$ref": "#/definitions/monthlyIncome"
+          },
+          "expectedIncome": {
+            "$ref": "#/definitions/expectedIncome"
+          },
+          "netWorth": {
+            "$ref": "#/definitions/netWorth"
+          },
+          "childPlaceOfBirth": {
+            "type": "string"
+          },
+          "childSocialSecurityNumber": {
+            "$ref": "#/definitions/ssn"
+          },
+          "biological": {
+            "type": "boolean"
+          },
+          "adopted": {
+            "type": "boolean"
+          },
+          "stepchild": {
+            "type": "boolean"
+          },
+          "attendingCollege": {
+            "type": "boolean"
+          },
+          "disabled": {
+            "type": "boolean"
+          },
+          "previouslyMarried": {
+            "type": "boolean"
           }
         }
       }
@@ -550,9 +617,6 @@
           },
           "workersComp": {
             "type": "integer"
-          },
-          "otherIncome": {
-            "$ref": "#/definitions/otherIncome"
           }
         }
       }
@@ -580,118 +644,8 @@
         }
       }
     },
-    "monthlyIncome": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "salary": {
-            "type": "integer"
-          },
-          "socialSecurity": {
-            "type": "integer"
-          },
-          "civilService": {
-            "type": "integer"
-          },
-          "railroad": {
-            "type": "integer"
-          },
-          "military": {
-            "type": "integer"
-          },
-          "blackLung": {
-            "type": "integer"
-          },
-          "ssi": {
-            "type": "integer"
-          },
-          "relationshipAndChildName": {
-            "$ref": "#/definitions/relationshipAndChildName"
-          },
-          "otherIncome": {
-            "$ref": "#/definitions/otherIncome"
-          }
-        }
-      }
-    },
     "remarks": {
       "type": "string"
-    },
-    "netWorth": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "childFullName": {
-            "$ref": "#/definitions/fullName"
-          },
-          "netWorthAccounts": {
-            "type": "object",
-            "properties": {
-              "bank": {
-                "$ref": "#/definitions/netWorthAccount"
-              },
-              "ira": {
-                "$ref": "#/definitions/netWorthAccount"
-              },
-              "stocks": {
-                "$ref": "#/definitions/netWorthAccount"
-              },
-              "business": {
-                "$ref": "#/definitions/netWorthAccount"
-              },
-              "realProperty": {
-                "type": "integer"
-              },
-              "otherProperty": {
-                "type": "integer"
-              }
-            }
-          },
-          "relationshipAndChildName": {
-            "$ref": "#/definitions/relationshipAndChildName"
-          }
-        }
-      }
-    },
-    "childrenInHousehold": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "childFullName": {
-            "$ref": "#/definitions/fullName"
-          },
-          "childDateOfBirth": {
-            "$ref": "#/definitions/date"
-          },
-          "childPlaceOfBirth": {
-            "type": "string"
-          },
-          "childSocialSecurityNumber": {
-            "$ref": "#/definitions/ssn"
-          },
-          "biological": {
-            "type": "boolean"
-          },
-          "adopted": {
-            "type": "boolean"
-          },
-          "stepchild": {
-            "type": "boolean"
-          },
-          "attendingCollege": {
-            "type": "boolean"
-          },
-          "disabled": {
-            "type": "boolean"
-          },
-          "previouslyMarried": {
-            "type": "boolean"
-          }
-        }
-      }
     },
     "veteranFullName": {
       "$ref": "#/definitions/fullName"
@@ -747,8 +701,23 @@
     "spouseMarriages": {
       "$ref": "#/definitions/marriages"
     },
-    "annualIncome,relationshipAndChildName": {
-      "$ref": "#/definitions/relationshipAndChildName"
+    "netWorth": {
+      "$ref": "#/definitions/netWorth"
+    },
+    "monthlyIncome": {
+      "$ref": "#/definitions/monthlyIncome"
+    },
+    "expectedIncome": {
+      "$ref": "#/definitions/expectedIncome"
+    },
+    "spouseNetWorth": {
+      "$ref": "#/definitions/netWorth"
+    },
+    "spouseMonthlyIncome": {
+      "$ref": "#/definitions/monthlyIncome"
+    },
+    "spouseExpectedIncome": {
+      "$ref": "#/definitions/expectedIncome"
     },
     "bankAccount": {
       "$ref": "#/definitions/bankAccount"

--- a/dist/21-527-schema.json
+++ b/dist/21-527-schema.json
@@ -21,13 +21,13 @@
         "bank": {
           "type": "integer"
         },
+        "interestBank": {
+          "type": "integer"
+        },
         "ira": {
           "type": "integer"
         },
         "stocks": {
-          "type": "integer"
-        },
-        "business": {
           "type": "integer"
         },
         "realProperty": {
@@ -58,9 +58,6 @@
     "monthlyIncome": {
       "type": "object",
       "properties": {
-        "salary": {
-          "type": "integer"
-        },
         "socialSecurity": {
           "type": "integer"
         },
@@ -70,10 +67,10 @@
         "railroad": {
           "type": "integer"
         },
-        "military": {
+        "blackLung": {
           "type": "integer"
         },
-        "blackLung": {
+        "serviceRetirement": {
           "type": "integer"
         },
         "ssi": {

--- a/dist/21-527-schema.json
+++ b/dist/21-527-schema.json
@@ -56,31 +56,48 @@
       }
     },
     "monthlyIncome": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "salary": {
-            "type": "integer"
-          },
-          "socialSecurity": {
-            "type": "integer"
-          },
-          "civilService": {
-            "type": "integer"
-          },
-          "railroad": {
-            "type": "integer"
-          },
-          "military": {
-            "type": "integer"
-          },
-          "blackLung": {
-            "type": "integer"
-          },
-          "ssi": {
-            "type": "integer"
-          }
+      "type": "object",
+      "properties": {
+        "salary": {
+          "type": "integer"
+        },
+        "socialSecurity": {
+          "type": "integer"
+        },
+        "civilService": {
+          "type": "integer"
+        },
+        "railroad": {
+          "type": "integer"
+        },
+        "military": {
+          "type": "integer"
+        },
+        "blackLung": {
+          "type": "integer"
+        },
+        "ssi": {
+          "type": "integer"
+        },
+        "additionalSources": {
+          "$ref": "#/definitions/additionalSources"
+        }
+      }
+    },
+    "expectedIncome": {
+      "type": "object",
+      "properties": {
+        "salary": {
+          "type": "integer"
+        },
+        "interest": {
+          "type": "integer"
+        },
+        "other": {
+          "type": "integer"
+        },
+        "additionalSources": {
+          "$ref": "#/definitions/additionalSources"
         }
       }
     },
@@ -540,6 +557,9 @@
           },
           "childDateOfBirth": {
             "$ref": "#/definitions/date"
+          },
+          "childNotInHousehold": {
+            "type": "boolean"
           },
           "childAddress": {
             "$ref": "#/definitions/address"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "2.7.1",
+  "version": "2.8.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-527/schema.js
+++ b/src/schemas/21-527/schema.js
@@ -7,10 +7,65 @@ let schema = {
   title: 'INCOME, NET WORTH, AND EMPLOYMENT STATEMENT',
   type: 'object',
   additionalProperties: false,
-  definitions: _.pick(definitions,
-    'dateRange',
-    'netWorthAccount'
-  ),
+  definitions: _.merge(_.pick(definitions,
+    'dateRange'
+  ), {
+    netWorth: {
+      type: 'object',
+      properties: {
+        bank: { type: 'integer' },
+        ira: { type: 'integer' },
+        stocks: { type: 'integer' },
+        business: { type: 'integer' },
+        realProperty: { type: 'integer' },
+        otherProperty: { type: 'integer' },
+        additionalSources: { $ref: '#/definitions/additionalSources' }
+      }
+    },
+    additionalSources: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string'
+          },
+          amount: {
+            type: 'integer'
+          }
+        }
+      }
+    },
+    monthlyIncome: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          salary: {
+            type: 'integer'
+          },
+          socialSecurity: {
+            type: 'integer'
+          },
+          civilService: {
+            type: 'integer'
+          },
+          railroad: {
+            type: 'integer'
+          },
+          military: {
+            type: 'integer'
+          },
+          blackLung: {
+            type: 'integer'
+          },
+          ssi: {
+            type: 'integer'
+          }
+        }
+      }
+    },
+  }),
   properties: {
     email: {
       type: 'string',
@@ -101,17 +156,46 @@ let schema = {
     highestEducationLevel: {
       type: 'string'
     },
-    childrenNotInHousehold: {
+    children: {
       type: 'array',
       items: {
         type: 'object',
         properties: {
           childFullName: schemaHelpers.getDefinition('fullName'),
+          childDateOfBirth: schemaHelpers.getDefinition('date'),
+          childNotInHousehold: {
+            type: 'boolean'
+          },
           childAddress: schemaHelpers.getDefinition('address'),
           personWhoLivesWithChild: schemaHelpers.getDefinition('fullName'),
           monthlyPayment: {
             type: 'integer'
-          }
+          },
+          monthlyIncome: { $ref: '#/definitions/monthlyIncome' },
+          expectedIncome: { $ref: '#/definitions/expectedIncome' },
+          netWorth: { $ref: '#/definitions/netWorth' },
+          childPlaceOfBirth: {
+            type: 'string'
+          },
+          childSocialSecurityNumber: schemaHelpers.getDefinition('ssn'),
+          biological: {
+            type: 'boolean'
+          },
+          adopted: {
+            type: 'boolean'
+          },
+          stepchild: {
+            type: 'boolean'
+          },
+          attendingCollege: {
+            type: 'boolean'
+          },
+          disabled: {
+            type: 'boolean'
+          },
+          previouslyMarried: {
+            type: 'boolean'
+          },
         }
       }
     },
@@ -168,95 +252,10 @@ let schema = {
         }
       }
     },
-    monthlyIncome: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          salary: {
-            type: 'integer'
-          },
-          socialSecurity: {
-            type: 'integer'
-          },
-          civilService: {
-            type: 'integer'
-          },
-          railroad: {
-            type: 'integer'
-          },
-          military: {
-            type: 'integer'
-          },
-          blackLung: {
-            type: 'integer'
-          },
-          ssi: {
-            type: 'integer'
-          }
-        }
-      }
-    },
     remarks: {
       type: 'string'
-    },
-    netWorth: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          childFullName: schemaHelpers.getDefinition('fullName'),
-          netWorthAccounts: {
-            type: 'object',
-            properties: {
-              bank: schemaHelpers.getDefinition('netWorthAccount'),
-              ira: schemaHelpers.getDefinition('netWorthAccount'),
-              stocks: schemaHelpers.getDefinition('netWorthAccount'),
-              business: schemaHelpers.getDefinition('netWorthAccount'),
-              realProperty: {
-                type: 'integer'
-              },
-              otherProperty: {
-                type: 'integer'
-              }
-            }
-          }
-        }
-      }
-    },
-    childrenInHousehold: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          childFullName: schemaHelpers.getDefinition('fullName'),
-          childDateOfBirth: schemaHelpers.getDefinition('date'),
-          childPlaceOfBirth: {
-            type: 'string'
-          },
-          childSocialSecurityNumber: schemaHelpers.getDefinition('ssn'),
-          biological: {
-            type: 'boolean'
-          },
-          adopted: {
-            type: 'boolean'
-          },
-          stepchild: {
-            type: 'boolean'
-          },
-          attendingCollege: {
-            type: 'boolean'
-          },
-          disabled: {
-            type: 'boolean'
-          },
-          previouslyMarried: {
-            type: 'boolean'
-          }
-        }
-      }
     }
-  },
+  }
 };
 
 [
@@ -279,13 +278,14 @@ let schema = {
   ['moneyTransfer', 'recentMoneyTransfer'],
   ['moneyTransfer', 'largeMoneyTransfer'],
   ['marriages', 'spouseMarriages'],
-  ['relationshipAndChildName', 'monthlyIncome.relationshipAndChildName'],
-  ['relationshipAndChildName', 'netWorth.relationshipAndChildName'],
-  ['relationshipAndChildName', 'annualIncome,relationshipAndChildName'],
   ['date', 'otherExpenses.date'],
-  ['otherIncome', 'monthlyIncome.otherIncome'],
+  ['netWorth'],
+  ['monthlyIncome'],
+  ['expectedIncome'],
+  ['netWorth', 'spouseNetWorth'],
+  ['monthlyIncome', 'spouseMonthlyIncome'],
+  ['expectedIncome', 'spouseExpectedIncome'],
   ['bankAccount'],
-  ['otherIncome', 'annualIncome.otherIncome']
 ].forEach((args) => {
   schemaHelpers.addDefinitionToSchema(schema, ...args);
 });

--- a/src/schemas/21-527/schema.js
+++ b/src/schemas/21-527/schema.js
@@ -14,9 +14,9 @@ let schema = {
       type: 'object',
       properties: {
         bank: { type: 'integer' },
+        interestBank: { type: 'integer' },
         ira: { type: 'integer' },
         stocks: { type: 'integer' },
-        business: { type: 'integer' },
         realProperty: { type: 'integer' },
         otherProperty: { type: 'integer' },
         additionalSources: { $ref: '#/definitions/additionalSources' }
@@ -39,9 +39,6 @@ let schema = {
     monthlyIncome: {
       type: 'object',
       properties: {
-        salary: {
-          type: 'integer'
-        },
         socialSecurity: {
           type: 'integer'
         },
@@ -51,10 +48,10 @@ let schema = {
         railroad: {
           type: 'integer'
         },
-        military: {
+        blackLung: {
           type: 'integer'
         },
-        blackLung: {
+        serviceRetirement: {
           type: 'integer'
         },
         ssi: {

--- a/src/schemas/21-527/schema.js
+++ b/src/schemas/21-527/schema.js
@@ -37,34 +37,49 @@ let schema = {
       }
     },
     monthlyIncome: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          salary: {
-            type: 'integer'
-          },
-          socialSecurity: {
-            type: 'integer'
-          },
-          civilService: {
-            type: 'integer'
-          },
-          railroad: {
-            type: 'integer'
-          },
-          military: {
-            type: 'integer'
-          },
-          blackLung: {
-            type: 'integer'
-          },
-          ssi: {
-            type: 'integer'
-          }
-        }
+      type: 'object',
+      properties: {
+        salary: {
+          type: 'integer'
+        },
+        socialSecurity: {
+          type: 'integer'
+        },
+        civilService: {
+          type: 'integer'
+        },
+        railroad: {
+          type: 'integer'
+        },
+        military: {
+          type: 'integer'
+        },
+        blackLung: {
+          type: 'integer'
+        },
+        ssi: {
+          type: 'integer'
+        },
+        additionalSources: { $ref: '#/definitions/additionalSources' }
       }
     },
+    expectedIncome: {
+      type: 'object',
+      properties: {
+        salary: {
+          type: 'integer'
+        },
+        interest: {
+          type: 'integer'
+        },
+        other: {
+          type: 'integer'
+        },
+        additionalSources: {
+          $ref: '#/definitions/additionalSources'
+        }
+      }
+    }
   }),
   properties: {
     email: {

--- a/test/schemas/21-527/schema.spec.js
+++ b/test/schemas/21-527/schema.spec.js
@@ -34,7 +34,7 @@ describe('21-527 schema', () => {
 
   sharedTests.runTest('moneyTransfer', ['recentMoneyTransfer', 'largeMoneyTransfer']);
 
-  schemaTestHelper.testValidAndInvalid('childrenInHousehold', {
+  schemaTestHelper.testValidAndInvalid('children', {
     valid: [[{
       childFullName: fixtures.fullName,
       childDateOfBirth: fixtures.date,
@@ -45,22 +45,42 @@ describe('21-527 schema', () => {
       stepchild: true,
       attendingCollege: true,
       disabled: true,
-      previouslyMarried: true
-    }]],
-    invalid: [[{
-      childFullName: 1
-    }]]
-  });
-
-  schemaTestHelper.testValidAndInvalid('childrenNotInHousehold', {
-    valid: [[{
+      previouslyMarried: true,
       childFullName: fixtures.fullName,
       childAddress: fixtures.address,
       personWhoLivesWithChild: fixtures.fullName,
-      monthlyPayment: 1
+      monthlyPayment: 1,
+      monthlyIncome: {
+        socialSecurity: 1,
+        railroad: 1,
+        blackLunk: 0,
+        serviceRetirement: 0,
+        civilService: 5,
+        ssi: 1,
+        additionalSources: [{
+          name: 'Something',
+          amount: 1
+        }]
+      },
+      netWorth: {
+        bank: 2,
+        ira: 2,
+        stocks: 2,
+        business: 2,
+        realProperty: 123,
+        otherProperty: 12
+      }
     }]],
     invalid: [[{
-      childFullName: 1
+      childFullName: 1,
+      monthlyIncome: {
+        civilService: 'what'
+      },
+      netWorth: {
+        additionalSources: [{
+          name: 1
+        }]
+      }
     }]]
   });
 
@@ -105,9 +125,8 @@ describe('21-527 schema', () => {
   });
 
   schemaTestHelper.testValidAndInvalid('monthlyIncome',{
-    valid: [[{
+    valid: [{
       relationshipAndChildName: fixtures.relationshipAndChildName,
-      salary: 1,
       socialSecurity: 1,
       civilService: 1,
       railroad: 0,
@@ -115,9 +134,9 @@ describe('21-527 schema', () => {
       blackLung: 0,
       ssi: 1,
       otherIncome: fixtures.otherIncome
-    }]],
+    }],
     invalid: [[{
-      salary: false
+      ssi: false
     }]]
   });
 
@@ -143,25 +162,6 @@ describe('21-527 schema', () => {
     }]],
     invalid: [[{
       amount: false
-    }]]
-  });
-
-  schemaTestHelper.testValidAndInvalid('netWorth', {
-    valid: [[{
-      relationshipAndChildName: fixtures.relationshipAndChildName,
-      netWorthAccounts: {
-        bank: fixtures.netWorthAccount,
-        ira: fixtures.netWorthAccount,
-        stocks: fixtures.netWorthAccount,
-        business: fixtures.netWorthAccount,
-        realProperty: 123,
-        otherProperty: 12
-      }
-    }]],
-    invalid: [[{
-      netWorthAccounts: {
-        realProperty: false
-      }
     }]]
   });
 });

--- a/test/support/fixtures.js
+++ b/test/support/fixtures.js
@@ -16,10 +16,6 @@ export default {
   },
   ssn: '123456789',
   phone: '555-555-5555',
-  netWorthAccount: {
-    amount: 123,
-    interest: true
-  },
   relationshipAndChildName: {
     relationship: 'self',
     childFullName: fullName


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2911

The EZ form has somewhat simplified financials (e.g. no interest) and the current UI for the financials section has us entering financial data for each spouse and child. It's very difficult to accomplish this with the current schema, so I've moved the financial info to be part of each row in the children array. I've also consolidated that array and made the in/out of household separation a property in the schema, instead of separate arrays.

I haven't updated tests or the version, I wanted to get some feedback first.