### PR TITLE
Preneeds schema updates

### DIFF
--- a/dist/40-10007-schema.json
+++ b/dist/40-10007-schema.json
@@ -198,23 +198,22 @@
         "street": {
           "type": "string",
           "minLength": 1,
-          "maxLength": 50
+          "maxLength": 35
         },
         "street2": {
           "type": "string",
           "minLength": 1,
-          "maxLength": 50
+          "maxLength": 35
         },
         "city": {
           "type": "string",
           "minLength": 1,
-          "maxLength": 51
+          "maxLength": 30
         }
-      }
-    },
-    "date": {
-      "pattern": "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$",
-      "type": "string"
+      },
+      "required": [
+        "street"
+      ]
     },
     "dateRange": {
       "type": "object",
@@ -254,7 +253,7 @@
         },
         "middle": {
           "type": "string",
-          "maxLength": 25
+          "maxLength": 15
         },
         "last": {
           "type": "string",
@@ -283,15 +282,26 @@
     },
     "phone": {
       "type": "string",
-      "minLength": 10
+      "minLength": 0,
+      "maxLength": 20,
+      "pattern": "[0-9+\\s-]{0,20}"
     },
     "ssn": {
       "type": "string",
-      "pattern": "^[0-9]{9}$"
+      "pattern": "\\d{3}-\\d{2}-\\d{4}"
     },
     "vaFileNumber": {
       "type": "string",
       "pattern": "^[cC]{0,1}\\d{7,9}$"
+    },
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
+    "email": {
+      "type": "string",
+      "maxLength": 50,
+      "pattern": "[a-zA-Z0-9_.+-]+@[a-zA-Z0-9_+-]+\\.[a-zA-Z]+"
     }
   },
   "properties": {
@@ -314,12 +324,12 @@
               "applicantEmail",
               "applicantPhoneNumber",
               "applicantRelationshipToClaimant",
-              "mailingAddress"
+              "mailingAddress",
+              "name"
             ],
             "properties": {
               "applicantEmail": {
-                "type": "string",
-                "format": "email"
+                "$ref": "#/definitions/email"
               },
               "applicantPhoneNumber": {
                 "$ref": "#/definitions/phone"
@@ -357,22 +367,17 @@
                 "$ref": "#/definitions/address"
               },
               "dateOfBirth": {
-                "type": "string",
-                "format": "date"
+                "$ref": "#/definitions/date"
               },
               "desiredCemetery": {
                 "type": "string",
                 "pattern": "^\\d{3}$"
               },
               "email": {
-                "type": "string",
-                "format": "email"
+                "$ref": "#/definitions/email"
               },
               "name": {
                 "$ref": "#/definitions/fullName"
-              },
-              "maidenName": {
-                "type": "string"
               },
               "phoneNumber": {
                 "$ref": "#/definitions/phone"
@@ -411,12 +416,10 @@
                 "$ref": "#/definitions/fullName"
               },
               "dateOfBirth": {
-                "type": "string",
-                "format": "date"
+                "$ref": "#/definitions/date"
               },
               "dateOfDeath": {
-                "type": "string",
-                "format": "date"
+                "$ref": "#/definitions/date"
               },
               "gender": {
                 "type": "string",
@@ -494,12 +497,13 @@
                     "dischargeType": {
                       "type": "string",
                       "enum": [
-                        "honorable",
-                        "general",
-                        "other",
-                        "bad-conduct",
-                        "dishonorable",
-                        "undesirable"
+                        "1",
+                        "2",
+                        "3",
+                        "4",
+                        "5",
+                        "6",
+                        "7"
                       ]
                     },
                     "highestRank": {

--- a/dist/40-10007-schema.json
+++ b/dist/40-10007-schema.json
@@ -451,30 +451,20 @@
                 "maxLength": 9
               },
               "militaryStatus": {
-                "type": "object",
-                "properties": {
-                  "veteran": {
-                    "type": "boolean"
-                  },
-                  "retiredActiveDuty": {
-                    "type": "boolean"
-                  },
-                  "diedOnActiveDuty": {
-                    "type": "boolean"
-                  },
-                  "retiredReserve": {
-                    "type": "boolean"
-                  },
-                  "retiredNationalGuard": {
-                    "type": "boolean"
-                  },
-                  "deathInactiveDuty": {
-                    "type": "boolean"
-                  },
-                  "other": {
-                    "type": "boolean"
-                  }
-                }
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 1,
+                "enum": [
+                  "A",
+                  "R",
+                  "S",
+                  "V",
+                  "X",
+                  "E",
+                  "D",
+                  "O",
+                  "I"
+                ]
               },
               "placeOfBirth": {
                 "type": "string",

--- a/src/schemas/40-10007/schema.js
+++ b/src/schemas/40-10007/schema.js
@@ -46,12 +46,13 @@ definitions.date = {
 
 definitions.email = {
   type: 'string',
+  maxLength: 50,
   pattern: '[a-zA-Z0-9_.+-]+@[a-zA-Z0-9_+-]+\\.[a-zA-Z]+'
 };
 
 definitions.fullName.properties.first.maxLength = 15;
 definitions.fullName.properties.last.maxLength = 25;
-definitions.fullName.properties.middle.maxLength = 25;
+definitions.fullName.properties.middle.maxLength = 15;
 definitions.fullName.properties.maiden = { type: 'string', maxLength: 15 };
 
 definitions.phone.minLength = 0;

--- a/src/schemas/40-10007/schema.js
+++ b/src/schemas/40-10007/schema.js
@@ -182,15 +182,15 @@ let schema = {
                 minLength: 1,
                 maxLength: 1,
                 'enum': [
-                  'A',
-                  'R',
-                  'S',
-                  'V',
-                  'X',
-                  'E',
-                  'D',
-                  'O',
-                  'I'
+                  'A', // Active Duty
+                  'R', // Retired
+                  'S', // Reserve/National Guard
+                  'V', // Veteran
+                  'X', // Other (Or Unknown)
+                  'E', // Retired Active Duty
+                  'D', // Died On Active Duty
+                  'O', // Retired Reserve Or National Guard
+                  'I'  // Death Related To Inactive Duty Training
                 ]
               },
               placeOfBirth: { type: 'string', maxLength: 100 },

--- a/src/schemas/40-10007/schema.js
+++ b/src/schemas/40-10007/schema.js
@@ -15,7 +15,15 @@ _.merge(modifiedToursOfDuty, {
     properties: {
       dischargeType: {
         type: 'string',
-        'enum': constants.dischargeTypes.map(option => option.value)
+        'enum': [
+          '1', // Honorable
+          '2', // General
+          '3', // Entry Level Separation/Uncharacterized
+          '4', // Other Than Honorable
+          '5', // Bad Conduct
+          '6', // Dishonorable
+          '7'  // Other
+        ]
       },
       highestRank: {
         type: 'string'

--- a/src/schemas/40-10007/schema.js
+++ b/src/schemas/40-10007/schema.js
@@ -26,7 +26,6 @@ _.merge(modifiedToursOfDuty, {
 
 definitions =  _.pick(definitions, [
   'address',
-  'date',
   'dateRange',
   'files',
   'fullName',
@@ -34,6 +33,16 @@ definitions =  _.pick(definitions, [
   'ssn',
   'vaFileNumber'
 ]);
+
+definitions.address.required = ['street'];
+definitions.address.properties.street.maxLength = 35;
+definitions.address.properties.street2.maxLength = 35;
+definitions.address.properties.city.maxLength = 30;
+
+definitions.date = {
+  type: 'string',
+  format: 'date'
+};
 
 definitions.email = {
   type: 'string',
@@ -106,7 +115,7 @@ let schema = {
             ],
             properties: {
               address: schemaHelpers.getDefinition('address'),
-              dateOfBirth: { type: 'string', format: 'date' },
+              dateOfBirth: schemaHelpers.getDefinition('date'),
               desiredCemetery: { type: 'string', pattern: '^\\d{3}$' },
               email: schemaHelpers.getDefinition('email'),
               name: schemaHelpers.getDefinition('fullName'),
@@ -138,8 +147,8 @@ let schema = {
             properties: {
               address: schemaHelpers.getDefinition('address'),
               currentName: schemaHelpers.getDefinition('fullName'),
-              dateOfBirth: { type: 'string', format: 'date' },
-              dateOfDeath: { type: 'string', format: 'date' },
+              dateOfBirth: schemaHelpers.getDefinition('date'),
+              dateOfDeath: schemaHelpers.getDefinition('date'),
               gender: {
                 type: 'string',
                 'enum': ['Female', 'Male']

--- a/src/schemas/40-10007/schema.js
+++ b/src/schemas/40-10007/schema.js
@@ -35,10 +35,21 @@ definitions =  _.pick(definitions, [
   'vaFileNumber'
 ]);
 
+definitions.email = {
+  type: 'string',
+  pattern: '[a-zA-Z0-9_.+-]+@[a-zA-Z0-9_+-]+\\.[a-zA-Z]+'
+};
+
 definitions.fullName.properties.first.maxLength = 15;
 definitions.fullName.properties.last.maxLength = 25;
 definitions.fullName.properties.middle.maxLength = 25;
 definitions.fullName.properties.maiden = { type: 'string', maxLength: 15 };
+
+definitions.phone.minLength = 0;
+definitions.phone.maxLength = 20;
+definitions.phone.pattern = '[0-9+\\s-]{0,20}';
+
+definitions.ssn.pattern = '\\d{3}-\\d{2}-\\d{4}';
 
 let schema = {
   $schema: 'http://json-schema.org/draft-04/schema#',
@@ -66,10 +77,11 @@ let schema = {
               'applicantEmail',
               'applicantPhoneNumber',
               'applicantRelationshipToClaimant',
-              'mailingAddress'
+              'mailingAddress',
+              'name'
             ],
             properties: {
-              applicantEmail: { type: 'string', format: 'email' },
+              applicantEmail: schemaHelpers.getDefinition('email'),
               applicantPhoneNumber: schemaHelpers.getDefinition('phone'),
               applicantRelationshipToClaimant: {
                 type: 'string',
@@ -96,9 +108,8 @@ let schema = {
               address: schemaHelpers.getDefinition('address'),
               dateOfBirth: { type: 'string', format: 'date' },
               desiredCemetery: { type: 'string', pattern: '^\\d{3}$' },
-              email: { type: 'string', format: 'email' },
+              email: schemaHelpers.getDefinition('email'),
               name: schemaHelpers.getDefinition('fullName'),
-              maidenName: { type: 'string' },
               phoneNumber: schemaHelpers.getDefinition('phone'),
               relationshipToVet: {
                 type: 'string',

--- a/src/schemas/40-10007/schema.js
+++ b/src/schemas/40-10007/schema.js
@@ -178,16 +178,20 @@ let schema = {
               },
               militaryServiceNumber: { type: 'string', maxLength: 9 },
               militaryStatus: {
-                type: 'object',
-                properties: {
-                  veteran: { type: 'boolean' },
-                  retiredActiveDuty: { type: 'boolean' },
-                  diedOnActiveDuty: { type: 'boolean' },
-                  retiredReserve: { type: 'boolean' },
-                  retiredNationalGuard: { type: 'boolean' },
-                  deathInactiveDuty: { type: 'boolean' },
-                  other: { type: 'boolean' }
-                }
+                type: 'string',
+                minLength: 1,
+                maxLength: 1,
+                'enum': [
+                  'A',
+                  'R',
+                  'S',
+                  'V',
+                  'X',
+                  'E',
+                  'D',
+                  'O',
+                  'I'
+                ]
               },
               placeOfBirth: { type: 'string', maxLength: 100 },
               serviceName: schemaHelpers.getDefinition('fullName'),


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#3863.
Resolves department-of-veterans-affairs/vets.gov-team#4817.

Went through the current differences between our schema and EOAS and made those interim changes. 

We don't use the date format that allows 'XXXX' in the string. We are using the default JSON schema `format: date`.

Addresses are still a mess in terms of compatibility, so I haven't touched that yet.