### PR TITLE
Add entity fields to burial schema

### DIFF
--- a/dist/21P-530-schema.json
+++ b/dist/21P-530-schema.json
@@ -423,6 +423,12 @@
     "officialPosition": {
       "type": "string"
     },
+    "firmName": {
+      "type": "string"
+    },
+    "isEntity": {
+      "type": "boolean"
+    },
     "privacyAgreementAccepted": {
       "$ref": "#/definitions/privacyAgreementAccepted"
     },

--- a/dist/21P-530-schema.json
+++ b/dist/21P-530-schema.json
@@ -314,6 +314,9 @@
         },
         "other": {
           "type": "string"
+        },
+        "isEntity": {
+          "type": "boolean"
         }
       }
     },
@@ -425,9 +428,6 @@
     },
     "firmName": {
       "type": "string"
-    },
-    "isEntity": {
-      "type": "boolean"
     },
     "privacyAgreementAccepted": {
       "$ref": "#/definitions/privacyAgreementAccepted"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.0.24",
+  "version": "3.0.25",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21P-530/schema.js
+++ b/src/schemas/21P-530/schema.js
@@ -47,6 +47,9 @@ let schema = {
         },
         other: {
           type: 'string'
+        },
+        isEntity: {
+          type: 'boolean'
         }
       }
     },
@@ -130,9 +133,6 @@ let schema = {
     firmName: {
       type: 'string'
     },
-    isEntity: {
-      type: 'boolean'
-    }
   },
   required: ['privacyAgreementAccepted']
 };

--- a/src/schemas/21P-530/schema.js
+++ b/src/schemas/21P-530/schema.js
@@ -126,6 +126,12 @@ let schema = {
     },
     officialPosition: {
       type: 'string'
+    },
+    firmName: {
+      type: 'string'
+    },
+    isEntity: {
+      type: 'boolean'
     }
   },
   required: ['privacyAgreementAccepted']


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/3721

Adding firm name field. We use the isEntity flag on the front end to show the official position and firm name questions, so if that field is true, I think it makes sense to fill in question 21.