### PR TITLE
Delete old properties

### DIFF
--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1516,8 +1516,7 @@
     "serviceInformation": {
       "type": "object",
       "required": [
-        "servicePeriods",
-        "servedInCombatZone"
+        "servicePeriods"
       ],
       "properties": {
         "servicePeriods": {
@@ -1588,10 +1587,6 @@
             }
           }
         },
-        "servedInCombatZone": {
-          "type": "boolean",
-          "default": false
-        },
         "separationLocationName": {
           "type": "string",
           "maxLength": 256,
@@ -1634,8 +1629,7 @@
       "items": {
         "type": "object",
         "required": [
-          "treatmentCenterName",
-          "treatmentCenterType"
+          "treatmentCenterName"
         ],
         "properties": {
           "treatmentCenterName": {
@@ -1648,13 +1642,6 @@
           },
           "treatmentCenterAddress": {
             "$ref": "#/definitions/vaTreatmentCenterAddress"
-          },
-          "treatmentCenterType": {
-            "type": "string",
-            "enum": [
-              "VA_MEDICAL_CENTER",
-              "DOD_MTF"
-            ]
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.78.0",
+  "version": "3.79.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -317,7 +317,7 @@ let schema = {
     },
     serviceInformation: {
       type: 'object',
-      required: ['servicePeriods', 'servedInCombatZone'],
+      required: ['servicePeriods'],
       properties: {
         servicePeriods: {
           type: 'array',
@@ -383,10 +383,6 @@ let schema = {
             }
           }
         },
-        servedInCombatZone: {
-          type: 'boolean',
-          default: false
-        },
         separationLocationName: {
           type: 'string',
           maxLength: 256,
@@ -428,7 +424,7 @@ let schema = {
       maxItems: 100,
       items: {
         type: 'object',
-        required: ['treatmentCenterName', 'treatmentCenterType'],
+        required: ['treatmentCenterName'],
         properties: {
           treatmentCenterName: {
             type: 'string',
@@ -441,10 +437,6 @@ let schema = {
           treatmentCenterAddress: {
             $ref: '#/definitions/vaTreatmentCenterAddress'
           },
-          treatmentCenterType: {
-            type: 'string',
-            enum: ['VA_MEDICAL_CENTER', 'DOD_MTF']
-          }
         }
       }
     },


### PR DESCRIPTION
Removes a couple of old properties so that our form submits without `vets-api` validation errors (which were being thrown because these two old properties happened to be required in the schema).

Tested locally by having vets-api use the new schema and the submission went through.