### PR TITLE
Remove minItems property from treatments schema

### DIFF
--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1615,7 +1615,6 @@
     },
     "treatments": {
       "type": "array",
-      "minItems": 1,
       "maxItems": 100,
       "items": {
         "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.94.0",
+  "version": "3.95.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -386,7 +386,6 @@ let schema = {
     },
     treatments: {
       type: 'array',
-      minItems: 1,
       maxItems: 100,
       items: {
         type: 'object',


### PR DESCRIPTION
Remove `minItems` property from the treatments schema because the front end can submit an empty array value for this property. Currently, doing so causes a schema validation error on the vets-api side.

Will need a corresponding version bump on vets-website.