### PR TITLE
526 add ramp mg

### DIFF
--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -2432,37 +2432,27 @@
       "items": {
         "type": "object",
         "required": [
-          "center",
-          "treatmentDateRange"
+          "treatmentCenterName",
+          "treatmentCenterType"
         ],
         "properties": {
-          "center": {
-            "type": "object",
-            "required": [
-              "name",
-              "type",
-              "treatmentCenterAddress"
-            ],
-            "properties": {
-              "name": {
-                "type": "string",
-                "maxLength": 100,
-                "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "VA_MEDICAL_CENTER",
-                  "DOD_MTF"
-                ]
-              },
-              "treatmentCenterAddress": {
-                "$ref": "#/definitions/vaTreatmentCenterAddress"
-              }
-            }
+          "treatmentCenterName": {
+            "type": "string",
+            "maxLength": 100,
+            "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
           },
           "treatmentDateRange": {
             "$ref": "#/definitions/dateRangeFromRequired"
+          },
+          "treatmentCenterAddress": {
+            "$ref": "#/definitions/vaTreatmentCenterAddress"
+          },
+          "treatmentCenterType": {
+            "type": "string",
+            "enum": [
+              "VA_MEDICAL_CENTER",
+              "DOD_MTF"
+            ]
           }
         }
       }

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -2468,32 +2468,6 @@
         }
       }
     },
-    "privateRecordReleases": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "treatmentCenterName"
-        ],
-        "properties": {
-          "treatmentCenterName": {
-            "type": "string",
-            "maxLength": 100,
-            "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
-          },
-          "treatmentDateRange": {
-            "$ref": "#/definitions/dateRangeFromRequired"
-          },
-          "treatmentCenterAddress": {
-            "$ref": "#/definitions/privateTreatmentCenterAddress"
-          },
-          "privateMedicalRecordsReleaseRestricted": {
-            "type": "boolean",
-            "default": false
-          }
-        }
-      }
-    },
     "specialCircumstances": {
       "type": "array",
       "maxItems": 100,

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -2491,9 +2491,6 @@
         }
       }
     },
-    "applicationExpirationDate": {
-      "type": "string"
-    },
     "standardClaim": {
       "type": "boolean",
       "default": false

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1472,13 +1472,19 @@
           "maxLength": 35,
           "pattern": "^([a-zA-Z0-9\\-'.,# ])+$"
         }
-      }
+      },
+      "required": [
+        "accountType",
+        "accountNumber",
+        "bankName",
+        "routingNumber"
+      ]
     },
     "date": {
       "pattern": "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$",
       "type": "string"
     },
-    "dateRange": {
+    "dateRangeFromRequired": {
       "type": "object",
       "properties": {
         "from": {
@@ -1490,6 +1496,21 @@
       },
       "required": [
         "from"
+      ]
+    },
+    "dateRangeAllRequired": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "$ref": "#/definitions/date"
+        },
+        "to": {
+          "$ref": "#/definitions/date"
+        }
+      },
+      "required": [
+        "from",
+        "to"
       ]
     },
     "disabilities": {
@@ -1628,7 +1649,11 @@
             "type": "string"
           },
           "dateRange": {
-            "$ref": "#/definitions/dateRange"
+            "$ref": "#/definitions/dateRange",
+            "required": [
+              "from",
+              "to"
+            ]
           }
         },
         "required": [
@@ -1655,9 +1680,22 @@
       }
     }
   },
