### PR TITLE
Remove applicationExpirationDate from requireds

### DIFF
--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -954,7 +954,6 @@
     "veteran",
     "serviceInformation",
     "disabilities",
-    "applicationExpirationDate",
     "standardClaim",
     "claimantCertification"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.76.0",
+  "version": "3.77.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -185,7 +185,6 @@ let schema = {
     'veteran',
     'serviceInformation',
     'disabilities',
-    'applicationExpirationDate',
     'standardClaim',
     'claimantCertification'
   ],


### PR DESCRIPTION
Fixes an issue where applicationExpirationDate is throwing errors in vets-api because it's required but not actually used anywhere.

This PR just removes the item from the required array, there's no further action needed since the corresponding property doesn't actually exist.