### PR TITLE
Customize 1990 currentlyActiveDuty

### DIFF
--- a/dist/22-1990-schema.json
+++ b/dist/22-1990-schema.json
@@ -499,20 +499,6 @@
           "serviceBranch"
         ]
       }
-    },
-    "currentlyActiveDuty": {
-      "type": "object",
-      "properties": {
-        "yes": {
-          "type": "boolean"
-        },
-        "onTerminalLeave": {
-          "type": "boolean"
-        },
-        "nonVaAssistance": {
-          "type": "boolean"
-        }
-      }
     }
   },
   "additionalProperties": false,
@@ -607,6 +593,17 @@
     "serviceAcademyGraduationYear": {
       "$ref": "#/definitions/year"
     },
+    "currentlyActiveDuty": {
+      "type": "object",
+      "properties": {
+        "yes": {
+          "type": "boolean"
+        },
+        "onTerminalLeave": {
+          "type": "boolean"
+        }
+      }
+    },
     "seniorRotc": {
       "type": "object",
       "properties": {
@@ -670,9 +667,6 @@
     },
     "toursOfDuty": {
       "$ref": "#/definitions/toursOfDuty"
-    },
-    "currentlyActiveDuty": {
-      "$ref": "#/definitions/currentlyActiveDuty"
     }
   },
   "required": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.0.31",
+  "version": "3.0.32",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/22-1990/schema.js
+++ b/src/schemas/22-1990/schema.js
@@ -193,7 +193,7 @@ let schema = {
 };
 
 [
-  ['toursOfDuty'],
+  ['toursOfDuty']
 ].forEach((args) => {
   schemaHelpers.addDefinitionToSchema(schema, ...args);
 });

--- a/src/schemas/22-1990/schema.js
+++ b/src/schemas/22-1990/schema.js
@@ -118,6 +118,17 @@ let schema = {
     serviceAcademyGraduationYear: {
       $ref: '#/definitions/year'
     },
+    currentlyActiveDuty: {
+      type: 'object',
+      properties: {
+        yes: {
+          type: 'boolean'
+        },
+        onTerminalLeave: {
+          type: 'boolean'
+        }
+      }
+    },
     seniorRotc: {
       type: 'object',
       properties: {
@@ -183,7 +194,6 @@ let schema = {
 
 [
   ['toursOfDuty'],
-  ['currentlyActiveDuty']
 ].forEach((args) => {
   schemaHelpers.addDefinitionToSchema(schema, ...args);
 });

--- a/test/schemas/22-1990/schema.spec.js
+++ b/test/schemas/22-1990/schema.spec.js
@@ -94,7 +94,7 @@ describe('education benefits json schema', () => {
     schemaTestHelper.testValidAndInvalid('currentlyActiveDuty', {
       valid: [{
         yes: true,
-        onTerminalLeave: true,
+        onTerminalLeave: true
       }],
       invalid: [{
         yes: 1

--- a/test/schemas/22-1990/schema.spec.js
+++ b/test/schemas/22-1990/schema.spec.js
@@ -34,8 +34,7 @@ describe('education benefits json schema', () => {
     'educationType',
     'nonMilitaryJobs',
     'secondaryContact',
-    'toursOfDuty',
-    'currentlyActiveDuty'
+    'toursOfDuty'
   ].forEach((test) => {
     sharedTests.runTest(test);
   });
@@ -87,6 +86,18 @@ describe('education benefits json schema', () => {
       }],
       invalid: [{
         commissionYear: 1981
+      }]
+    });
+  });
+  
+  context('currentlyActiveDuty', () => {
+    schemaTestHelper.testValidAndInvalid('currentlyActiveDuty', {
+      valid: [{
+        yes: true,
+        onTerminalLeave: true,
+      }],
+      invalid: [{
+        yes: 1
       }]
     });
   });


### PR DESCRIPTION
The 1990 does not require all of the properties of the common definition of `currentlyActiveDuty`, so as in the 5490, a custom definition has been provided. (Also it looks like `currentlyActiveDuty` is provided in 5495 but that it is not used in the form, please let me know if that should be removed as well as part of this set of changes.)

<img width="637" alt="screen shot 2017-08-11 at 10 35 23 am" src="https://user-images.githubusercontent.com/16051172/29224846-daa79c3a-7e80-11e7-96b3-a24bd9637bb1.png">
