### PR TITLE
Rename fields containing child to dependent on 10-10EZ schema

### DIFF
--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -278,7 +278,7 @@
         "fullName": {
           "$ref": "#/definitions/fullName"
         },
-        "relation": {
+        "dependentRelation": {
           "enum": [
             "Daughter",
             "Son",
@@ -306,7 +306,7 @@
         "attendedSchoolLastYear": {
           "type": "boolean"
         },
-        "educationExpenses": {
+        "dependentEducationExpenses": {
           "$ref": "#/definitions/monetaryValue"
         },
         "cohabitedLastYear": {

--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -226,13 +226,13 @@
         },
         "childRelation": {
           "enum": [
-            "Spouse",
             "Daughter",
             "Son",
             "Stepson",
             "Stepdaughter",
             "Father",
             "Mother",
+            "Spouse",
             "Other"
           ],
           "type": "string"
@@ -259,6 +259,60 @@
           "type": "boolean"
         },
         "childReceivedSupportLastYear": {
+          "type": "boolean"
+        },
+        "grossIncome": {
+          "$ref": "#/definitions/monetaryValue"
+        },
+        "netIncome": {
+          "$ref": "#/definitions/monetaryValue"
+        },
+        "otherIncome": {
+          "$ref": "#/definitions/monetaryValue"
+        }
+      }
+    },
+    "dependent": {
+      "type": "object",
+      "properties": {
+        "fullName": {
+          "$ref": "#/definitions/fullName"
+        },
+        "relation": {
+          "enum": [
+            "Daughter",
+            "Son",
+            "Stepson",
+            "Stepdaughter",
+            "Father",
+            "Mother",
+            "Spouse",
+            "Other"
+          ],
+          "type": "string"
+        },
+        "socialSecurityNumber": {
+          "$ref": "#/definitions/ssn"
+        },
+        "becameDependent": {
+          "$ref": "#/definitions/date"
+        },
+        "dateOfBirth": {
+          "$ref": "#/definitions/date"
+        },
+        "disabledBefore18": {
+          "type": "boolean"
+        },
+        "attendedSchoolLastYear": {
+          "type": "boolean"
+        },
+        "educationExpenses": {
+          "$ref": "#/definitions/monetaryValue"
+        },
+        "cohabitedLastYear": {
+          "type": "boolean"
+        },
+        "receivedSupportLastYear": {
           "type": "boolean"
         },
         "grossIncome": {
@@ -1634,6 +1688,12 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/child"
+      }
+    },
+    "dependents": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/dependent"
       }
     },
     "veteranGrossIncome": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1591,7 +1591,7 @@ const vaMedicalFacilities = {
   ],
 };
 
-const childRelationships = [
+const dependentRelationships = [
   'Daughter',
   'Son',
   'Stepson',
@@ -1620,7 +1620,7 @@ module.exports = {
   months,
   days,
   vaMedicalFacilities,
-  childRelationships,
+  dependentRelationships,
   yesNo,
   usaStates
 };

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -81,7 +81,7 @@ let schema = {
           $ref: '#/definitions/fullName'
         },
         childRelation: {
-          'enum': constants.childRelationships,
+          'enum': constants.dependentRelationships,
           type: 'string',
         },
         childSocialSecurityNumber: {
@@ -106,6 +106,51 @@ let schema = {
           type: 'boolean'
         },
         childReceivedSupportLastYear: {
+          type: 'boolean'
+        },
+        grossIncome: {
+          $ref: '#/definitions/monetaryValue'
+        },
+        netIncome: {
+          $ref: '#/definitions/monetaryValue'
+        },
+        otherIncome: {
+          $ref: '#/definitions/monetaryValue'
+        },
+      }
+    },
+    dependent: {
+      type: 'object',
+      properties: {
+        fullName: {
+          $ref: '#/definitions/fullName'
+        },
+        relation: {
+          'enum': constants.dependentRelationships,
+          type: 'string',
+        },
+        socialSecurityNumber: {
+          $ref: '#/definitions/ssn'
+        },
+        becameDependent: {
+          $ref: '#/definitions/date'
+        },
+        dateOfBirth: {
+          $ref: '#/definitions/date'
+        },
+        disabledBefore18: {
+          type: 'boolean'
+        },
+        attendedSchoolLastYear: {
+          type: 'boolean'
+        },
+        educationExpenses: {
+          $ref: '#/definitions/monetaryValue'
+        },
+        cohabitedLastYear: {
+          type: 'boolean'
+        },
+        receivedSupportLastYear: {
           type: 'boolean'
         },
         grossIncome: {
@@ -307,7 +352,13 @@ let schema = {
     children: {
       type: 'array',
       items: {
-        $ref: '#/definitions/child'
+        $ref: '#/definitions/dependent'
+      },
+    },
+    dependents: {
+      type: 'array',
+      items: {
+        $ref: '#/definitions/dependent'
       },
     },
     veteranGrossIncome: {

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -125,7 +125,7 @@ let schema = {
         fullName: {
           $ref: '#/definitions/fullName'
         },
-        relation: {
+        dependentRelation: {
           'enum': constants.dependentRelationships,
           type: 'string',
         },
@@ -144,7 +144,7 @@ let schema = {
         attendedSchoolLastYear: {
           type: 'boolean'
         },
-        educationExpenses: {
+        dependentEducationExpenses: {
           $ref: '#/definitions/monetaryValue'
         },
         cohabitedLastYear: {

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -352,7 +352,7 @@ let schema = {
     children: {
       type: 'array',
       items: {
-        $ref: '#/definitions/dependent'
+        $ref: '#/definitions/child'
       },
     },
     dependents: {


### PR DESCRIPTION
This PR is the first step of the `childRelation` to `dependantRelation` refactor.

Connected to department-of-veterans-affairs/vets.gov-team#4924

* Renames `childRelationships` enum to `dependentRelationships`
  * This does not affect the resulting schemas because the enums are inlined
* Add `dependent` definition to 10-10EZ form schema
  * Duplicate of `child` definition but removes `child` prefix from most field names
* Add `dependents` property to 10-10EZ form schema
  * Duplicate of `children` property, but points to `dependent` rather than `child` item type
* Bump version to `3.5.0`
* Rebuilt all schemas with `yarn run build`

@jbalboni Is this what you had in mind when specifying that we should support both fields until the frontend and backend have been refactored to support the new field name?