### PR TITLE
Remove other field from expected income

### DIFF
--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -111,10 +111,6 @@
           "type": "integer",
           "default": 0
         },
-        "other": {
-          "type": "integer",
-          "default": 0
-        },
         "additionalSources": {
           "$ref": "#/definitions/additionalSources"
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21P-527EZ/schema.js
+++ b/src/schemas/21P-527EZ/schema.js
@@ -63,7 +63,6 @@ let schema = {
       properties: {
         salary: financialNumber,
         interest: financialNumber,
-        other: financialNumber,
         additionalSources: {
           $ref: '#/definitions/additionalSources'
         }

--- a/test/schemas/21P-527EZ/schema.spec.js
+++ b/test/schemas/21P-527EZ/schema.spec.js
@@ -137,6 +137,17 @@ describe('21-527 schema', () => {
     }]]
   });
 
+  schemaTestHelper.testValidAndInvalid('expectedIncome', {
+    valid: [{
+      salary: 1,
+      interest: 2,
+      additionalSources: [fixtures.otherIncome]
+    }],
+    invalid: [{
+      salary: true
+    }]
+  });
+
   schemaTestHelper.testValidAndInvalid('monthlyIncome',{
     valid: [{
       relationshipAndChildName: fixtures.relationshipAndChildName,


### PR DESCRIPTION
![expected_income](https://user-images.githubusercontent.com/830084/27062163-2b47a78c-4fb7-11e7-8377-27e6af1d0c87.png)
there's no place to put an unnamed "other" expected income, the other fields all need names which are included in additional sources