### PR TITLE
Add Form 8940 to definitions and 21-526EZ schema.

### DIFF
--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1888,6 +1888,9 @@
     },
     "form4142": {
       "$ref": "#/definitions/form4142"
+    },
+    "form8940": {
+      "$ref": "#/definitions/form8940"
     }
   }
 }

--- a/dist/definitions.json
+++ b/dist/definitions.json
@@ -1014,5 +1014,169 @@
         "$ref": "#/definitions/privacyAgreementAccepted"
       }
     }
+  },
+  "form8940": {
+    "type": "object",
+    "unemployability": {
+      "type": "object",
+      "properties": {
+        "disabilityPreventingEmployment": {
+          "type": "string"
+        },
+        "underDoctorHopitalCarePast12M": {
+          "type": "boolean"
+        },
+        "doctorProvidedCare": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "name": {
+              "type": "string"
+            },
+            "address": {
+              "$ref": "#/definitions/address"
+            },
+            "dates": {
+              "$ref": "#/definitions/dateRange"
+            }
+          }
+        },
+        "hospitalProvidedCare": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "name": {
+              "type": "string"
+            },
+            "address": {
+              "$ref": "#/definitions/address"
+            },
+            "dates": {
+              "$ref": "#/definitions/dateRange"
+            }
+          }
+        },
+        "disabilityAffectedEmploymentFullTimeDate": {
+          "$ref": "#/definitions/date"
+        },
+        "lastWoredFullTimeDate": {
+          "$ref": "#/definitions/date"
+        },
+        "becameTooDisabledToWorkDate": {
+          "$ref": "#/definitions/date"
+        },
+        "mostEarningsInAYear": {
+          "type": "string"
+        },
+        "yearOfMostEarnings": {
+          "type": "string"
+        },
+        "occupationDuringMostEarnings": {
+          "type": "string"
+        },
+        "previousEmployers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "name": {
+              "type": "string"
+            },
+            "address": {
+              "$ref": "#/definitions/address"
+            },
+            "workType": {
+              "type": "string"
+            },
+            "hoursPerWeek": {
+              "type": "string"
+            },
+            "dates": {
+              "$ref": "#/definitions/dateRange"
+            },
+            "timeLostFromIllness": {
+              "type": "string"
+            },
+            "mostEarningsInAMonth": {
+              "type": "string"
+            }
+          }
+        },
+        "disabilityPreventMilitaryDuties": {
+          "type": "boolean"
+        },
+        "past12MonthsEarnedIncome": {
+          "type": "string"
+        },
+        "currentMonthlyEarnedIncome": {
+          "type": "string"
+        },
+        "leftLastJobDueToDisability": {
+          "type": "boolean"
+        },
+        "receiveExpectDisabilityRetirement": {
+          "type": "boolean"
+        },
+        "receiveExpectWorkersCompensation": {
+          "type": "boolean"
+        },
+        "attemptedToObtainEmploymentSinceUnemployability": {
+          "type": "boolean"
+        },
+        "appliedEmployers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "name": {
+              "type": "string"
+            },
+            "address": {
+              "$ref": "#/definitions/address"
+            },
+            "workType": {
+              "type": "string"
+            },
+            "date": {
+              "$ref": "#/definitions/date"
+            }
+          }
+        },
+        "education": {
+          "type": "string"
+        },
+        "receivedOtherEducationTrainingPreUnemployability": {
+          "type": "boolean"
+        },
+        "otherEducationTrainingPreUnemployability": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "name": {
+              "type": "string"
+            },
+            "dates": {
+              "$ref": "#/definitions/dateRange"
+            }
+          }
+        },
+        "receivedOtherEducationTrainingPostUnemployability": {
+          "type": "boolean"
+        },
+        "otherEducationTrainingPostUnemployability": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "name": {
+              "type": "string"
+            },
+            "dates": {
+              "$ref": "#/definitions/dateRange"
+            }
+          }
+        },
+        "remarks": {
+          "type": "string"
+        }
+      }
+    }
   }
 }

--- a/src/common/definitions.js
+++ b/src/common/definitions.js
@@ -550,6 +550,170 @@ const form4142 = {
   }
 };
 
