### PR TITLE
fix postal code regex

### DIFF
--- a/dist/21-686C-schema.json
+++ b/dist/21-686C-schema.json
@@ -828,7 +828,7 @@
     "postalCode": {
       "type": "string",
       "maxLength": 10,
-      "pattern": "(^\\d{5}(?:[-]\\d{4})?$)?"
+      "pattern": "^\\d{5}(?:[- ]?\\d{4})?$"
     },
     "location": {
       "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.102.0",
+  "version": "3.103.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-686C/schema.js
+++ b/src/schemas/21-686C/schema.js
@@ -106,7 +106,7 @@ let schema = {
           addressType: {
             type: 'string',
             'enum': ['DOMESTIC'],
-            default: 'DOMESTIC'  
+            default: 'DOMESTIC'
           },
           state: {
             type: 'string',
@@ -129,11 +129,11 @@ let schema = {
         type: 'object',
         required: [...commonAddressFields.required, 'postOffice', 'postalType', 'postalCode'],
         properties: {
-          ...commonAddressFields.properties, 
+          ...commonAddressFields.properties,
           addressType: {
             type: 'string',
             enum: ['MILITARY'],
-            default: 'MILITARY'  
+            default: 'MILITARY'
           },
           postOffice: {
             type: 'string',
@@ -147,7 +147,6 @@ let schema = {
               'Diplomatic Post Office',
               'Fleet Post Office'
             ]
-            
           },
           postalType: {
             type: 'string',
@@ -212,7 +211,7 @@ let schema = {
       postalCode: {
         type: 'string',
         maxLength: 10,
-        pattern: '(^\\d{5}(?:[-]\\d{4})?$)?'
+        pattern: '^\\d{5}(?:[- ]?\\d{4})?$'
       },
       location: {
         type: 'object',


### PR DESCRIPTION
previous regex wasn't working at all. Fixed it and made it accept either a dash or a space as an option divider between the first 5 and last 4.