### PR TITLE
disallow space-only input on required fields

### DIFF
--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -171,6 +171,7 @@
             },
             "provinceCode": {
               "type": "string",
+              "pattern": "^.*\\S.*",
               "maxLength": 51
             }
           }
@@ -179,6 +180,7 @@
       "properties": {
         "street": {
           "type": "string",
+          "pattern": "^.*\\S.*",
           "minLength": 1,
           "maxLength": 50
         },
@@ -192,6 +194,7 @@
         },
         "city": {
           "type": "string",
+          "pattern": "^.*\\S.*",
           "minLength": 1,
           "maxLength": 51
         },
@@ -269,6 +272,7 @@
       "properties": {
         "first": {
           "type": "string",
+          "pattern": "^.*\\S.*",
           "minLength": 1,
           "maxLength": 30
         },
@@ -277,6 +281,7 @@
         },
         "last": {
           "type": "string",
+          "pattern": "^.*\\S.*",
           "minLength": 2,
           "maxLength": 30
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.44.0",
+  "version": "3.45.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -45,7 +45,6 @@ let schema = {
         street: {
           type: 'string',
           pattern: '^.*\\S.*',
-          minLength: 2,
           minLength: 1,
           maxLength: 50
         },
@@ -60,7 +59,6 @@ let schema = {
         city: {
           type: 'string',
           pattern: '^.*\\S.*',
-          minLength: 2,
           minLength: 1,
           maxLength: 51
         },

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -28,6 +28,7 @@ countryStateProperites.push(
       },
       provinceCode: {
         type: 'string',
+        pattern: '^.*\\S.*',
         maxLength: 51
       },
     },
@@ -43,6 +44,8 @@ let schema = {
       properties: {
         street: {
           type: 'string',
+          pattern: '^.*\\S.*',
+          minLength: 2,
           minLength: 1,
           maxLength: 50
         },
@@ -56,6 +59,8 @@ let schema = {
         },
         city: {
           type: 'string',
+          pattern: '^.*\\S.*',
+          minLength: 2,
           minLength: 1,
           maxLength: 51
         },
@@ -124,6 +129,7 @@ let schema = {
       properties: {
         first: {
           type: 'string',
+          pattern: '^.*\\S.*',
           minLength: 1,
           maxLength: 30
         },
@@ -132,6 +138,7 @@ let schema = {
         },
         last: {
           type: 'string',
+          pattern: '^.*\\S.*',
           minLength: 2,
           maxLength: 30
         },

--- a/test/schemas/10-10EZ/schema.spec.js
+++ b/test/schemas/10-10EZ/schema.spec.js
@@ -79,6 +79,17 @@ describe('healthcare-application json schema', () => {
     it('doesnt allow 1 letter last names', () => {
       expect(fullNameValidation({ first: 'foo', last: 'b' })).to.be.false;
     });
+
+    it('doesn\'t allow names with only spaces', () => {
+      expect(fullNameValidation({ first: '   ', last: '  ' })).to.be.false;
+    });
+  });
+
+  describe('address', () => {
+    const addressValidation = definitionValidator('address');
+    it('doesn\'t allow street, cities, or provinces with only spaces', () => {
+      expect(addressValidation({ street: '   ', city: '    ', country: '     ', provinceCode: '     ' })).to.be.false;
+    });
   });
 
   describe('provider', () => {


### PR DESCRIPTION
My regex skills are about 3/10 and there are a lot of ways to do this so LMK if I should use a different pattern.

Tested that this works. I will add error messages when I do the website PR.
![screen shot 2018-05-18 at 09 36 15](https://user-images.githubusercontent.com/4998130/40244236-936ac4ce-5a7f-11e8-8522-c7b7015ea80d.png)


Decided to go the schema validation route for 
- client / server app validation parity 
- using schema validation is the most well supported error pattern for accessibility concerns in the client app

I dug a little into json schema documentation to see if there was an easy way to reuse this pattern but didn't find anything. 