### PR TITLE
Remove required prop from rotc object

### DIFF
--- a/dist/22-1990-schema.json
+++ b/dist/22-1990-schema.json
@@ -644,10 +644,7 @@
             }
           }
         }
-      },
-      "required": [
-        "rotcScholarshipAmounts"
-      ]
+      }
     },
     "seniorRotcScholarshipProgram": {
       "type": "boolean"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/22-1990/schema.js
+++ b/src/schemas/22-1990/schema.js
@@ -142,8 +142,7 @@ let schema = {
             }
           }
         }
-      },
-      required: ['rotcScholarshipAmounts']
+      }
     },
     seniorRotcScholarshipProgram: {
       type: 'boolean'

--- a/test/schemas/22-1990/schema.spec.js
+++ b/test/schemas/22-1990/schema.spec.js
@@ -85,9 +85,11 @@ describe('education benefits json schema', () => {
           year: 1999,
           amount: 99.99
         }]
+      }, {
+        commissionYear: 1981
       }],
       invalid: [{
-        commissionYear: 1981
+        commissionYear: 'a'
       }]
     });
   });


### PR DESCRIPTION
Connects to: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/4684

We're getting a schema error because we don't alway send back scholarship amounts when someone is in senior ROTC. It looks like the backend supports this, just the schema is preventing it.