### PR TITLE
Remove directDeposit section from 526 schema and bump version

### DIFF
--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1448,38 +1448,6 @@
         }
       }
     },
-    "directDeposit": {
-      "type": "object",
-      "properties": {
-        "accountType": {
-          "type": "string",
-          "enum": [
-            "CHECKING",
-            "SAVINGS",
-            "NOBANK"
-          ]
-        },
-        "routingNumber": {
-          "type": "string",
-          "pattern": "^\\d{9}$"
-        },
-        "accountNumber": {
-          "type": "string",
-          "pattern": "^\\d{4,17}$"
-        },
-        "bankName": {
-          "type": "string",
-          "maxLength": 35,
-          "pattern": "^([a-zA-Z0-9\\-'.,# ])+$"
-        }
-      },
-      "required": [
-        "accountType",
-        "accountNumber",
-        "bankName",
-        "routingNumber"
-      ]
-    },
     "date": {
       "pattern": "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$",
       "type": "string"
@@ -2311,9 +2279,6 @@
           "default": false
         }
       }
-    },
-    "directDeposit": {
-      "$ref": "#/definitions/directDeposit"
     },
     "serviceInformation": {
       "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.50.0",
+  "version": "3.51.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -1,27 +1,6 @@
 import _ from 'lodash/fp';
 import definitions from '../../common/definitions';
 
-// TODO: Verify why we don't validate accountNumber in common definition
-const uniqueBankFields = {
-  type: 'object',
-  required: ['accountType', 'accountNumber', 'bankName', 'routingNumber'],
-  properties: {
-    accountType: {
-      type: 'string',
-      enum: ['CHECKING', 'SAVINGS', 'NOBANK'] // If NOBANK, no acct/routing num, or bank name.
-    },
-    accountNumber: {
-      type: 'string',
-      pattern: '^\\d{4,17}$'
-    },
-    bankName: {
-      type: 'string',
-      maxLength: 35,
-      pattern: "^([a-zA-Z0-9\\-'.,# ])+$"
-    }
-  }
-};
-
 const disabilitiesBaseDef = {
   type: 'array',
   maxItems: 100,
@@ -115,7 +94,7 @@ const vaTreatmentCenterAddressDef = (({ pciuAddress }) => {
  */
 const privateTreatmentCenterAddressDef = (({ pciuAddress }) => {
   const { type, oneOf, required, properties } = pciuAddress;
-  
+
   return Object.assign({}, {
     type,
     oneOf: oneOf.map((obj) => _.cloneDeep(obj)),
@@ -135,7 +114,6 @@ let schema = {
     address: addressDef,
     vaTreatmentCenterAddress: vaTreatmentCenterAddressDef,
     privateTreatmentCenterAddress: privateTreatmentCenterAddressDef,
-    directDeposit: _.merge(definitions.bankAccount, uniqueBankFields),
     date: definitions.date,
     dateRange: definitions.dateRange,
     dateRangeFromRequired,
@@ -303,9 +281,6 @@ let schema = {
           default: false
         },
       }
-    },
-    directDeposit: {
-      $ref: '#/definitions/directDeposit'
     },
     serviceInformation: {
       type: 'object',


### PR DESCRIPTION
`directDeposit` section in the 526ez form has been removed. Banking information will not be submitted by the front end anymore but, rather, determined via a service call to EVSS ppiu endpoint during form submission.

Issue: https://app.zenhub.com/workspace/o/department-of-veterans-affairs/vets.gov-team/issues/10751