### PR TITLE
remove 'zipcode' from 10-10EZ schema

### DIFF
--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -30,10 +30,6 @@
                 "SK",
                 "YT"
               ]
-            },
-            "zipcode": {
-              "type": "string",
-              "maxLength": 50
             }
           }
         },
@@ -81,10 +77,6 @@
                 "yucatan",
                 "zacatecas"
               ]
-            },
-            "zipcode": {
-              "type": "string",
-              "maxLength": 50
             }
           }
         },
@@ -162,10 +154,6 @@
                 "WI",
                 "WY"
               ]
-            },
-            "zipcode": {
-              "type": "string",
-              "maxLength": 50
             }
           }
         },
@@ -184,10 +172,20 @@
             "provinceCode": {
               "type": "string",
               "maxLength": 51
-            },
+            }
+          }
+        }
+      ],
+      "anyOf": [
+        {
+          "properties": {
             "postalCode": {
               "type": "string",
               "maxLength": 51
+            },
+            "zipcode": {
+              "type": "string",
+              "maxLength": 50
             }
           }
         }

--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -176,20 +176,6 @@
           }
         }
       ],
-      "anyOf": [
-        {
-          "properties": {
-            "postalCode": {
-              "type": "string",
-              "maxLength": 51
-            },
-            "zipcode": {
-              "type": "string",
-              "maxLength": 50
-            }
-          }
-        }
-      ],
       "properties": {
         "street": {
           "type": "string",
@@ -207,6 +193,10 @@
         "city": {
           "type": "string",
           "minLength": 1,
+          "maxLength": 51
+        },
+        "postalCode": {
+          "type": "string",
           "maxLength": 51
         }
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.40.0",
+  "version": "3.41.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -14,10 +14,6 @@ const countryStateProperites = _.map(constants.states, (value, key) => ({
     state: {
       type: 'string',
       'enum': value.map(x => x.value)
-    },
-    zipcode: {
-      type: 'string',
-      maxLength: 50
     }
   }
 }));
@@ -34,10 +30,6 @@ countryStateProperites.push(
         type: 'string',
         maxLength: 51
       },
-      postalCode: {
-        type: 'string',
-        maxLength: 51
-      },
     },
   });
 
@@ -48,6 +40,20 @@ let schema = {
     address: {
       type: 'object',
       oneOf: countryStateProperites,
+      anyOf: [
+        {
+          properties: {
+            postalCode: {
+              type: 'string',
+              maxLength: 51
+            },
+            zipcode: {
+              type: 'string',
+              maxLength: 50
+            }
+          }
+        }
+      ],
       properties: {
         street: {
           type: 'string',
@@ -66,7 +72,7 @@ let schema = {
           type: 'string',
           minLength: 1,
           maxLength: 51
-        }
+        },
       },
       required: [
         'street',

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -40,20 +40,6 @@ let schema = {
     address: {
       type: 'object',
       oneOf: countryStateProperites,
-      anyOf: [
-        {
-          properties: {
-            postalCode: {
-              type: 'string',
-              maxLength: 51
-            },
-            zipcode: {
-              type: 'string',
-              maxLength: 50
-            }
-          }
-        }
-      ],
       properties: {
         street: {
           type: 'string',
@@ -73,6 +59,10 @@ let schema = {
           minLength: 1,
           maxLength: 51
         },
+        postalCode: {
+          type: 'string',
+          maxLength: 51
+        }
       },
       required: [
         'street',


### PR DESCRIPTION
FWIW, I tested these changes locally with the latest changes to API and website and they cause no issues (because `postalCode` is not in the array of `required` properties in the schema).