### PR TITLE
change regex to get rid of warning in vets-api

### DIFF
--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -232,22 +232,22 @@
         "addressLine1": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "^([a-zA-Z0-9-'.,&#]([a-zA-Z0-9-'.,&# ])?)+$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "addressLine2": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "^([a-zA-Z0-9-'.,&#]([a-zA-Z0-9-'.,&# ])?)+$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "addressLine3": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "^([a-zA-Z0-9-'.,&#]([a-zA-Z0-9-'.,&# ])?)+$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "city": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "^([a-zA-Z0-9-'.#]([a-zA-Z0-9-'.# ])?)+$"
+          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
         },
         "state": {
           "type": "string",
@@ -617,7 +617,7 @@
         "city": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "^([a-zA-Z0-9-'.#]([a-zA-Z0-9-'.# ])?)+$"
+          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
         },
         "state": {
           "type": "string",
@@ -1213,22 +1213,22 @@
             "addressLine1": {
               "type": "string",
               "maxLength": 35,
-              "pattern": "^([a-zA-Z0-9-'.,&#]([a-zA-Z0-9-'.,&# ])?)+$"
+              "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
             },
             "addressLine2": {
               "type": "string",
               "maxLength": 35,
-              "pattern": "^([a-zA-Z0-9-'.,&#]([a-zA-Z0-9-'.,&# ])?)+$"
+              "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
             },
             "addressLine3": {
               "type": "string",
               "maxLength": 35,
-              "pattern": "^([a-zA-Z0-9-'.,&#]([a-zA-Z0-9-'.,&# ])?)+$"
+              "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
             },
             "city": {
               "type": "string",
               "maxLength": 35,
-              "pattern": "^([a-zA-Z0-9-'.#]([a-zA-Z0-9-'.# ])?)+$"
+              "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
             },
             "state": {
               "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.59.0",
+  "version": "3.60.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -52,22 +52,22 @@ const addressBaseDef = {
     addressLine1: {
       type: 'string',
       maxLength: 35,
-      pattern: "^([a-zA-Z0-9-'.,&#]([a-zA-Z0-9-'.,&# ])?)+$"
+      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
     },
     addressLine2: {
       type: 'string',
       maxLength: 35,
-      pattern: "^([a-zA-Z0-9-'.,&#]([a-zA-Z0-9-'.,&# ])?)+$"
+      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
     },
     addressLine3: {
       type: 'string',
       maxLength: 35,
-      pattern: "^([a-zA-Z0-9-'.,&#]([a-zA-Z0-9-'.,&# ])?)+$"
+      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
     },
     city: {
       type: 'string',
       maxLength: 35,
-      pattern: "^([a-zA-Z0-9-'.#]([a-zA-Z0-9-'.# ])?)+$"
+      pattern: "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
     },
     state: {
       type: 'string',


### PR DESCRIPTION
When running the vet-api test suite, a number of warnings are displayed:
`gems/json-schema-2.7.0/lib/json-schema/attributes/pattern.rb:10: warning: character class has '-' without escape: /^([a-zA-Z0-9-'.,&#]([a-zA-Z0-9-'.,&# ])?)+$/`

altering these regexes fixes it.