### PR TITLE
Make file number name consistent across VRE forms

### DIFF
--- a/dist/28-1900-schema.json
+++ b/dist/28-1900-schema.json
@@ -382,7 +382,7 @@
         }
       }
     },
-    "vaFileNumber": {
+    "veteranVaFileNumber": {
       "$ref": "#/definitions/vaFileNumber"
     },
     "privacyAgreementAccepted": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/28-1900/schema.js
+++ b/src/schemas/28-1900/schema.js
@@ -97,7 +97,7 @@ let schema = {
 };
 
 [
-  ['vaFileNumber'],
+  ['vaFileNumber', 'veteranVaFileNumber'],
   ['privacyAgreementAccepted'],
   ['fullName', 'veteranFullName'],
   ['ssn', 'veteranSocialSecurityNumber'],

--- a/test/schemas/28-1900/schema.spec.js
+++ b/test/schemas/28-1900/schema.spec.js
@@ -20,7 +20,7 @@ describe('disabled veterans vocational rehabilitation schema', () => {
     ['address', ['veteranAddress', 'newVeteranAddress', 'employerAddress', 'hospitalAddress']],
     ['phone', ['homePhone', 'mobilePhone']],
     ['email'],
-    ['vaFileNumber'],
+    ['vaFileNumber', ['veteranVaFileNumber']],
     ['serviceHistory']
   ].forEach((args) => {
     sharedTests.runTest(...args); 


### PR DESCRIPTION
This makes things a little easier on the front end and is consistent with the other `veteran` prefixed fields.