### PR TITLE
13553# 4142 schema updates to fix date range, address definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+/.project

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -926,10 +926,18 @@
                 "type": "string"
               },
               "treatmentDateRange": {
-                "$ref": "#/definitions/dateRange"
+                "type": "array",
+                "properties": {
+                  "from": {
+                    "$ref": "#/definitions/date"
+                  },
+                  "to": {
+                    "$ref": "#/definitions/date"
+                  }
+                }
               },
               "providerFacilityAddress": {
-                "$ref": "#/definitions/address"
+                "$ref": "#/definitions/centralMailAddress"
               }
             }
           }
@@ -938,6 +946,224 @@
           "$ref": "#/definitions/privacyAgreementAccepted"
         }
       }
+    },
+    "centralMailAddress": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "country": {
+              "type": "string",
+              "enum": [
+                "CAN"
+              ]
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "AB",
+                "BC",
+                "MB",
+                "NB",
+                "NF",
+                "NT",
+                "NV",
+                "NU",
+                "ON",
+                "PE",
+                "QC",
+                "SK",
+                "YT"
+              ]
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "country": {
+              "type": "string",
+              "enum": [
+                "MEX"
+              ]
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "aguascalientes",
+                "baja-california-norte",
+                "baja-california-sur",
+                "campeche",
+                "chiapas",
+                "chihuahua",
+                "coahuila",
+                "colima",
+                "distrito-federal",
+                "durango",
+                "guanajuato",
+                "guerrero",
+                "hidalgo",
+                "jalisco",
+                "mexico",
+                "michoacan",
+                "morelos",
+                "nayarit",
+                "nuevo-leon",
+                "oaxaca",
+                "puebla",
+                "queretaro",
+                "quintana-roo",
+                "san-luis-potosi",
+                "sinaloa",
+                "sonora",
+                "tabasco",
+                "tamaulipas",
+                "tlaxcala",
+                "veracruz",
+                "yucatan",
+                "zacatecas"
+              ]
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "country": {
+              "type": "string",
+              "enum": [
+                "USA"
+              ]
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "AL",
+                "AK",
+                "AS",
+                "AZ",
+                "AR",
+                "AA",
+                "AE",
+                "AP",
+                "CA",
+                "CO",
+                "CT",
+                "DE",
+                "DC",
+                "FM",
+                "FL",
+                "GA",
+                "GU",
+                "HI",
+                "ID",
+                "IL",
+                "IN",
+                "IA",
+                "KS",
+                "KY",
+                "LA",
+                "ME",
+                "MH",
+                "MD",
+                "MA",
+                "MI",
+                "MN",
+                "MS",
+                "MO",
+                "MT",
+                "NE",
+                "NV",
+                "NH",
+                "NJ",
+                "NM",
+                "NY",
+                "NC",
+                "ND",
+                "MP",
+                "OH",
+                "OK",
+                "OR",
+                "PW",
+                "PA",
+                "PR",
+                "RI",
+                "SC",
+                "SD",
+                "TN",
+                "TX",
+                "UT",
+                "VT",
+                "VI",
+                "VA",
+                "WA",
+                "WV",
+                "WI",
+                "WY"
+              ]
+            },
+            "postalCode": {
+              "type": "string",
+              "anyOf": [
+                {
+                  "pattern": "^\\d{5}$"
+                },
+                {
+                  "pattern": "^\\d{5}-\\d{4}$"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "properties": {
+            "country": {
+              "not": {
+                "type": "string",
+                "enum": [
+                  "CAN",
+                  "MEX",
+                  "USA"
+                ]
+              }
+            },
+            "state": {
+              "type": "string",
+              "maxLength": 51
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 51
+            }
+          }
+        }
+      ],
+      "properties": {
+        "street": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50
+        },
+        "street2": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50
+        },
+        "city": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 51
+        }
+      },
+      "required": [
+        "postalCode"
+      ]
     }
   },
   "required": [
@@ -1615,7 +1841,7 @@
     },
     "treatments": {
       "type": "array",
-      "minItems": 1,
+      "minItems": 0,
       "maxItems": 100,
       "items": {
         "type": "object",

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1841,7 +1841,6 @@
     },
     "treatments": {
       "type": "array",
-      "minItems": 0,
       "maxItems": 100,
       "items": {
         "type": "object",

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -927,13 +927,8 @@
               },
               "treatmentDateRange": {
                 "type": "array",
-                "properties": {
-                  "from": {
-                    "$ref": "#/definitions/date"
-                  },
-                  "to": {
-                    "$ref": "#/definitions/date"
-                  }
+                "items": {
+                  "$ref": "#/definitions/dateRange"
                 }
               },
               "providerFacilityAddress": {

--- a/dist/definitions.json
+++ b/dist/definitions.json
@@ -1000,13 +1000,8 @@
             },
             "treatmentDateRange": {
               "type": "array",
-              "properties": {
-                "from": {
-                  "$ref": "#/definitions/date"
-                },
-                "to": {
-                  "$ref": "#/definitions/date"
-                }
+              "items": {
+                "$ref": "#/definitions/dateRange"
               }
             },
             "providerFacilityAddress": {

--- a/dist/definitions.json
+++ b/dist/definitions.json
@@ -999,10 +999,18 @@
               "type": "string"
             },
             "treatmentDateRange": {
-              "$ref": "#/definitions/dateRange"
+              "type": "array",
+              "properties": {
+                "from": {
+                  "$ref": "#/definitions/date"
+                },
+                "to": {
+                  "$ref": "#/definitions/date"
+                }
+              }
             },
             "providerFacilityAddress": {
-              "$ref": "#/definitions/address"
+              "$ref": "#/definitions/centralMailAddress"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.94.0",
+  "version": "3.95.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.95.0",
+  "version": "3.96.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/common/definitions.js
+++ b/src/common/definitions.js
@@ -534,13 +534,8 @@ const form4142 = {
           },
           treatmentDateRange: {
             type: 'array',
-            properties: {
-              from: {
-                $ref: '#/definitions/date'
-              },
-              to: {
-                $ref: '#/definitions/date'
-              }
+            items: {
+              $ref: '#/definitions/dateRange'
             }
           },
           providerFacilityAddress: {

--- a/src/common/definitions.js
+++ b/src/common/definitions.js
@@ -533,10 +533,18 @@ const form4142 = {
             type: 'string'
           },
           treatmentDateRange: {
-            $ref: '#/definitions/dateRange'
+            type: 'array',
+            properties: {
+              from: {
+                $ref: '#/definitions/date'
+              },
+              to: {
+                $ref: '#/definitions/date'
+              }
+            }
           },
           providerFacilityAddress: {
-            $ref: '#/definitions/address'
+            $ref: '#/definitions/centralMailAddress'
           }
         }
       }

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -144,6 +144,10 @@ let schema = {
     fullName: fullNameDef,
     phone: definitions.usaPhone,
     form4142: definitions.form4142,
+    // Private Provider Facility Address for forms 4142/4142A 
+    // uses Central Mail Address Schema properties as the
+    // document is submitted to Central Mail (ICMHS)
+    // Refer to definitions.js $ref: '#/definitions/centralMailAddress'
     centralMailAddress: definitions.centralMailAddress
   },
   required: [

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -387,7 +387,6 @@ let schema = {
     },
     treatments: {
       type: 'array',
-      minItems: 0,
       maxItems: 100,
       items: {
         type: 'object',

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -143,7 +143,8 @@ let schema = {
     }),
     fullName: fullNameDef,
     phone: definitions.usaPhone,
-    form4142: definitions.form4142
+    form4142: definitions.form4142,
+    centralMailAddress: definitions.centralMailAddress
   },
   required: [
     'veteran',
@@ -386,7 +387,7 @@ let schema = {
     },
     treatments: {
       type: 'array',
-      minItems: 1,
+      minItems: 0,
       maxItems: 100,
       items: {
         type: 'object',


### PR DESCRIPTION
Updates for 4142 form properties

1) Form 4142 property "treatmentDateRange" to be of type array
2) Form 526EZ property "treatments" to have minimum item as 0, to fix the schema validation error for empty "treatments"=>[]
3) For the 4142 property "providerFacilityAddress", use "centralMailAddress" definition to use the correct address properties and avoid conflict with 526 schema definition of "address"