### PR TITLE
Make financialNumbers required in financialDisclosure properties

### DIFF
--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -48,8 +48,7 @@
         "interestBank",
         "ira",
         "stocks",
-        "realProperty",
-        "additionalSources"
+        "realProperty"
       ],
       "properties": {
         "bank": {

--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -43,6 +43,14 @@
     },
     "netWorth": {
       "type": "object",
+      "required": [
+        "bank",
+        "interestBank",
+        "ira",
+        "stocks",
+        "realProperty",
+        "additionalSources"
+      ],
       "properties": {
         "bank": {
           "type": "integer",
@@ -88,6 +96,14 @@
     },
     "monthlyIncome": {
       "type": "object",
+      "required": [
+        "socialSecurity",
+        "civilService",
+        "railroad",
+        "blackLung",
+        "serviceRetirement",
+        "ssi"
+      ],
       "properties": {
         "socialSecurity": {
           "type": "integer",
@@ -120,6 +136,10 @@
     },
     "expectedIncome": {
       "type": "object",
+      "required": [
+        "salary",
+        "interest"
+      ],
       "properties": {
         "salary": {
           "type": "integer",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.0.20",
+  "version": "3.0.21",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21P-527EZ/schema.js
+++ b/src/schemas/21P-527EZ/schema.js
@@ -25,6 +25,7 @@ let schema = {
     },
     netWorth: {
       type: 'object',
+      required: ['bank', 'interestBank', 'ira', 'stocks', 'realProperty', 'additionalSources'],
       properties: {
         bank: financialNumber,
         interestBank: financialNumber,
@@ -51,6 +52,7 @@ let schema = {
     },
     monthlyIncome: {
       type: 'object',
+      required: ['socialSecurity', 'civilService', 'railroad', 'blackLung', 'serviceRetirement', 'ssi'],
       properties: {
         socialSecurity: financialNumber,
         civilService: financialNumber,
@@ -63,6 +65,7 @@ let schema = {
     },
     expectedIncome: {
       type: 'object',
+      required: ['salary', 'interest'],
       properties: {
         salary: financialNumber,
         interest: financialNumber,

--- a/src/schemas/21P-527EZ/schema.js
+++ b/src/schemas/21P-527EZ/schema.js
@@ -25,7 +25,7 @@ let schema = {
     },
     netWorth: {
       type: 'object',
-      required: ['bank', 'interestBank', 'ira', 'stocks', 'realProperty', 'additionalSources'],
+      required: ['bank', 'interestBank', 'ira', 'stocks', 'realProperty'],
       properties: {
         bank: financialNumber,
         interestBank: financialNumber,

--- a/test/schemas/21P-527EZ/schema.spec.js
+++ b/test/schemas/21P-527EZ/schema.spec.js
@@ -64,7 +64,7 @@ describe('21-527 schema', () => {
       monthlyIncome: {
         socialSecurity: 1,
         railroad: 1,
-        blackLunk: 0,
+        blackLung: 0,
         serviceRetirement: 0,
         civilService: 5,
         ssi: 1,
@@ -77,7 +77,7 @@ describe('21-527 schema', () => {
         bank: 2,
         ira: 2,
         stocks: 2,
-        business: 2,
+        interestBank: 2,
         realProperty: 123
       }
     }]],
@@ -157,7 +157,7 @@ describe('21-527 schema', () => {
       socialSecurity: 1,
       civilService: 1,
       railroad: 0,
-      military: 0,
+      serviceRetirement: 0,
       blackLung: 0,
       ssi: 1,
       otherIncome: fixtures.otherIncome


### PR DESCRIPTION
financialNumbers should be required (in the event that the user deletes the zero default value and does not replace it), according to stakeholders.