### PR TITLE
Add education program to 1990

### DIFF
--- a/dist/22-1990-schema.json
+++ b/dist/22-1990-schema.json
@@ -331,6 +331,20 @@
         "tuitionTopUp"
       ]
     },
+    "educationProgram": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "address": {
+          "$ref": "#/definitions/address"
+        },
+        "educationType": {
+          "$ref": "#/definitions/educationType"
+        }
+      }
+    },
     "preferredContactMethod": {
       "type": "string",
       "enum": [
@@ -597,6 +611,9 @@
     },
     "educationType": {
       "$ref": "#/definitions/educationType"
+    },
+    "educationProgram": {
+      "$ref": "#/definitions/educationProgram"
     },
     "highSchoolOrGedCompletionDate": {
       "$ref": "#/definitions/date"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.0.34",
+  "version": "3.1.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/22-1990/schema.js
+++ b/src/schemas/22-1990/schema.js
@@ -25,6 +25,7 @@ let schema = {
     'date',
     'dateRange',
     'educationType',
+    'educationProgram',
     'preferredContactMethod',
     'privacyAgreementAccepted',
     'gender',
@@ -108,6 +109,9 @@ let schema = {
     },
     educationType: {
       $ref: '#/definitions/educationType'
+    },
+    educationProgram: {
+      $ref: '#/definitions/educationProgram'
     },
     highSchoolOrGedCompletionDate: {
       $ref: '#/definitions/date'

--- a/test/schemas/22-1990/schema.spec.js
+++ b/test/schemas/22-1990/schema.spec.js
@@ -32,6 +32,7 @@ describe('education benefits json schema', () => {
     'school',
     'postHighSchoolTrainings',
     'educationType',
+    'educationProgram',
     'nonMilitaryJobs',
     'secondaryContact',
     'toursOfDuty',


### PR DESCRIPTION
Connects to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/2819

On forms after the 1990 we added an `educationProgram` definition to more easily handle the school selection page fields. I want to switch to that with the RJSF 1990. I don't want to update the existing form, so I'm hoping to move to it this way:

1. Add `educationProgram` to 1990 schema
2. Before launching, update the backend to use `educationProgram` in place of `school` and `educationType`, when it exists. Use the old fields otherwise.
3. Launch the new 1990 form
4. After a few days, remove the old fields from this schema and remove the switching logic from the backend.

Does that work for you, @lihanli? I'm assuming you would be the one doing steps 2 and 4.