### PR TITLE
add dd214 field to 28-1900 schema

### DIFF
--- a/dist/28-1900-schema.json
+++ b/dist/28-1900-schema.json
@@ -346,6 +346,24 @@
       "type": "number",
       "minimum": 0
     },
+    "dd214": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "confirmationCode": {
+            "type": "string"
+          }
+        }
+      },
+      "minItems": 1
+    },
     "disabilityRating": {
       "type": "number"
     },

--- a/dist/28-1900-schema.json
+++ b/dist/28-1900-schema.json
@@ -346,7 +346,7 @@
       "type": "number",
       "minimum": 0
     },
-    "dd214": {
+    "dischargeDocuments": {
       "type": "array",
       "items": {
         "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.27.0",
+  "version": "3.28.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/28-1900/schema.js
+++ b/src/schemas/28-1900/schema.js
@@ -1,6 +1,7 @@
 import constants from '../../common/constants';
 import _ from 'lodash';
 import definitions from '../../common/definitions';
+import originalDefinitions from '../../common/definitions';
 import schemaHelpers from '../../common/schema-helpers';
 
 let schema = {
@@ -52,6 +53,9 @@ let schema = {
       type: 'number',
       minimum: 0
     },
+    dd214: Object.assign({}, originalDefinitions.files, {
+      minItems: 1
+    }),
     disabilityRating: {
       type: 'number'
     },

--- a/src/schemas/28-1900/schema.js
+++ b/src/schemas/28-1900/schema.js
@@ -53,7 +53,7 @@ let schema = {
       type: 'number',
       minimum: 0
     },
-    dd214: Object.assign({}, originalDefinitions.files, {
+    dischargeDocuments: Object.assign({}, originalDefinitions.files, {
       minItems: 1
     }),
     disabilityRating: {

--- a/test/schemas/28-1900/schema.spec.js
+++ b/test/schemas/28-1900/schema.spec.js
@@ -36,3 +36,12 @@ schemaTestHelper.testValidAndInvalid('employer', {
   valid: ['foo corp'],
   invalid: [1]
 });
+
+schemaTestHelper.testValidAndInvalid('dischargeDocuments', {
+  valid: [[{
+    name: 'test',
+    size: 40,
+    confirmationCode: 'testcode'
+  }]],
+  invalid: [[]]
+});


### PR DESCRIPTION
Add discharge document field to schema for this [page](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/8954).

There was no unit test for this field on vic-v2 but I can add one for that validates that at least one object exists. 