### PR TITLE
Change service questions to allow multiple periods

### DIFF
--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -519,8 +519,19 @@
     "monthlySpousePayment": {
       "type": "integer"
     },
-    "serviceBranch": {
-      "type": "string"
+    "servicePeriods": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "serviceBranch": {
+            "type": "string"
+          },
+          "activeServiceDateRange": {
+            "$ref": "#/definitions/dateRange"
+          }
+        }
+      }
     },
     "previousNames": {
       "type": "array",
@@ -714,9 +725,6 @@
     },
     "gender": {
       "$ref": "#/definitions/gender"
-    },
-    "activeServiceDateRange": {
-      "$ref": "#/definitions/dateRange"
     },
     "powDateRange": {
       "$ref": "#/definitions/dateRange"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.0.23",
+  "version": "3.0.24",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21P-527EZ/schema.js
+++ b/src/schemas/21P-527EZ/schema.js
@@ -116,8 +116,18 @@ let schema = {
     monthlySpousePayment: {
       type: 'integer'
     },
-    serviceBranch: {
-      type: 'string'
+    // 12a-c, but multiple items
+    servicePeriods: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          serviceBranch: {
+            type: 'string'
+          },
+          activeServiceDateRange: schemaHelpers.getDefinition('dateRange')
+        }
+      }
     },
     previousNames: {
       type: 'array',
@@ -266,8 +276,6 @@ let schema = {
   ['usaPhone', 'mobilePhone'],
   ['maritalStatus'],
   ['gender'],
-  // TODO: make sure they allow dates like 2017-01-XX
-  ['dateRange', 'activeServiceDateRange'],
   ['dateRange', 'powDateRange'],
   ['date', 'veteranDateOfBirth'],
   ['date', 'spouseDateOfBirth'],

--- a/test/schemas/21P-527EZ/schema.spec.js
+++ b/test/schemas/21P-527EZ/schema.spec.js
@@ -28,7 +28,7 @@ describe('21-527 schema', () => {
 
   sharedTests.runTest('ssn', ['veteranSocialSecurityNumber', 'spouseSocialSecurityNumber']);
 
-  sharedTests.runTest('dateRange', ['activeServiceDateRange', 'powDateRange']);
+  sharedTests.runTest('dateRange', ['powDateRange']);
 
   sharedTests.runTest('vaFileNumber', ['vaFileNumber', 'spouseVaFileNumber']);
 
@@ -137,6 +137,17 @@ describe('21-527 schema', () => {
     }]],
     invalid: [[{
       employer: 1
+    }]]
+  });
+
+  schemaTestHelper.testValidAndInvalid('servicePeriods', {
+    valid: [[{
+      activeServiceDateRange: fixtures.dateRange,
+      serviceBranch: 'Army'
+    }]],
+    invalid: [[{
+      activeServiceDateRange: fixtures.dateRange,
+      serviceBranch: 3
     }]]
   });
 


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3648

Based on stakeholder feedback, we want to allow multiple periods of service to be entered.

If this should use the `toursOfDuty` definition, I can switch, but I figured carrying over the current field names was slightly less disruptive.