### PR TITLE
Fix misspelling in burials form

### DIFF
--- a/dist/21P-530-schema.json
+++ b/dist/21P-530-schema.json
@@ -402,10 +402,10 @@
     "placeOfRemains": {
       "type": "string"
     },
-    "federalCemetary": {
+    "federalCemetery": {
       "type": "boolean"
     },
-    "stateCemetary": {
+    "stateCemetery": {
       "type": "boolean"
     },
     "govtContributions": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21P-530/schema.js
+++ b/src/schemas/21P-530/schema.js
@@ -112,10 +112,10 @@ let schema = {
     placeOfRemains: {
       type: 'string'
     },
-    federalCemetary: {
+    federalCemetery: {
       type: 'boolean'
     },
-    stateCemetary: {
+    stateCemetery: {
       type: 'boolean'
     },
     govtContributions: {

--- a/test/schemas/21P-530/schema.spec.js
+++ b/test/schemas/21P-530/schema.spec.js
@@ -81,7 +81,7 @@ describe('21-530 schema', () => {
     }]]
   });
 
-  ['federalCemetary', 'stateCemetary', 'govtContributions', 'previouslyReceivedAllowance', 'incurredExpenses', 'benefitsUnclaimedRemains', 'burialAllowance', 'plotAllowance', 'transportation'].forEach(attr => {
+  ['federalCemetery', 'stateCemetery', 'govtContributions', 'previouslyReceivedAllowance', 'incurredExpenses', 'benefitsUnclaimedRemains', 'burialAllowance', 'plotAllowance', 'transportation'].forEach(attr => {
     schemaTestHelper.testValidAndInvalid(attr, {
       valid: [true, false],
       invalid: ['012345678x', 1]


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3343

I misspelled cemetery and I'm fixing it now because I don't want to have do a form data migration for it when we launch burials and save in progress.