### PR TITLE
Enum to support new HCA eligibility question format

### DIFF
--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -514,10 +514,10 @@
     "vaCompensationType": {
       "type": "string",
       "enum": [
-        "none",
-        "pension",
         "lowDisability",
-        "highDisability"
+        "highDisability",
+        "pension",
+        "none"
       ]
     },
     "isEssentialAcaCoverage": {

--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -502,14 +502,14 @@
     "maritalStatus": {
       "$ref": "#/definitions/maritalStatus"
     },
-    "isVaServiceConnected": {
-      "type": "boolean"
-    },
-    "compensableVaServiceConnected": {
-      "type": "boolean"
-    },
-    "receivesVaPension": {
-      "type": "boolean"
+    "vaCompensationType": {
+      "type": "string",
+      "enum": [
+        "none",
+        "pension",
+        "lowDisability",
+        "highDisability"
+      ]
     },
     "isEssentialAcaCoverage": {
       "type": "boolean"
@@ -1757,6 +1757,7 @@
     "veteranDateOfBirth",
     "gender",
     "maritalStatus",
+    "vaCompensationType",
     "vaMedicalFacility",
     "isSpanishHispanicLatino",
     "veteranAddress",

--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -218,60 +218,6 @@
         "country"
       ]
     },
-    "child": {
-      "type": "object",
-      "properties": {
-        "childFullName": {
-          "$ref": "#/definitions/fullName"
-        },
-        "childRelation": {
-          "enum": [
-            "Daughter",
-            "Son",
-            "Stepson",
-            "Stepdaughter",
-            "Father",
-            "Mother",
-            "Spouse",
-            "Other"
-          ],
-          "type": "string"
-        },
-        "childSocialSecurityNumber": {
-          "$ref": "#/definitions/ssn"
-        },
-        "childBecameDependent": {
-          "$ref": "#/definitions/date"
-        },
-        "childDateOfBirth": {
-          "$ref": "#/definitions/date"
-        },
-        "childDisabledBefore18": {
-          "type": "boolean"
-        },
-        "childAttendedSchoolLastYear": {
-          "type": "boolean"
-        },
-        "childEducationExpenses": {
-          "$ref": "#/definitions/monetaryValue"
-        },
-        "childCohabitedLastYear": {
-          "type": "boolean"
-        },
-        "childReceivedSupportLastYear": {
-          "type": "boolean"
-        },
-        "grossIncome": {
-          "$ref": "#/definitions/monetaryValue"
-        },
-        "netIncome": {
-          "$ref": "#/definitions/monetaryValue"
-        },
-        "otherIncome": {
-          "$ref": "#/definitions/monetaryValue"
-        }
-      }
-    },
     "dependent": {
       "type": "object",
       "properties": {
@@ -1683,12 +1629,6 @@
     },
     "spousePhone": {
       "$ref": "#/definitions/phone"
-    },
-    "children": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/child"
-      }
     },
     "dependents": {
       "type": "array",

--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -502,6 +502,15 @@
     "maritalStatus": {
       "$ref": "#/definitions/maritalStatus"
     },
+    "isVaServiceConnected": {
+      "type": "boolean"
+    },
+    "compensableVaServiceConnected": {
+      "type": "boolean"
+    },
+    "receivesVaPension": {
+      "type": "boolean"
+    },
     "vaCompensationType": {
       "type": "string",
       "enum": [
@@ -1757,7 +1766,6 @@
     "veteranDateOfBirth",
     "gender",
     "maritalStatus",
-    "vaCompensationType",
     "vaMedicalFacility",
     "isSpanishHispanicLatino",
     "veteranAddress",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -234,7 +234,7 @@ let schema = {
     },
     vaCompensationType: {
       type: 'string',
-      enum: ['none', 'pension', 'lowDisability', 'highDisability']
+      enum: ['lowDisability', 'highDisability', 'pension', 'none']
     },
     isEssentialAcaCoverage: {
       type: 'boolean'

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -223,6 +223,15 @@ let schema = {
       type: 'string',
       'enum': constants.maritalStatuses
     },
+    isVaServiceConnected: {
+      type: 'boolean'
+    },
+    compensableVaServiceConnected: {
+      type: 'boolean'
+    },
+    receivesVaPension: {
+      type: 'boolean'
+    },
     vaCompensationType: {
       type: 'string',
       enum: ['none', 'pension', 'lowDisability', 'highDisability']
@@ -403,7 +412,6 @@ let schema = {
     'veteranDateOfBirth',
     'gender',
     'maritalStatus',
-    'vaCompensationType',
     'vaMedicalFacility',
     'isSpanishHispanicLatino',
     'veteranAddress',

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -74,51 +74,6 @@ let schema = {
         'country'
       ]
     },
-    child: {
-      type: 'object',
-      properties: {
-        childFullName: {
-          $ref: '#/definitions/fullName'
-        },
-        childRelation: {
-          'enum': constants.dependentRelationships,
-          type: 'string',
-        },
-        childSocialSecurityNumber: {
-          $ref: '#/definitions/ssn'
-        },
-        childBecameDependent: {
-          $ref: '#/definitions/date'
-        },
-        childDateOfBirth: {
-          $ref: '#/definitions/date'
-        },
-        childDisabledBefore18: {
-          type: 'boolean'
-        },
-        childAttendedSchoolLastYear: {
-          type: 'boolean'
-        },
-        childEducationExpenses: {
-          $ref: '#/definitions/monetaryValue'
-        },
-        childCohabitedLastYear: {
-          type: 'boolean'
-        },
-        childReceivedSupportLastYear: {
-          type: 'boolean'
-        },
-        grossIncome: {
-          $ref: '#/definitions/monetaryValue'
-        },
-        netIncome: {
-          $ref: '#/definitions/monetaryValue'
-        },
-        otherIncome: {
-          $ref: '#/definitions/monetaryValue'
-        },
-      }
-    },
     dependent: {
       type: 'object',
       properties: {
@@ -348,12 +303,6 @@ let schema = {
     },
     spousePhone: {
       $ref: '#/definitions/phone'
-    },
-    children: {
-      type: 'array',
-      items: {
-        $ref: '#/definitions/child'
-      },
     },
     dependents: {
       type: 'array',

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -223,14 +223,9 @@ let schema = {
       type: 'string',
       'enum': constants.maritalStatuses
     },
-    isVaServiceConnected: {
-      type: 'boolean'
-    },
-    compensableVaServiceConnected: {
-      type: 'boolean'
-    },
-    receivesVaPension: {
-      type: 'boolean'
+    vaCompensationType: {
+      type: 'string',
+      enum: ['none', 'pension', 'lowDisability', 'highDisability']
     },
     isEssentialAcaCoverage: {
       type: 'boolean'
@@ -408,6 +403,7 @@ let schema = {
     'veteranDateOfBirth',
     'gender',
     'maritalStatus',
+    'vaCompensationType',
     'vaMedicalFacility',
     'isSpanishHispanicLatino',
     'veteranAddress',


### PR DESCRIPTION
Adds a new `vaCompensationType` enum field that replaces `isVaServiceConnected`, `compensableVaServiceConnected`, `receivesVaPension` to reflect the new mutually exclusive nature of the fields.

The old fields map to the new enum like so:

## Which type of VA compensation do you currently receive? (*Required)

### Service-connected disability pay for a 10%, 20%, 30%, or 40% disability rating
Old: `compensableVaServiceConnected: true`
New: `vaCompensationType: 'lowDisability'`

### Service-connected disability pay for a 50% or higher disability rating
Old: `isVaServiceConnected: true`
New: `vaCompensationType: 'highDisability'`

### VA pension
Old: `receivesVaPension: true`
New: `vaCompensationType: 'pension'`

### I don't receive any VA pay
Old: All fields false
New: `vaCompensationType: 'none'`

Currently both styles of fields are supported at the moment. Fallback support will be removed once migrations on the front and backend have been made. 