### PR TITLE
Add activation date as 'date' to nationalGuard

### DIFF
--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -472,6 +472,9 @@
         },
         "phone": {
           "$ref": "#/definitions/usaPhone"
+        },
+        "date": {
+          "$ref": "#/definitions/date"
         }
       }
     },

--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -670,9 +670,6 @@
     "powDateRange": {
       "$ref": "#/definitions/dateRange"
     },
-    "activationDate": {
-      "$ref": "#/definitions/date"
-    },
     "veteranDateOfBirth": {
       "$ref": "#/definitions/date"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21P-527EZ/schema.js
+++ b/src/schemas/21P-527EZ/schema.js
@@ -280,7 +280,6 @@ let schema = {
   // TODO: make sure they allow dates like 2017-01-XX
   ['dateRange', 'activeServiceDateRange'],
   ['dateRange', 'powDateRange'],
-  ['date', 'activationDate'],
   ['date', 'veteranDateOfBirth'],
   ['date', 'spouseDateOfBirth'],
   ['ssn', 'spouseSocialSecurityNumber'],

--- a/src/schemas/21P-527EZ/schema.js
+++ b/src/schemas/21P-527EZ/schema.js
@@ -130,7 +130,8 @@ let schema = {
       properties: {
         name: { type: 'string' },
         address: schemaHelpers.getDefinition('address'),
-        phone: schemaHelpers.getDefinition('usaPhone')
+        phone: schemaHelpers.getDefinition('usaPhone'),
+        date: schemaHelpers.getDefinition('date')
       }
     },
     // 16A-C. DID YOU RECEIVE ANY TYPE OF SEPARATION/SEVERANCE RETIRED PAY?

--- a/test/schemas/21P-527EZ/schema.spec.js
+++ b/test/schemas/21P-527EZ/schema.spec.js
@@ -24,7 +24,7 @@ describe('21-527 schema', () => {
 
   sharedTests.runTest('ssn', ['veteranSocialSecurityNumber', 'spouseSocialSecurityNumber']);
 
-  sharedTests.runTest('date', ['spouseDateOfBirth', 'veteranDateOfBirth', 'activationDate']);
+  sharedTests.runTest('date', ['spouseDateOfBirth', 'veteranDateOfBirth', 'nationalGuard.date']);
 
   sharedTests.runTest('dateRange', ['activeServiceDateRange', 'powDateRange']);
 
@@ -157,7 +157,8 @@ describe('21-527 schema', () => {
     valid: [{
       name: 'unit 123',
       address: fixtures.address,
-      phone: '0123456789'
+      phone: '0123456789',
+      date: fixtures.date
     }],
     invalid: [[{
       name: false


### PR DESCRIPTION
Connects to department-of-veterans-affairs/vets.gov-team#2222

Adds date to 527EX nationalGuard schema so that can match design as:

Are you currently on federal active duty in the National Guard? * [Y/N]
{ if yes }
Date of activation [DATE]
Name of Reserve/NG unit [TEXT]
Address of unit [ADDRESS]
Phone number of unit [PHONE]