### PR TITLE
Update package.json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.60.0",
+  "version": "3.61.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"


### PR DESCRIPTION
Bumping version number to account for the fact that another PR was merged in as 526 changes were getting worked on. The version number was bumped to the same number in both PRs, so the problem wasn't caught on resolving merge conflicts.