### PR TITLE
Remove specialIssues from 526 Increase schema

### DIFF
--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -823,9 +823,6 @@
               "REOPEN"
             ]
           },
-          "specialIssues": {
-            "$ref": "#/definitions/specialIssues"
-          },
           "ratedDisabilityId": {
             "type": "string"
           },
@@ -860,9 +857,6 @@
                     "INCREASE",
                     "REOPEN"
                   ]
-                },
-                "specialIssues": {
-                  "$ref": "#/definitions/specialIssues"
                 },
                 "ratedDisabilityId": {
                   "type": "string"
@@ -911,43 +905,6 @@
     "phone": {
       "type": "string",
       "pattern": "^\\d{10}$"
-    },
-    "specialIssues": {
-      "type": "array",
-      "maxItems": 100,
-      "items": {
-        "type": "object",
-        "required": [
-          "code",
-          "name"
-        ],
-        "properties": {
-          "code": {
-            "type": "string",
-            "enum": [
-              "ALS",
-              "AOIV",
-              "AOOV",
-              "ASB",
-              "EHCL",
-              "GW",
-              "HEPC",
-              "MG",
-              "POW",
-              "RDN",
-              "SHAD",
-              "TRM",
-              "38USC1151",
-              "PTSD/1",
-              "PTSD/2",
-              "PTSD/4"
-            ]
-          },
-          "name": {
-            "type": "string"
-          }
-        }
-      }
     }
   },
   "required": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.84.0",
+  "version": "3.85.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -20,9 +20,6 @@ const disabilitiesBaseDef = {
         type: 'string',
         enum: ['NONE', 'NEW', 'SECONDARY', 'INCREASE', 'REOPEN']
       },
-      specialIssues: {
-        $ref: '#/definitions/specialIssues'
-      },
       ratedDisabilityId: {
         type: 'string'
       },
@@ -145,41 +142,7 @@ let schema = {
       }
     }),
     fullName: fullNameDef,
-    phone: definitions.usaPhone,
-    specialIssues: {
-      type: 'array',
-      maxItems: 100,
-      items: {
-        type: 'object',
-        required: ['code', 'name'],
-        properties: {
-          code: {
-            type: 'string',
-            enum: [
-              'ALS',
-              'AOIV',
-              'AOOV',
-              'ASB',
-              'EHCL',
-              'GW',
-              'HEPC',
-              'MG',
-              'POW',
-              'RDN',
-              'SHAD',
-              'TRM',
-              '38USC1151',
-              'PTSD/1',
-              'PTSD/2',
-              'PTSD/4'
-            ]
-          },
-          name: {
-            type: 'string'
-          }
-        }
-      }
-    }
+    phone: definitions.usaPhone
   },
   required: [
     'veteran',


### PR DESCRIPTION
This removes `specialIssues` schema from the 526 Increase form, because it isn't supported by the form submit endpoint.