### PR TITLE
526 update reserves mg

### DIFF
--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1506,46 +1506,31 @@
         "reservesNationalGuardService": {
           "type": "object",
           "required": [
-            "obligationTermOfServiceDateRange",
             "unitName",
-            "unitPhone"
+            "obligationTermOfServiceDateRange",
+            "waiveVABenefitsToRetainTrainingPay"
           ],
           "properties": {
+            "unitName": {
+              "type": "string",
+              "maxLength": 256,
+              "pattern": "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
+            },
+            "obligationTermOfServiceDateRange": {
+              "$ref": "#/definitions/dateRangeAllRequired"
+            },
+            "waiveVABenefitsToRetainTrainingPay": {
+              "type": "boolean",
+              "default": false
+            },
             "title10Activation": {
               "type": "object",
-              "required": [
-                "title10ActivationDate",
-                "anticipatedSeparationDate"
-              ],
               "properties": {
                 "title10ActivationDate": {
                   "$ref": "#/definitions/date"
                 },
                 "anticipatedSeparationDate": {
                   "$ref": "#/definitions/date"
-                }
-              }
-            },
-            "obligationTermOfServiceDateRange": {
-              "$ref": "#/definitions/dateRangeAllRequired"
-            },
-            "unitName": {
-              "type": "string",
-              "maxLength": 256,
-              "pattern": "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
-            },
-            "unitPhone": {
-              "$ref": "#/definitions/phone"
-            },
-            "inactiveDutyTrainingPay": {
-              "type": "object",
-              "required": [
-                "waiveVABenefitsToRetainTrainingPay"
-              ],
-              "properties": {
-                "waiveVABenefitsToRetainTrainingPay": {
-                  "type": "boolean",
-                  "default": false
                 }
               }
             }

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1520,8 +1520,7 @@
               "$ref": "#/definitions/dateRangeAllRequired"
             },
             "waiveVABenefitsToRetainTrainingPay": {
-              "type": "boolean",
-              "default": false
+              "type": "boolean"
             },
             "title10Activation": {
               "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.65.0",
+  "version": "3.66.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -355,11 +355,25 @@ let schema = {
         },
         reservesNationalGuardService: {
           type: 'object',
-          required: ['obligationTermOfServiceDateRange', 'unitName', 'unitPhone', ],
+          required: ['unitName', 'obligationTermOfServiceDateRange', 'waiveVABenefitsToRetainTrainingPay'],
           properties: {
+            unitName: {
+              type: 'string',
+              maxLength: 256,
+              pattern: "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
+            },
+            obligationTermOfServiceDateRange: {
+              $ref: '#/definitions/dateRangeAllRequired'
+            },
+            waiveVABenefitsToRetainTrainingPay: {
+              // I elect to waive VA benefits for the days I accrued
+              // inactive duty training pay in order to retain my inactive
+              // duty training pay.
+              type: 'boolean',
+              default: false
+            },
             title10Activation: {
               type: 'object',
-              required: ['title10ActivationDate', 'anticipatedSeparationDate'],
               properties: {
                 title10ActivationDate: {
                   $ref: '#/definitions/date'
@@ -367,30 +381,6 @@ let schema = {
                 anticipatedSeparationDate: {
                   $ref: '#/definitions/date'
                 },
-              }
-            },
-            obligationTermOfServiceDateRange: {
-              $ref: '#/definitions/dateRangeAllRequired'
-            },
-            unitName: {
-              type: 'string',
-              maxLength: 256,
-              pattern: "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
-            },
-            unitPhone: {
-              $ref: '#/definitions/phone'
-            },
-            inactiveDutyTrainingPay: {
-              type: 'object',
-              required: ['waiveVABenefitsToRetainTrainingPay'],
-              properties: {
-                waiveVABenefitsToRetainTrainingPay: {
-                  // I elect to waive VA benefits for the days I accrued
-                  // inactive duty training pay in order to retain my inactive
-                  // duty training pay.
-                  type: 'boolean',
-                  default: false
-                }
               }
             }
           }

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -370,7 +370,6 @@ let schema = {
               // inactive duty training pay in order to retain my inactive
               // duty training pay.
               type: 'boolean',
-              default: false
             },
             title10Activation: {
               type: 'object',


### PR DESCRIPTION
Makes some updates to the `reservesNationalGuardService` schema:
- Moves some schema properties around to align with the front end (not strictly necessary...)
- Removes `inactiveDutyTrainingPay` parent for the `waiveVABenefitsToRetainTrainingPay` property, effectively bumping it up a level
- Removes `unitPhone` property
- Updates `required` array, adding `waiveVABenefitsToRetainTrainingPay` and removing `unitPhone` (since this property is getting removed altogether).