### PR TITLE
Reorder 1990 benefitsRelinquished

### DIFF
--- a/dist/22-1990-schema.json
+++ b/dist/22-1990-schema.json
@@ -518,10 +518,10 @@
     "benefitsRelinquished": {
       "type": "string",
       "enum": [
-        "chapter1607",
         "unknown",
         "chapter30",
-        "chapter1606"
+        "chapter1606",
+        "chapter1607"
       ]
     },
     "veteranFullName": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.0.32",
+  "version": "3.0.33",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/22-1990/schema.js
+++ b/src/schemas/22-1990/schema.js
@@ -47,7 +47,7 @@ let schema = {
     },
     benefitsRelinquished: {
       type: 'string',
-      'enum': ['chapter1607', 'unknown', ..._.without(benefits, 'chapter33', 'chapter32')]
+      'enum': ['unknown', ..._.without(benefits, 'chapter33', 'chapter32'), 'chapter1607']
     },
     veteranFullName: {
       $ref: '#/definitions/fullName'


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2814

The order of the enum affects the order it's displayed on the front end (using rjsf), so this just matches the order it's displayed on the current 1990.