### PR TITLE
Add files to burials and pensions schemas

### DIFF
--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -438,6 +438,23 @@
           }
         }
       }
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "confirmationCode": {
+            "type": "string"
+          }
+        }
+      }
     }
   },
   "properties": {
@@ -746,6 +763,9 @@
     },
     "bankAccount": {
       "$ref": "#/definitions/bankAccount"
+    },
+    "files": {
+      "$ref": "#/definitions/files"
     }
   }
 }

--- a/dist/21P-530-schema.json
+++ b/dist/21P-530-schema.json
@@ -270,6 +270,23 @@
     "date": {
       "pattern": "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$",
       "type": "string"
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "confirmationCode": {
+            "type": "string"
+          }
+        }
+      }
     }
   },
   "properties": {
@@ -420,6 +437,12 @@
     },
     "deathDate": {
       "$ref": "#/definitions/date"
+    },
+    "deathCertificate": {
+      "$ref": "#/definitions/files"
+    },
+    "transportationReceipts": {
+      "$ref": "#/definitions/files"
     }
   }
 }

--- a/dist/definitions.json
+++ b/dist/definitions.json
@@ -639,5 +639,22 @@
         }
       }
     }
+  },
+  "files": {
+    "type": "array",
+    "items": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "size": {
+          "type": "integer"
+        },
+        "confirmationCode": {
+          "type": "string"
+        }
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/common/definitions.js
+++ b/src/common/definitions.js
@@ -408,6 +408,24 @@ const usaPhone = {
   pattern: '^\\d{10}$'
 };
 
+const files = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      name: {
+        type: 'string'
+      },
+      size: {
+        type: 'integer'
+      },
+      confirmationCode: {
+        type: 'string'
+      }
+    }
+  }
+};
+
 export default {
   usaPhone,
   fullName,
@@ -436,5 +454,6 @@ export default {
   maritalStatus,
   netWorthAccount,
   relationshipAndChildName,
-  marriages
+  marriages,
+  files
 };

--- a/src/schemas/21P-527EZ/schema.js
+++ b/src/schemas/21P-527EZ/schema.js
@@ -298,6 +298,7 @@ let schema = {
   ['monthlyIncome', 'spouseMonthlyIncome'],
   ['expectedIncome', 'spouseExpectedIncome'],
   ['bankAccount'],
+  ['files'],
 ].forEach((args) => {
   schemaHelpers.addDefinitionToSchema(schema, ...args);
 });

--- a/src/schemas/21P-530/schema.js
+++ b/src/schemas/21P-530/schema.js
@@ -136,6 +136,8 @@ let schema = {
   ['vaFileNumber'],
   ['date', 'burialDate'],
   ['date', 'deathDate'],
+  ['files', 'deathCertificate'],
+  ['files', 'transportationReceipts']
 ].forEach((args) => {
   schemaHelpers.addDefinitionToSchema(schema, ...args);
 });

--- a/test/common/definitions.spec.js
+++ b/test/common/definitions.spec.js
@@ -255,4 +255,15 @@ describe('schema definitions', () => {
   ].forEach((definition) => {
     testValidAndInvalidDefinitions(definition, testData[definition].data);
   });
+
+  testValidAndInvalidDefinitions('files', {
+    valid: [[{
+      confirmationCode: 'testing',
+      name: 'testing',
+      size: 1
+    }]],
+    invalid: [[{
+      size: 'asdf'
+    }]]
+  });
 });

--- a/test/common/definitions.spec.js
+++ b/test/common/definitions.spec.js
@@ -251,19 +251,9 @@ describe('schema definitions', () => {
     'usaPhone',
     'maritalStatus',
     'relationshipAndChildName',
-    'marriages'
+    'marriages',
+    'files'
   ].forEach((definition) => {
     testValidAndInvalidDefinitions(definition, testData[definition].data);
-  });
-
-  testValidAndInvalidDefinitions('files', {
-    valid: [[{
-      confirmationCode: 'testing',
-      name: 'testing',
-      size: 1
-    }]],
-    invalid: [[{
-      size: 'asdf'
-    }]]
   });
 });

--- a/test/schemas/21P-527EZ/schema.spec.js
+++ b/test/schemas/21P-527EZ/schema.spec.js
@@ -35,6 +35,8 @@ describe('21-527 schema', () => {
 
   sharedTests.runTest('marriages', ['marriages', 'spouseMarriages']);
 
+  sharedTests.runTest('files', ['files']);
+
   schemaTestHelper.testValidAndInvalid('dependents', {
     valid: [[{
       fullName: fixtures.fullName,

--- a/test/schemas/21P-530/schema.spec.js
+++ b/test/schemas/21P-530/schema.spec.js
@@ -22,6 +22,8 @@ describe('21-530 schema', () => {
 
   sharedTests.runTest('email', ['claimantEmail']);
 
+  sharedTests.runTest('files', ['deathCertificate', 'transportationReceipts']);
+
   schemaTestHelper.testValidAndInvalid('relationship', {
     valid: [{
       type: 'spouse'

--- a/test/support/test-data.js
+++ b/test/support/test-data.js
@@ -303,5 +303,17 @@ export default {
         }]
       ],
     }
+  },
+  files: {
+    data: {
+      valid: [[{
+        confirmationCode: 'testing',
+        name: 'testing',
+        size: 1
+      }]],
+      invalid: [[{
+        size: 'asdf'
+      }]]
+    }
   }
 };


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3326

This adds a common field for documents to the schema. The data needed for the backend is the confirmationCode field, which will have the identifier sent back from the upload endpoint. The other fields are probably not useful, but this is less error-prone that me stripping them out.

It's also easier on the front end to have this always be an array, rather than be an object or array depending on if multiple files are allowed. There's validation on the front end to set the min and max items. We could do that here too if it seems useful.