### PR TITLE
Remove claimant signature from schema - added post-submit by vets-api

### DIFF
--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -954,8 +954,7 @@
     "veteran",
     "serviceInformation",
     "disabilities",
-    "standardClaim",
-    "claimantCertification"
+    "standardClaim"
   ],
   "properties": {
     "veteran": {
@@ -1685,10 +1684,6 @@
       }
     },
     "standardClaim": {
-      "type": "boolean",
-      "default": false
-    },
-    "claimantCertification": {
       "type": "boolean",
       "default": false
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.77.0",
+  "version": "3.78.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -185,7 +185,7 @@ let schema = {
     'veteran',
     'serviceInformation',
     'disabilities',
-    'standardClaim',
+    'standardClaim'
   ],
   properties: {
     veteran: {

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -186,7 +186,6 @@ let schema = {
     'serviceInformation',
     'disabilities',
     'standardClaim',
-    'claimantCertification'
   ],
   properties: {
     veteran: {
@@ -472,11 +471,6 @@ let schema = {
     standardClaim: {
       // I DO NOT want my claim considered for rapid processing under the FDC
       // program because I plan to submit further evidence in support of my claim
-      type: 'boolean',
-      default: false
-    },
-    claimantCertification: {
-      // VETERAN/SERVICE MEMBER/ALTERNATE SIGNER SIGNATURE
       type: 'boolean',
       default: false
     }


### PR DESCRIPTION
Not much else to add. We found out that claimaint signature gets added in by vets-api. It works this way because a veteran can't physically hit the submit button unless they've checked the affirmation box, which means that we can assume that any submission to vets-api has been affirmed / signed.