### PR TITLE
Re-add minItems property

### DIFF
--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1836,6 +1836,7 @@
     },
     "treatments": {
       "type": "array",
+      "minItems": 1,
       "maxItems": 100,
       "items": {
         "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.96.0",
+  "version": "3.97.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -391,6 +391,7 @@ let schema = {
     },
     treatments: {
       type: 'array',
+      minItems: 1,
       maxItems: 100,
       items: {
         type: 'object',


### PR DESCRIPTION
Restores the minItems property for the 526 form.
This issue should be handled in vets-website by modifying the presubmit transformer, as this schema is correct.