### PR TITLE
Create seniorRotcCommissioned and make seniorRotc fields not required

### DIFF
--- a/dist/22-1990-schema.json
+++ b/dist/22-1990-schema.json
@@ -627,10 +627,10 @@
             }
           }
         }
-      },
-      "required": [
-        "rotcScholarshipAmounts"
-      ]
+      }
+    },
+    "seniorRotcCommissioned": {
+      "type": "boolean"
     },
     "seniorRotcScholarshipProgram": {
       "type": "boolean"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.0.34",
+  "version": "3.0.35",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/22-1990/schema.js
+++ b/src/schemas/22-1990/schema.js
@@ -138,8 +138,10 @@ let schema = {
             }
           }
         }
-      },
-      required: ['rotcScholarshipAmounts']
+      }
+    },
+    seniorRotcCommissioned: {
+      type: 'boolean'
     },
     seniorRotcScholarshipProgram: {
       type: 'boolean'

--- a/test/schemas/22-1990/schema.spec.js
+++ b/test/schemas/22-1990/schema.spec.js
@@ -86,7 +86,7 @@ describe('education benefits json schema', () => {
         }]
       }],
       invalid: [{
-        commissionYear: 1981
+        commissionYear: 800
       }]
     });
   });


### PR DESCRIPTION
These changes provide another boolean property `seniorRotcCommissioned`, and make seniorRotc fields not required, as it looks like they're not required on the current form. Please let me know if we decided to update this, or if it makes sense to, and I'll revert that part of the changes.

<img width="666" alt="screen shot 2017-08-15 at 1 57 00 pm" src="https://user-images.githubusercontent.com/16051172/29336103-a97b566c-81c1-11e7-9600-da5c3d0b8647.png">
