### PR TITLE
Change integer to number for monetary amounts on pension form

### DIFF
--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -52,23 +52,23 @@
       ],
       "properties": {
         "bank": {
-          "type": "integer",
+          "type": "number",
           "default": 0
         },
         "interestBank": {
-          "type": "integer",
+          "type": "number",
           "default": 0
         },
         "ira": {
-          "type": "integer",
+          "type": "number",
           "default": 0
         },
         "stocks": {
-          "type": "integer",
+          "type": "number",
           "default": 0
         },
         "realProperty": {
-          "type": "integer",
+          "type": "number",
           "default": 0
         },
         "additionalSources": {
@@ -88,7 +88,7 @@
             "type": "string"
           },
           "amount": {
-            "type": "integer"
+            "type": "number"
           }
         }
       }
@@ -105,27 +105,27 @@
       ],
       "properties": {
         "socialSecurity": {
-          "type": "integer",
+          "type": "number",
           "default": 0
         },
         "civilService": {
-          "type": "integer",
+          "type": "number",
           "default": 0
         },
         "railroad": {
-          "type": "integer",
+          "type": "number",
           "default": 0
         },
         "blackLung": {
-          "type": "integer",
+          "type": "number",
           "default": 0
         },
         "serviceRetirement": {
-          "type": "integer",
+          "type": "number",
           "default": 0
         },
         "ssi": {
-          "type": "integer",
+          "type": "number",
           "default": 0
         },
         "additionalSources": {
@@ -141,11 +141,11 @@
       ],
       "properties": {
         "salary": {
-          "type": "integer",
+          "type": "number",
           "default": 0
         },
         "interest": {
-          "type": "integer",
+          "type": "number",
           "default": 0
         },
         "additionalSources": {
@@ -166,7 +166,7 @@
         ],
         "properties": {
           "amount": {
-            "type": "integer"
+            "type": "number"
           },
           "purpose": {
             "type": "string"
@@ -524,7 +524,7 @@
       "type": "string"
     },
     "monthlySpousePayment": {
-      "type": "integer"
+      "type": "number"
     },
     "servicePeriods": {
       "type": "array",
@@ -593,7 +593,7 @@
       "type": "object",
       "properties": {
         "amount": {
-          "type": "integer"
+          "type": "number"
         },
         "type": {
           "type": "string",
@@ -645,7 +645,7 @@
             "type": "string"
           },
           "annualEarnings": {
-            "type": "integer"
+            "type": "number"
           }
         }
       }
@@ -671,7 +671,7 @@
             "$ref": "#/definitions/fullName"
           },
           "monthlyPayment": {
-            "type": "integer"
+            "type": "number"
           },
           "monthlyIncome": {
             "$ref": "#/definitions/monthlyIncome"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.0.30",
+  "version": "3.0.31",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21P-527EZ/schema.js
+++ b/src/schemas/21P-527EZ/schema.js
@@ -6,7 +6,7 @@ let definitions = _.cloneDeep(originalDefinitions);
 definitions.bankAccount.properties.bankName = { type: 'string' };
 
 const financialNumber = {
-  type: 'integer',
+  type: 'number',
   default: 0
 };
 
@@ -45,7 +45,7 @@ let schema = {
             type: 'string'
           },
           amount: {
-            type: 'integer'
+            type: 'number'
           }
         }
       }
@@ -82,7 +82,7 @@ let schema = {
         required: ['amount', 'purpose', 'paidTo', 'date'],
         properties: {
           amount: {
-            type: 'integer'
+            type: 'number'
           },
           purpose: {
             type: 'string'
@@ -116,7 +116,7 @@ let schema = {
       type: 'string'
     },
     monthlySpousePayment: {
-      type: 'integer'
+      type: 'number'
     },
     // 12a-c, but multiple items
     servicePeriods: {
@@ -175,7 +175,7 @@ let schema = {
     severancePay: {
       type: 'object',
       properties: {
-        amount: { type: 'integer' },
+        amount: { type: 'number' },
         type: {
           type: 'string',
           enum: [
@@ -221,7 +221,7 @@ let schema = {
             type: 'string'
           },
           annualEarnings: {
-            type: 'integer'
+            type: 'number'
           }
         }
       }
@@ -239,7 +239,7 @@ let schema = {
           childAddress: schemaHelpers.getDefinition('address'),
           personWhoLivesWithChild: schemaHelpers.getDefinition('fullName'),
           monthlyPayment: {
-            type: 'integer'
+            type: 'number'
           },
           monthlyIncome: { $ref: '#/definitions/monthlyIncome' },
           expectedIncome: { $ref: '#/definitions/expectedIncome' },


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4205

According to @J-Quag in Slack, we should allow decimals for monetary amounts. This updates the amounts with an integer type to use number.

If this will break something on the backend PDF filling code, let me know and we can see what our options are.