+  "required": [
+    "veteran",
+    "serviceInformation",
+    "disabilities",
+    "applicationExpirationDate",
+    "standardClaim",
+    "claimantCertification"
+  ],
   "properties": {
     "veteran": {
       "type": "object",
+      "required": [
+        "emailAddress",
+        "mailingAddress",
+        "primaryPhone"
+      ],
       "properties": {
         "emailAddress": {
           "type": "string",
@@ -2184,6 +2222,9 @@
         },
         "homelessness": {
           "type": "object",
+          "required": [
+            "hasPointOfContact"
+          ],
           "properties": {
             "hasPointOfContact": {
               "type": "boolean",
@@ -2191,6 +2232,10 @@
             },
             "pointOfContact": {
               "type": "object",
+              "required": [
+                "pointOfContactName",
+                "primaryPhone"
+              ],
               "properties": {
                 "pointOfContactName": {
                   "type": "string",
@@ -2232,12 +2277,20 @@
     },
     "militaryPayments": {
       "type": "object",
+      "required": [
+        "payments",
+        "receiveCompensationInLieuOfRetired"
+      ],
       "properties": {
         "payments": {
           "type": "array",
           "maxItems": 100,
           "items": {
             "type": "object",
+            "required": [
+              "payType",
+              "amount"
+            ],
             "properties": {
               "amount": {
                 "type": "number"
@@ -2258,14 +2311,6 @@
         "receiveCompensationInLieuOfRetired": {
           "type": "boolean",
           "default": false
-        },
-        "receivingInactiveDutyTrainingPay": {
-          "type": "boolean",
-          "default": false
-        },
-        "waveBenifitsToRecInactDutyTraiPay": {
-          "type": "boolean",
-          "default": false
         }
       }
     },
@@ -2274,15 +2319,28 @@
     },
     "serviceInformation": {
       "type": "object",
+      "required": [
+        "servicePeriods",
+        "servedInCombatZone"
+      ],
       "properties": {
         "servicePeriods": {
           "$ref": "#/definitions/servicePeriods"
         },
         "reservesNationalGuardService": {
           "type": "object",
+          "required": [
+            "obligationTermOfServiceDateRange",
+            "unitName",
+            "unitPhone"
+          ],
           "properties": {
             "title10Activation": {
               "type": "object",
+              "required": [
+                "title10ActivationDate",
+                "anticipatedSeparationDate"
+              ],
               "properties": {
                 "title10ActivationDate": {
                   "$ref": "$/definitions/date"
@@ -2293,7 +2351,7 @@
               }
             },
             "obligationTermOfServiceDateRange": {
-              "$ref": "$/definitions/dateRange"
+              "$ref": "$/definitions/dateRangeAllRequired"
             },
             "unitName": {
               "type": "string",
@@ -2302,6 +2360,18 @@
             },
             "unitPhone": {
               "$ref": "#/definitions/phone"
+            },
+            "inactiveDutyTrainingPay": {
+              "type": "object",
+              "required": [
+                "waiveVABenefitsToRetainTrainingPay"
+              ],
+              "properties": {
+                "waiveVABenefitsToRetainTrainingPay": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
             }
           }
         },
@@ -2330,7 +2400,7 @@
             "type": "object",
             "properties": {
               "confinementDateRange": {
-                "$ref": "#/definitions/dateRange"
+                "$ref": "#/definitions/dateRangeAllRequired"
               },
               "verifiedIndicator": {
                 "type": "boolean",
@@ -2339,11 +2409,7 @@
             }
           }
         }
-      },
-      "required": [
-        "servicePeriods",
-        "servedInCombatZone"
-      ]
+      }
     },
     "disabilities": {
       "$ref": "#/definitions/disabilities"
@@ -2364,7 +2430,7 @@
             "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
           },
           "treatmentDateRange": {
-            "$ref": "#/definitions/dateRange"
+            "$ref": "#/definitions/dateRangeFromRequired"
           },
           "treatmentCenterAddress": {
             "$ref": "#/definitions/vaTreatmentCenterAddress"
@@ -2393,7 +2459,7 @@
             "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
           },
           "treatmentDateRange": {
-            "$ref": "#/definitions/dateRange"
+            "$ref": "#/definitions/dateRangeFromRequired"
           },
           "treatmentCenterAddress": {
             "$ref": "#/definitions/privateTreatmentCenterAddress"
@@ -2427,11 +2493,17 @@
     "noRapidProcessing": {
       "type": "boolean",
       "default": false
+    },
+    "applicationExpirationDate": {
+      "type": "string"
+    },
+    "standardClaim": {
+      "type": "boolean",
+      "default": false
+    },
+    "claimantCertification": {
+      "type": "boolean",
+      "default": false
     }
-  },
-  "required": [
-    "veteran",
-    "disabilities",
-    "serviceInformation"
-  ]
+  }
 }

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -2467,6 +2467,32 @@
         }
       }
     },
+    "privateRecordReleases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "treatmentCenterName"
+        ],
+        "properties": {
+          "treatmentCenterName": {
+            "type": "string",
+            "maxLength": 100,
+            "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+          },
+          "treatmentDateRange": {
+            "$ref": "#/definitions/dateRangeFromRequired"
+          },
+          "treatmentCenterAddress": {
+            "$ref": "#/definitions/privateTreatmentCenterAddress"
+          },
+          "privateMedicalRecordsReleaseRestricted": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    },
     "specialCircumstances": {
       "type": "array",
       "maxItems": 100,

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -2490,10 +2490,6 @@
         }
       }
     },
-    "noRapidProcessing": {
-      "type": "boolean",
-      "default": false
-    },
     "applicationExpirationDate": {
       "type": "string"
     },

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1529,7 +1529,7 @@
             "type": "string"
           },
           "diagnosticCode": {
-            "type": "number"
+            "type": "string"
           },
           "specialIssueTypeCode": {
             "type": "string"
@@ -1574,7 +1574,7 @@
                   "type": "string"
                 },
                 "diagnosticCode": {
-                  "type": "number"
+                  "type": "string"
                 },
                 "specialIssueTypeCode": {
                   "type": "string"

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1519,10 +1519,8 @@
       "items": {
         "type": "object",
         "required": [
-          "diagnosticText",
-          "disabilityActionType",
-          "decisionCode",
-          "ratedDisabilityId"
+          "name",
+          "disabilityActionType"
         ],
         "properties": {
           "name": {
@@ -1550,10 +1548,7 @@
             "type": "string"
           },
           "diagnosticCode": {
-            "type": "string"
-          },
-          "specialIssueTypeCode": {
-            "type": "string"
+            "type": "number"
           },
           "classificationCode": {
             "type": "string"
@@ -1564,10 +1559,8 @@
             "items": {
               "type": "object",
               "required": [
-                "diagnosticText",
-                "disabilityActionType",
-                "decisionCode",
-                "ratedDisabilityId"
+                "name",
+                "disabilityActionType"
               ],
               "properties": {
                 "name": {
@@ -1595,10 +1588,7 @@
                   "type": "string"
                 },
                 "diagnosticCode": {
-                  "type": "string"
-                },
-                "specialIssueTypeCode": {
-                  "type": "string"
+                  "type": "number"
                 },
                 "classificationCode": {
                   "type": "string"
@@ -1669,9 +1659,31 @@
       "maxItems": 100,
       "items": {
         "type": "object",
+        "required": [
+          "code",
+          "name"
+        ],
         "properties": {
           "code": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "ALS",
+              "AOIV",
+              "AOOV",
+              "ASB",
+              "EHCL",
+              "GW",
+              "HEPC",
+              "MG",
+              "POW",
+              "RDN",
+              "SHAD",
+              "TRM",
+              "38USC1151",
+              "PTSD/1",
+              "PTSD/2",
+              "PTSD/4)"
+            ]
           },
           "name": {
             "type": "string"

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -2396,6 +2396,7 @@
         },
         "confinements": {
           "type": "array",
+          "maxItems": 100,
           "items": {
             "type": "object",
             "properties": {

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1470,7 +1470,7 @@
         "bankName": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "([a-zA-Z0-9\\-'.,# ])+$"
+          "pattern": "^([a-zA-Z0-9\\-'.,# ])+$"
         }
       }
     },
@@ -1507,7 +1507,7 @@
           "name": {
             "type": "string",
             "maxLength": 255,
-            "pattern": "([a-zA-Z0-9\\-'.,#]([a-zA-Z0-9\\-',.# ])?)+$"
+            "pattern": "^([a-zA-Z0-9\\-'.,#]([a-zA-Z0-9\\-',.# ])?)+$"
           },
           "disabilityActionType": {
             "type": "string",
@@ -1552,7 +1552,7 @@
                 "name": {
                   "type": "string",
                   "maxLength": 255,
-                  "pattern": "([a-zA-Z0-9\\-'.,#]([a-zA-Z0-9\\-',.# ])?)+$"
+                  "pattern": "^([a-zA-Z0-9\\-'.,#]([a-zA-Z0-9\\-',.# ])?)+$"
                 },
                 "disabilityActionType": {
                   "type": "string",
@@ -1596,17 +1596,17 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 30,
-          "pattern": "([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+          "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
         },
         "middle": {
           "type": "string",
-          "pattern": "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
+          "pattern": "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
         },
         "last": {
           "type": "string",
           "minLength": 1,
           "maxLength": 30,
-          "pattern": "([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+          "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
         }
       },
       "required": [
@@ -1617,7 +1617,7 @@
     "phone": {
       "type": "string",
       "minLength": 10,
-      "pattern": "\\d{7}"
+      "pattern": "^\\d{7}"
     },
     "servicePeriods": {
       "type": "array",
@@ -2195,7 +2195,7 @@
                 "pointOfContactName": {
                   "type": "string",
                   "maxLength": 100,
-                  "pattern": "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
+                  "pattern": "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
                 },
                 "primaryPhone": {
                   "$ref": "#/definitions/phone"
@@ -2298,7 +2298,7 @@
             "unitName": {
               "type": "string",
               "maxLength": 256,
-              "pattern": "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
+              "pattern": "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
             },
             "unitPhone": {
               "$ref": "#/definitions/phone"
@@ -2312,7 +2312,7 @@
         "separationLocationName": {
           "type": "string",
           "maxLength": 256,
-          "pattern": "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
+          "pattern": "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
         },
         "separationLocationCode": {
           "type": "string"
@@ -2361,7 +2361,7 @@
           "treatmentCenterName": {
             "type": "string",
             "maxLength": 100,
-            "pattern": "([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+            "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
           },
           "treatmentDateRange": {
             "$ref": "#/definitions/dateRange"
@@ -2390,7 +2390,7 @@
           "treatmentCenterName": {
             "type": "string",
             "maxLength": 100,
-            "pattern": "([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+            "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
           },
           "treatmentDateRange": {
             "$ref": "#/definitions/dateRange"

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -2497,6 +2497,11 @@
     "specialCircumstances": {
       "type": "array",
       "maxItems": 100,
+      "required": [
+        "name",
+        "code",
+        "needed"
+      ],
       "items": {
         "type": "object",
         "properties": {

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1627,8 +1627,7 @@
     },
     "phone": {
       "type": "string",
-      "minLength": 10,
-      "pattern": "^\\d{7}"
+      "pattern": "^\\d{10}$"
     },
     "servicePeriods": {
       "type": "array",

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -2433,27 +2433,37 @@
       "items": {
         "type": "object",
         "required": [
-          "treatmentCenterName",
-          "treatmentCenterType"
+          "center",
+          "treatmentDateRange"
         ],
         "properties": {
-          "treatmentCenterName": {
-            "type": "string",
-            "maxLength": 100,
-            "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+          "center": {
+            "type": "object",
+            "required": [
+              "name",
+              "type",
+              "treatmentCenterAddress"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "maxLength": 100,
+                "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "VA_MEDICAL_CENTER",
+                  "DOD_MTF"
+                ]
+              },
+              "treatmentCenterAddress": {
+                "$ref": "#/definitions/vaTreatmentCenterAddress"
+              }
+            }
           },
           "treatmentDateRange": {
             "$ref": "#/definitions/dateRangeFromRequired"
-          },
-          "treatmentCenterAddress": {
-            "$ref": "#/definitions/vaTreatmentCenterAddress"
-          },
-          "treatmentCenterType": {
-            "type": "string",
-            "enum": [
-              "VA_MEDICAL_CENTER",
-              "DOD_MTF"
-            ]
           }
         }
       }

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1470,7 +1470,7 @@
         "bankName": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "([a-zA-Z0-9-'.,# ])+$"
+          "pattern": "([a-zA-Z0-9\\-'.,# ])+$"
         }
       }
     },
@@ -1507,7 +1507,7 @@
           "name": {
             "type": "string",
             "maxLength": 255,
-            "pattern": "([a-zA-Z0-9-'.,#]([a-zA-Z0-9-',.# ])?)+$"
+            "pattern": "([a-zA-Z0-9\\-'.,#]([a-zA-Z0-9\\-',.# ])?)+$"
           },
           "disabilityActionType": {
             "type": "string",
@@ -1552,7 +1552,7 @@
                 "name": {
                   "type": "string",
                   "maxLength": 255,
-                  "pattern": "([a-zA-Z0-9-'.,#]([a-zA-Z0-9-',.# ])?)+$"
+                  "pattern": "([a-zA-Z0-9\\-'.,#]([a-zA-Z0-9\\-',.# ])?)+$"
                 },
                 "disabilityActionType": {
                   "type": "string",
@@ -1596,17 +1596,17 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 30,
-          "pattern": "([a-zA-Z0-9-'.#]([a-zA-Z0-9-'.# ])?)+$"
+          "pattern": "([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
         },
         "middle": {
           "type": "string",
-          "pattern": "([a-zA-Z0-9-'.#][a-zA-Z0-9-'.# ]?)*$"
+          "pattern": "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
         },
         "last": {
           "type": "string",
           "minLength": 1,
           "maxLength": 30,
-          "pattern": "([a-zA-Z0-9-'.#]([a-zA-Z0-9-'.# ])?)+$"
+          "pattern": "([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
         }
       },
       "required": [
@@ -1617,7 +1617,7 @@
     "phone": {
       "type": "string",
       "minLength": 10,
-      "pattern": "d{7}"
+      "pattern": "\\d{7}"
     },
     "servicePeriods": {
       "type": "array",
@@ -2195,7 +2195,7 @@
                 "pointOfContactName": {
                   "type": "string",
                   "maxLength": 100,
-                  "pattern": "([a-zA-Z0-9-'.#][a-zA-Z0-9-'.# ]?)*$"
+                  "pattern": "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
                 },
                 "primaryPhone": {
                   "$ref": "#/definitions/phone"
@@ -2298,7 +2298,7 @@
             "unitName": {
               "type": "string",
               "maxLength": 256,
-              "pattern": "([a-zA-Z0-9-'.#][a-zA-Z0-9-'.# ]?)*$"
+              "pattern": "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
             },
             "unitPhone": {
               "$ref": "#/definitions/phone"
@@ -2312,7 +2312,7 @@
         "separationLocationName": {
           "type": "string",
           "maxLength": 256,
-          "pattern": "([a-zA-Z0-9-'.#][a-zA-Z0-9-'.# ]?)*$"
+          "pattern": "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
         },
         "separationLocationCode": {
           "type": "string"
@@ -2361,7 +2361,7 @@
           "treatmentCenterName": {
             "type": "string",
             "maxLength": 100,
-            "pattern": "([a-zA-Z0-9-'.#]([a-zA-Z0-9-'.# ])?)+$"
+            "pattern": "([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
           },
           "treatmentDateRange": {
             "$ref": "#/definitions/dateRange"

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -2423,6 +2423,10 @@
           }
         }
       }
+    },
+    "noRapidProcessing": {
+      "type": "boolean",
+      "default": false
     }
   },
   "required": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.41.0",
+  "version": "3.42.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -469,16 +469,12 @@ let schema = {
         }
       }
     },
-    StandardClaim: {
-      // I DO NOT want my claim considered for rapid processing under the FDC
-      // program because I plan to submit further evidence in support of my claim
-      type: 'boolean',
-      default: false
-    },
     applicationExpirationDate: {
       type: 'string'
     },
     standardClaim: {
+      // I DO NOT want my claim considered for rapid processing under the FDC
+      // program because I plan to submit further evidence in support of my claim
       type: 'boolean',
       default: false
     },

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -419,31 +419,23 @@ let schema = {
       maxItems: 100,
       items: {
         type: 'object',
-        required: ['center', 'treatmentDateRange'],
+        required: ['treatmentCenterName', 'treatmentCenterType'],
         properties: {
-          center: {
-            type: 'object',
-            required: ['name', 'type', 'treatmentCenterAddress'],
-            properties: {
-              name: {
-                type: 'string',
-                maxLength: 100,
-                pattern: "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
-              },
-              type: {
-                type: 'string',
-                enum: ['VA_MEDICAL_CENTER', 'DOD_MTF']
-              },
-              treatmentCenterAddress: {
-                // maps to 'TreatmentCenter.country/state/city' in Swagger
-                // Only country is required
-                $ref: '#/definitions/vaTreatmentCenterAddress'
-              },
-            }
+          treatmentCenterName: {
+            type: 'string',
+            maxLength: 100,
+            pattern: "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
           },
           treatmentDateRange: {
             $ref: '#/definitions/dateRangeFromRequired'
           },
+          treatmentCenterAddress: {
+            $ref: '#/definitions/vaTreatmentCenterAddress'
+          },
+          treatmentCenterType: {
+            type: 'string',
+            enum: ['VA_MEDICAL_CENTER', 'DOD_MTF']
+          }
         }
       }
     },

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -444,7 +444,11 @@ let schema = {
           }
         }
       }
-    }
+    },
+    noRapidProcessing: {
+      type: 'boolean',
+      default: false
+    },
   },
   required: ['veteran', 'disabilities', 'serviceInformation']
 };

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -450,35 +450,39 @@ let schema = {
         }
       }
     },
-    privateRecordReleases: {
-    // These records are sent through an ancillary form and are not directly
-    // submitted via 526. This ancillary submission process has no actual
-    // validations, but we thought keeping them here (especially for address)
-    // would enforce a baseline of data quality which would be in the
-    // submitter's best interest.
-      type: 'array',
-      items: {
-        type: 'object',
-        required: ['treatmentCenterName'],
-        properties: {
-          treatmentCenterName: {
-            type: 'string',
-            maxLength: 100,
-            pattern: "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
-          },
-          treatmentDateRange: {
-            $ref: '#/definitions/dateRangeFromRequired'
-          },
-          treatmentCenterAddress: {
-            $ref: '#/definitions/privateTreatmentCenterAddress'
-          },
-          privateMedicalRecordsReleaseRestricted: {
-            type: 'boolean',
-            default: false
-          }
-        }
-      }
-    },
+    /**
+     * Private Medical Record Release Requests are not part of MVP due to
+     * uncertainty surrounding filling PDFs using form data.
+     */
+    // privateRecordReleases: {
+    // // These records are sent through an ancillary form and are not directly
+    // // submitted via 526. This ancillary submission process has no actual
+    // // validations, but we thought keeping them here (especially for address)
+    // // would enforce a baseline of data quality which would be in the
+    // // submitter's best interest.
+    //   type: 'array',
+    //   items: {
+    //     type: 'object',
+    //     required: ['treatmentCenterName'],
+    //     properties: {
+    //       treatmentCenterName: {
+    //         type: 'string',
+    //         maxLength: 100,
+    //         pattern: "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+    //       },
+    //       treatmentDateRange: {
+    //         $ref: '#/definitions/dateRangeFromRequired'
+    //       },
+    //       treatmentCenterAddress: {
+    //         $ref: '#/definitions/privateTreatmentCenterAddress'
+    //       },
+    //       privateMedicalRecordsReleaseRestricted: {
+    //         type: 'boolean',
+    //         default: false
+    //       }
+    //     }
+    //   }
+    // },
     specialCircumstances: {
       type: 'array',
       maxItems: 100,

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -47,7 +47,7 @@ const disabilitiesBaseDef = {
         type: 'string'
       },
       diagnosticCode: {
-        type: 'number'
+        type: 'string'
       },
       specialIssueTypeCode: {
         type: 'string'

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -469,8 +469,9 @@ let schema = {
         }
       }
     },
-    noRapidProcessing: {
-      // Ancillary form, not part of 526 submit endpoint data
+    StandardClaim: {
+      // I DO NOT want my claim considered for rapid processing under the FDC
+      // program because I plan to submit further evidence in support of my claim
       type: 'boolean',
       default: false
     },

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -16,7 +16,7 @@ const uniqueBankFields = {
     bankName: {
       type: 'string',
       maxLength: 35,
-      pattern: "([a-zA-Z0-9\-'.,# ])+$"
+      pattern: "([a-zA-Z0-9\\-'.,# ])+$"
     }
   }
 };
@@ -31,7 +31,7 @@ const disabilitiesBaseDef = {
       name: {
         type: 'string',
         maxLength: 255,
-        pattern: "([a-zA-Z0-9\-'.,#]([a-zA-Z0-9\-',.# ])?)+$"
+        pattern: "([a-zA-Z0-9\\-'.,#]([a-zA-Z0-9\\-',.# ])?)+$"
       },
       disabilityActionType: {
         type: 'string',
@@ -96,10 +96,10 @@ const fullNameDef = ((definitions) => {
   delete fullNameClone.properties.suffix;
 
   // These patterns are taken straight from Swagger
-  const firstLastPattern = "([a-zA-Z0-9\-'.#]([a-zA-Z0-9\-'.# ])?)+$"
+  const firstLastPattern = "([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
   fullNameClone.properties.first.pattern = firstLastPattern;
   fullNameClone.properties.last.pattern = firstLastPattern;
-  fullNameClone.properties.middle.pattern = "([a-zA-Z0-9\-'.#][a-zA-Z0-9\-'.# ]?)*$";
+  fullNameClone.properties.middle.pattern = "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$";
 
   return fullNameClone;
 })(definitions);
@@ -165,7 +165,7 @@ let schema = {
     fullName: fullNameDef,
     // vets-api will split into separate area code & phone number fields
     phone: Object.assign({}, definitions.phone, {
-      pattern: "\d{7}" // differs from Swagger, but agreement from EVSS to update
+      pattern: "\\d{7}" // differs from Swagger, but agreement from EVSS to update
     }),
     servicePeriods: servicePeriodsDef,
     specialIssues: {
@@ -220,7 +220,7 @@ let schema = {
                 pointOfContactName: {
                   type: 'string',
                   maxLength: 100, // Why can this be so long but not the address parts?
-                  pattern: "([a-zA-Z0-9\-'.#][a-zA-Z0-9\-'.# ]?)*$"
+                  pattern: "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
                 },
                 primaryPhone: {
                   $ref: '#/definitions/phone'
@@ -324,7 +324,7 @@ let schema = {
             unitName: {
               type: 'string',
               maxLength: 256,
-              pattern: "([a-zA-Z0-9\-'.#][a-zA-Z0-9\-'.# ]?)*$"
+              pattern: "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
             },
             unitPhone: {
               $ref: '#/definitions/phone'
@@ -338,7 +338,7 @@ let schema = {
         separationLocationName: {
           type: 'string',
           maxLength: 256,
-          pattern: "([a-zA-Z0-9\-'.#][a-zA-Z0-9\-'.# ]?)*$"
+          pattern: "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
         },
         separationLocationCode: {
           type: 'string'
@@ -381,7 +381,7 @@ let schema = {
           treatmentCenterName: {
             type: 'string',
             maxLength: 100,
-            pattern: "([a-zA-Z0-9\-'.#]([a-zA-Z0-9\-'.# ])?)+$"
+            pattern: "([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
           },
           treatmentDateRange: {
             $ref: '#/definitions/dateRange'

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -422,23 +422,31 @@ let schema = {
       maxItems: 100,
       items: {
         type: 'object',
-        required: ['treatmentCenterName', 'treatmentCenterType'],
+        required: ['center', 'treatmentDateRange'],
         properties: {
-          treatmentCenterName: {
-            type: 'string',
-            maxLength: 100,
-            pattern: "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+          center: {
+            type: 'object',
+            required: ['name', 'type', 'treatmentCenterAddress'],
+            properties: {
+              name: {
+                type: 'string',
+                maxLength: 100,
+                pattern: "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+              },
+              type: {
+                type: 'string',
+                enum: ['VA_MEDICAL_CENTER', 'DOD_MTF']
+              },
+              treatmentCenterAddress: {
+                // maps to 'TreatmentCenter.country/state/city' in Swagger
+                // Only country is required
+                $ref: '#/definitions/vaTreatmentCenterAddress'
+              },
+            }
           },
           treatmentDateRange: {
             $ref: '#/definitions/dateRangeFromRequired'
           },
-          treatmentCenterAddress: {
-            $ref: '#/definitions/vaTreatmentCenterAddress'
-          },
-          treatmentCenterType: {
-            type: 'string',
-            enum: ['VA_MEDICAL_CENTER', 'DOD_MTF']
-          }
         }
       }
     },

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -27,7 +27,7 @@ const disabilitiesBaseDef = {
   maxItems: 100,
   items: {
     type: 'object',
-    required: ['diagnosticText', 'disabilityActionType', 'decisionCode', 'ratedDisabilityId'],
+    required: ['name', 'disabilityActionType'],
     properties: {
       name: {
         type: 'string',
@@ -48,10 +48,7 @@ const disabilitiesBaseDef = {
         type: 'string'
       },
       diagnosticCode: {
-        type: 'string'
-      },
-      specialIssueTypeCode: {
-        type: 'string'
+        type: 'number'
       },
       classificationCode: {
         type: 'string'
@@ -182,9 +179,28 @@ let schema = {
       maxItems: 100,
       items: {
         type: 'object',
+        required: ['code', 'name'],
         properties: {
           code: {
-            type: 'string'
+            type: 'string',
+            enum: [
+              'ALS',
+              'AOIV',
+              'AOOV',
+              'ASB',
+              'EHCL',
+              'GW',
+              'HEPC',
+              'MG',
+              'POW',
+              'RDN',
+              'SHAD',
+              'TRM',
+              '38USC1151',
+              'PTSD/1',
+              'PTSD/2',
+              'PTSD/4)'
+            ]
           },
           name: {
             type: 'string'

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -169,10 +169,7 @@ let schema = {
       }
     }),
     fullName: fullNameDef,
-    // vets-api will split into separate area code & phone number fields
-    phone: Object.assign({}, definitions.phone, {
-      pattern: "^\\d{7}" // differs from Swagger, but agreement from EVSS to update
-    }),
+    phone: definitions.usaPhone,
     servicePeriods: servicePeriodsDef,
     specialIssues: {
       type: 'array',

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -500,10 +500,6 @@ let schema = {
         }
       }
     },
-    applicationExpirationDate: {
-      // 365 days from created date (check how to handle this when submitting new form)
-      type: 'string'
-    },
     standardClaim: {
       // I DO NOT want my claim considered for rapid processing under the FDC
       // program because I plan to submit further evidence in support of my claim

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -382,6 +382,7 @@ let schema = {
         },
         confinements: {
           type: 'array',
+          maxItems: 100,
           items: {
             type: 'object',
             properties: {

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -16,7 +16,7 @@ const uniqueBankFields = {
     bankName: {
       type: 'string',
       maxLength: 35,
-      pattern: "([a-zA-Z0-9\\-'.,# ])+$"
+      pattern: "^([a-zA-Z0-9\\-'.,# ])+$"
     }
   }
 };
@@ -31,7 +31,7 @@ const disabilitiesBaseDef = {
       name: {
         type: 'string',
         maxLength: 255,
-        pattern: "([a-zA-Z0-9\\-'.,#]([a-zA-Z0-9\\-',.# ])?)+$"
+        pattern: "^([a-zA-Z0-9\\-'.,#]([a-zA-Z0-9\\-',.# ])?)+$"
       },
       disabilityActionType: {
         type: 'string',
@@ -96,10 +96,10 @@ const fullNameDef = ((definitions) => {
   delete fullNameClone.properties.suffix;
 
   // These patterns are taken straight from Swagger
-  const firstLastPattern = "([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+  const firstLastPattern = "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
   fullNameClone.properties.first.pattern = firstLastPattern;
   fullNameClone.properties.last.pattern = firstLastPattern;
-  fullNameClone.properties.middle.pattern = "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$";
+  fullNameClone.properties.middle.pattern = "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$";
 
   return fullNameClone;
 })(definitions);
@@ -165,7 +165,7 @@ let schema = {
     fullName: fullNameDef,
     // vets-api will split into separate area code & phone number fields
     phone: Object.assign({}, definitions.phone, {
-      pattern: "\\d{7}" // differs from Swagger, but agreement from EVSS to update
+      pattern: "^\\d{7}" // differs from Swagger, but agreement from EVSS to update
     }),
     servicePeriods: servicePeriodsDef,
     specialIssues: {
@@ -220,7 +220,7 @@ let schema = {
                 pointOfContactName: {
                   type: 'string',
                   maxLength: 100, // Why can this be so long but not the address parts?
-                  pattern: "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
+                  pattern: "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
                 },
                 primaryPhone: {
                   $ref: '#/definitions/phone'
@@ -324,7 +324,7 @@ let schema = {
             unitName: {
               type: 'string',
               maxLength: 256,
-              pattern: "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
+              pattern: "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
             },
             unitPhone: {
               $ref: '#/definitions/phone'
@@ -338,7 +338,7 @@ let schema = {
         separationLocationName: {
           type: 'string',
           maxLength: 256,
-          pattern: "([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
+          pattern: "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
         },
         separationLocationCode: {
           type: 'string'
@@ -381,7 +381,7 @@ let schema = {
           treatmentCenterName: {
             type: 'string',
             maxLength: 100,
-            pattern: "([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+            pattern: "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
           },
           treatmentDateRange: {
             $ref: '#/definitions/dateRange'
@@ -410,7 +410,7 @@ let schema = {
           treatmentCenterName: {
             type: 'string',
             maxLength: 100,
-            pattern: "([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+            pattern: "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
           },
           treatmentDateRange: {
             $ref: '#/definitions/dateRange'

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -447,39 +447,35 @@ let schema = {
         }
       }
     },
-    /**
-     * Private Medical Record Release Requests are not part of MVP due to
-     * uncertainty surrounding filling PDFs using form data.
-     */
-    // privateRecordReleases: {
-    // // These records are sent through an ancillary form and are not directly
-    // // submitted via 526. This ancillary submission process has no actual
-    // // validations, but we thought keeping them here (especially for address)
-    // // would enforce a baseline of data quality which would be in the
-    // // submitter's best interest.
-    //   type: 'array',
-    //   items: {
-    //     type: 'object',
-    //     required: ['treatmentCenterName'],
-    //     properties: {
-    //       treatmentCenterName: {
-    //         type: 'string',
-    //         maxLength: 100,
-    //         pattern: "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
-    //       },
-    //       treatmentDateRange: {
-    //         $ref: '#/definitions/dateRangeFromRequired'
-    //       },
-    //       treatmentCenterAddress: {
-    //         $ref: '#/definitions/privateTreatmentCenterAddress'
-    //       },
-    //       privateMedicalRecordsReleaseRestricted: {
-    //         type: 'boolean',
-    //         default: false
-    //       }
-    //     }
-    //   }
-    // },
+    privateRecordReleases: {
+    // These records are sent through an ancillary form and are not directly
+    // submitted via 526. This ancillary submission process has no actual
+    // validations, but we thought keeping them here (especially for address)
+    // would enforce a baseline of data quality which would be in the
+    // submitter's best interest.
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['treatmentCenterName'],
+        properties: {
+          treatmentCenterName: {
+            type: 'string',
+            maxLength: 100,
+            pattern: "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+          },
+          treatmentDateRange: {
+            $ref: '#/definitions/dateRangeFromRequired'
+          },
+          treatmentCenterAddress: {
+            $ref: '#/definitions/privateTreatmentCenterAddress'
+          },
+          privateMedicalRecordsReleaseRestricted: {
+            type: 'boolean',
+            default: false
+          }
+        }
+      }
+    },
     specialCircumstances: {
       type: 'array',
       maxItems: 100,

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -482,6 +482,7 @@ let schema = {
     specialCircumstances: {
       type: 'array',
       maxItems: 100,
+      required: ['name', 'code', 'needed'],
       items: {
         type: 'object',
         properties: {

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -303,6 +303,7 @@ let schema = {
           }
         },
         receiveCompensationInLieuOfRetired: {
+          // I want military retired pay instead of VA compensation
           type: 'boolean',
           default: false
         },
@@ -350,6 +351,9 @@ let schema = {
               required: ['waiveVABenefitsToRetainTrainingPay'],
               properties: {
                 waiveVABenefitsToRetainTrainingPay: {
+                  // I elect to waive VA benefits for the days I accrued
+                  // inactive duty training pay in order to retain my inactive
+                  // duty training pay.
                   type: 'boolean',
                   default: false
                 }
@@ -470,6 +474,7 @@ let schema = {
       }
     },
     applicationExpirationDate: {
+      // 365 days from created date (check how to handle this when submitting new form)
       type: 'string'
     },
     standardClaim: {
@@ -479,6 +484,7 @@ let schema = {
       default: false
     },
     claimantCertification: {
+      // VETERAN/SERVICE MEMBER/ALTERNATE SIGNER SIGNATURE
       type: 'boolean',
       default: false
     }


### PR DESCRIPTION
- Updates several schema properties / hierarchies to match current swagger
- Removes / adds several schema fields to reflect desired MVP functionality and moving responsibility for some fields to purely vets-api

Introduces breaking changes for the form config so needs to be coordinated with changes to `vets-website`

In addition to connected issue, also resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/10135 and https://github.com/department-of-veterans-affairs/vets.gov-team/issues/10054

Though for 10054, ramp exclusion was already in the schema - we just didn't know what it was.

For reference, please check the submit endpoint schema by pasting this into Swagger:
https://csraciapp6.evss.srarad.com/wss-form526-services-web/rest/swagger.yaml