### PR TITLE
686: change references to 'claimant' to 'veteran'

### DIFF
--- a/dist/21-686C-schema.json
+++ b/dist/21-686C-schema.json
@@ -106,7 +106,7 @@
     }
   },
   "properties": {
-    "claimantAddress": {
+    "veteranAddress": {
       "type": "object",
       "oneOf": [
         {
@@ -896,7 +896,7 @@
         }
       ]
     },
-    "claimantEmail": {
+    "veteranEmail": {
       "type": "string",
       "format": "email"
     },
@@ -2947,9 +2947,6 @@
     "privacyAgreementAccepted": {
       "$ref": "#/definitions/privacyAgreementAccepted"
     },
-    "claimantFullName": {
-      "$ref": "#/definitions/fullName"
-    },
     "veteranFullName": {
       "$ref": "#/definitions/fullName"
     },
@@ -2960,9 +2957,6 @@
       "$ref": "#/definitions/usaPhone"
     },
     "veteranSocialSecurityNumber": {
-      "$ref": "#/definitions/ssn"
-    },
-    "claimantSocialSecurityNumber": {
       "$ref": "#/definitions/ssn"
     },
     "spouseSocialSecurityNumber": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.100.0",
+  "version": "3.101.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-686C/schema.js
+++ b/src/schemas/21-686C/schema.js
@@ -409,11 +409,11 @@ let schema = {
   additionalProperties: false,
   definitions,
   properties: {
-    claimantAddress: {
+    veteranAddress: {
       type: 'object',
       oneOf: addressDefs
     },
-    claimantEmail: {
+    veteranEmail: {
       type: 'string',
       format: 'email'
     },
@@ -534,12 +534,10 @@ let schema = {
 
 [
   ['privacyAgreementAccepted'],
-  ['fullName', 'claimantFullName'],
   ['fullName', 'veteranFullName'],
   ['usaPhone', 'dayPhone'],
   ['usaPhone', 'nightPhone'],
   ['ssn', 'veteranSocialSecurityNumber'],
-  ['ssn', 'claimantSocialSecurityNumber'],
   ['ssn', 'spouseSocialSecurityNumber'],
   ['vaFileNumber'],
   ['vaFileNumber', 'spouseVaFileNumber'],

--- a/test/schemas/21-686C/schema.spec.js
+++ b/test/schemas/21-686C/schema.spec.js
@@ -17,10 +17,10 @@ describe('21-686C schema', () => {
     expect(schema.required).to.deep.equal(['privacyAgreementAccepted']);
   });
 
-  sharedTests.runTest('fullName', ['veteranFullName', 'claimantFullName']);
-  sharedTests.runTest('ssn', ['veteranSocialSecurityNumber', 'claimantSocialSecurityNumber', 'spouseSocialSecurityNumber']);
+  sharedTests.runTest('fullName', ['veteranFullName']);
+  sharedTests.runTest('ssn', ['veteranSocialSecurityNumber', 'spouseSocialSecurityNumber']);
   sharedTests.runTest('vaFileNumber', ['vaFileNumber', 'spouseVaFileNumber']);
-  sharedTests.runTest('email', ['claimantEmail']);
+  sharedTests.runTest('email', ['veteranEmail']);
   sharedTests.runTest('maritalStatus');
   sharedTests.runTest('date', ['spouseDateOfBirth']);
   sharedTests.runTest('marriages', ['marriages', 'spouseMarriages']);
@@ -85,7 +85,7 @@ describe('21-686C schema', () => {
     ]
   });
 
-  schemaTestHelper.testValidAndInvalid('claimantAddress', {
+  schemaTestHelper.testValidAndInvalid('veteranAddress', {
     valid: [
       {
         addressType: 'DOMESTIC',


### PR DESCRIPTION
Since `claimant` and `veteran` are the same now, removing references to `claimant`