### PR TITLE
Disallow `0000` for last 4 of SSN

### DIFF
--- a/dist/FEEDBACK-TOOL-schema.json
+++ b/dist/FEEDBACK-TOOL-schema.json
@@ -10,7 +10,7 @@
     },
     "ssnLastFour": {
       "type": "string",
-      "pattern": "^[0-9]{4}$"
+      "pattern": "^(?!0000)[0-9]{4}$"
     },
     "privacyAgreementAccepted": {
       "type": "boolean",

--- a/dist/definitions.json
+++ b/dist/definitions.json
@@ -264,7 +264,7 @@
   },
   "ssnLastFour": {
     "type": "string",
-    "pattern": "^[0-9]{4}$"
+    "pattern": "^(?!0000)[0-9]{4}$"
   },
   "school": {
     "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.91.0",
+  "version": "3.92.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/common/definitions.js
+++ b/src/common/definitions.js
@@ -126,9 +126,11 @@ const ssn = {
   pattern: '^[0-9]{9}$'
 };
 
+// The last four digits (or serial number) must be a number from 0001 to 9999
+// https://www.ssa.gov/history/ssn/geocard.html
 const ssnLastFour = {
   type: 'string',
-  pattern: '^[0-9]{4}$'
+  pattern: '^(?!0000)[0-9]{4}$'
 };
 
 const school = {

--- a/test/schemas/FEEDBACK-TOOL/schema.spec.js
+++ b/test/schemas/FEEDBACK-TOOL/schema.spec.js
@@ -39,6 +39,7 @@ describe('feedback tool schema', () => {
     ],
     invalid: [
       '',
+      '0000',
       '1',
       '12',
       '123',


### PR DESCRIPTION
The validation rules for last four are simpler than I expected so we can do it entirely in the JSON schema definition.