+const form8940 = {
+  type: 'object',
+  unemployability: {
+    type: 'object',
+    properties: {
+      disabilityPreventingEmployment: {
+        type: 'string'
+      },
+      underDoctorHopitalCarePast12M: {
+        type: 'boolean'
+      },
+      doctorProvidedCare: {
+        type: 'array',
+        items: {
+          type: 'object',
+          name: {
+            type: 'string'
+          },
+          address: {
+            $ref: '#/definitions/address'
+          },
+          dates: {
+            $ref: '#/definitions/dateRange'
+          }
+        }
+      },
+      hospitalProvidedCare: {
+        type: 'array',
+        items: {
+          type: 'object',
+          name: {
+            type: 'string'
+          },
+          address: {
+            $ref: '#/definitions/address'
+          },
+          dates: {
+            $ref: '#/definitions/dateRange'
+          }
+        }
+      },
+      disabilityAffectedEmploymentFullTimeDate: {
+        $ref: '#/definitions/date'
+      },
+      lastWoredFullTimeDate: {
+        $ref: '#/definitions/date'
+      },
+      becameTooDisabledToWorkDate: {
+        $ref: '#/definitions/date'
+      },
+      mostEarningsInAYear: {
+        type: 'string'
+      },
+      yearOfMostEarnings: {
+        type: 'string'
+      },
+      occupationDuringMostEarnings: {
+        type: 'string'
+      },
+      previousEmployers: {
+        type: 'array',
+        items: {
+          type: 'object',
+          name: {
+            type: 'string'
+          },
+          address: {
+            $ref: '#/definitions/address'
+          },
+          workType: {
+            type: 'string'
+          },
+          hoursPerWeek: {
+            type: 'string'
+          },
+          dates: {
+            $ref: '#/definitions/dateRange'
+          },
+          timeLostFromIllness: {
+            type: 'string'
+          },
+          mostEarningsInAMonth: {
+            type: 'string'
+          },
+        }
+      },
+      disabilityPreventMilitaryDuties: {
+        type: 'boolean'
+      },
+      past12MonthsEarnedIncome: {
+        type: 'string'
+      },
+      currentMonthlyEarnedIncome: {
+        type: 'string'
+      },
+      leftLastJobDueToDisability: {
+        type: 'boolean'
+      },
+      receiveExpectDisabilityRetirement: {
+        type: 'boolean'
+      },
+      receiveExpectWorkersCompensation: {
+        type: 'boolean'
+      },
+      attemptedToObtainEmploymentSinceUnemployability: {
+        type: 'boolean'
+      },
+      appliedEmployers: {
+        type: 'array',
+        items: {
+          type: 'object',
+          name: {
+            type: 'string'
+          },
+          address: {
+            $ref: '#/definitions/address'
+          },
+          workType: {
+            type: 'string'
+          },
+          date: {
+            $ref: '#/definitions/date'
+          },
+        }
+      },
+      education: {
+        type: 'string'
+      },
+      receivedOtherEducationTrainingPreUnemployability: {
+        type: 'boolean'
+      },
+      otherEducationTrainingPreUnemployability: {
+        type: 'array',
+        items: {
+          type: 'object',
+          name: {
+            type: 'string'
+          },
+          dates: {
+            $ref: '#/definitions/dateRange'
+          },
+        }
+      },
+      receivedOtherEducationTrainingPostUnemployability: {
+        type: 'boolean'
+      },
+      otherEducationTrainingPostUnemployability: {
+        type: 'array',
+        items: {
+          type: 'object',
+          name: {
+            type: 'string'
+          },
+          dates: {
+            $ref: '#/definitions/dateRange'
+          },
+        }
+      },
+      remarks: {
+        type: 'string'
+      }
+    }
+  }
+};
 
 export default {
   usaPhone,
@@ -590,5 +754,6 @@ export default {
   usaPostalCode,
   centralMailAddress,
   year,
-  form4142
+  form4142,
+  form8940
 };

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -144,7 +144,7 @@ let schema = {
     fullName: fullNameDef,
     phone: definitions.usaPhone,
     form4142: definitions.form4142,
-    // Private Provider Facility Address for forms 4142/4142A 
+    // Private Provider Facility Address for forms 4142/4142A
     // uses Central Mail Address Schema properties as the
     // document is submitted to Central Mail (ICMHS)
     // Refer to definitions.js $ref: '#/definitions/centralMailAddress'
@@ -439,6 +439,9 @@ let schema = {
     },
     form4142: {
       $ref: '#/definitions/form4142'
+    },
+    form8940: {
+      $ref: '#/definitions/form8940'
     }
   },
 };


### PR DESCRIPTION
Form 8940: Schema creation#14081

As a developer on Claims Modernization, I need for the form 8940 schema to be created.

Supporting Artifact

    https://www.vba.va.gov/pubs/forms/vba-21-8940-are.pdf

Assumptions

    The 8940 schema will be integrated with the 526 All claims schema in the same way the 4142 schema is incorporated with the 526 Claims for increase schema.
    This story is related to #12701 (for reference only)
    The schema is only needed for 8940; not for 4192 since 4192 will only be downloaded/uploaded

Acceptance Criteria

    Schema is available in repo and the unit tests have run successfully
    Schema contains the appropriate data elements
    Unit tests are developed and runs successfully