### PR TITLE
Updates for dependents on pensions

### DIFF
--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -580,13 +580,20 @@
         }
       }
     },
-    "children": {
+    "dependents": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "childFullName": {
+          "fullName": {
             "$ref": "#/definitions/fullName"
+          },
+          "relationship": {
+            "type": "string",
+            "enum": [
+              "child",
+              "parent"
+            ]
           },
           "childDateOfBirth": {
             "$ref": "#/definitions/date"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21P-527EZ/schema.js
+++ b/src/schemas/21P-527EZ/schema.js
@@ -194,12 +194,19 @@ let schema = {
         }
       }
     },
-    children: {
+    dependents: {
       type: 'array',
       items: {
         type: 'object',
         properties: {
-          childFullName: schemaHelpers.getDefinition('fullName'),
+          fullName: schemaHelpers.getDefinition('fullName'),
+          relationship: {
+            type: 'string',
+            enum: [
+              'child',
+              'parent'
+            ]
+          },
           childDateOfBirth: schemaHelpers.getDefinition('date'),
           childNotInHousehold: {
             type: 'boolean'

--- a/test/schemas/21P-527EZ/schema.spec.js
+++ b/test/schemas/21P-527EZ/schema.spec.js
@@ -35,9 +35,10 @@ describe('21-527 schema', () => {
 
   sharedTests.runTest('marriages', ['marriages', 'spouseMarriages']);
 
-  schemaTestHelper.testValidAndInvalid('children', {
+  schemaTestHelper.testValidAndInvalid('dependents', {
     valid: [[{
-      childFullName: fixtures.fullName,
+      fullName: fixtures.fullName,
+      relationship: 'child',
       childDateOfBirth: fixtures.date,
       childPlaceOfBirth: 'ny, ny',
       childSocialSecurityNumber: fixtures.ssn,
@@ -74,7 +75,7 @@ describe('21-527 schema', () => {
       }
     }]],
     invalid: [[{
-      childFullName: 1,
+      fullName: 1,
       monthlyIncome: {
         civilService: 'what'
       },


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2905

Parent and child dependents will be in the this same array, since they both have the same financial info and are entered together in the UI. Spouses are still separate (the above ticket will be updated).

Most fields are still for children only, so I left the `child` prefixes except for the name.