### PR TITLE
686 schema minor tweaks

### DIFF
--- a/dist/21-686C-schema.json
+++ b/dist/21-686C-schema.json
@@ -23,16 +23,6 @@
           "minLength": 1,
           "maxLength": 30,
           "pattern": "^(?!\\s)(?!.*?\\s{2,})[^<>%$#@!^&*0-9]+$"
-        },
-        "suffix": {
-          "type": "string",
-          "enum": [
-            "Jr.",
-            "Sr.",
-            "II",
-            "III",
-            "IV"
-          ]
         }
       },
       "required": [
@@ -54,7 +44,7 @@
         "addressType",
         "street",
         "city",
-        "country",
+        "countryDropdown",
         "state",
         "postalCode"
       ],
@@ -87,7 +77,7 @@
           "maxLength": 30,
           "pattern": "^(?!\\s)(?!.*?\\s{2,})[^<>%$#@!^&*0-9]+$"
         },
-        "country": {
+        "countryDropdown": {
           "type": "string",
           "maxLength": 50,
           "default": "USA"
@@ -238,7 +228,7 @@
         "addressType",
         "street",
         "city",
-        "country",
+        "countryDropdown",
         "postOffice",
         "postalType",
         "postalCode"
@@ -272,7 +262,7 @@
           "maxLength": 30,
           "pattern": "^(?!\\s)(?!.*?\\s{2,})[^<>%$#@!^&*0-9]+$"
         },
-        "country": {
+        "countryDropdown": {
           "type": "string",
           "maxLength": 50,
           "enum": [
@@ -529,7 +519,7 @@
         "addressType",
         "street",
         "city",
-        "country"
+        "countryDropdown"
       ],
       "properties": {
         "addressType": {
@@ -560,7 +550,7 @@
           "maxLength": 30,
           "pattern": "^(?!\\s)(?!.*?\\s{2,})[^<>%$#@!^&*0-9]+$"
         },
-        "country": {
+        "countryDropdown": {
           "type": "string",
           "enum": [
             "Afghanistan",
@@ -785,7 +775,7 @@
         "addressType",
         "street",
         "city",
-        "country",
+        "countryDropdown",
         "countryText"
       ],
       "properties": {
@@ -817,7 +807,7 @@
           "maxLength": 30,
           "pattern": "^(?!\\s)(?!.*?\\s{2,})[^<>%$#@!^&*0-9]+$"
         },
-        "country": {
+        "countryDropdown": {
           "type": "string",
           "enum": [
             "Country Not In List"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.110.0",
+  "version": "3.111.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-686C/schema.js
+++ b/src/schemas/21-686C/schema.js
@@ -21,15 +21,16 @@ const textAndNumbersRegex = '^(?!\\s)(?!.*?\\s{2,})[^<>%$#@!^&*]+$';
 let definitions = _.cloneDeep(originalDefinitions);
 definitions =  _.pick(definitions, 'fullName', 'date', 'ssn');
 
-definitions.fullName.properties.first.pattern = textRegex
-definitions.fullName.properties.last.pattern = textRegex
-definitions.fullName.properties.middle.pattern = textRegex
-definitions.fullName.properties.first.maxLength = 30
-definitions.fullName.properties.last.maxLength = 30
-definitions.fullName.properties.middle.maxLength = 20
+definitions.fullName.properties.first.pattern = textRegex;
+definitions.fullName.properties.last.pattern = textRegex;
+definitions.fullName.properties.middle.pattern = textRegex;
+definitions.fullName.properties.first.maxLength = 30;
+definitions.fullName.properties.last.maxLength = 30;
+definitions.fullName.properties.middle.maxLength = 20;
+delete definitions.fullName.properties.suffix;
 
 const commonAddressFields = {
-  required: ['addressType', 'street', 'city', 'country'],
+  required: ['addressType', 'street', 'city', 'countryDropdown'],
   properties: {
     addressType: {
       type: 'string',
@@ -65,7 +66,7 @@ const commonAddressFields = {
       maxLength: 30,
       pattern: textRegex
     },
-    country: {
+    countryDropdown: {
       type: 'string',
       maxLength: 50,
       'enum': [countryUSA, countryNotInList].concat(nonUSACountries)
@@ -117,7 +118,7 @@ let schema = {
           postalCode: {
             $ref: '#/definitions/postalCode'
           },
-          country: {
+          countryDropdown: {
             type: 'string',
             maxLength: 50,
             default: countryUSA
@@ -177,7 +178,7 @@ let schema = {
             enum: ['INTERNATIONAL'],
             default: 'INTERNATIONAL'
           },
-          country: {
+          countryDropdown: {
             type: 'string',
             'enum': nonUSACountries
           }
@@ -194,7 +195,7 @@ let schema = {
             enum: ['INTERNATIONAL'],
             default: 'INTERNATIONAL'
           },
-          country: {
+          countryDropdown: {
             type: 'string',
             'enum': [countryNotInList],
             default: countryNotInList

--- a/test/schemas/21-686C/schema.spec.js
+++ b/test/schemas/21-686C/schema.spec.js
@@ -39,9 +39,15 @@ describe('21-686C schema', () => {
     marriedDate: fixtures.date,
     previouslyMarried: true,
     childInHousehold: true,
-    childAddress: Object.assign(fixtures.address, {addressType: 'DOMESTIC', state: 'TX', postalCode: '344546767'}),
-    childHasNoSsn: true,
-    childHasNoSsnReason: 'NONRESIDENTALIEN',
+    childAddress: {
+      street: '123 a rd',
+      city: 'abc',
+      countryDropdown: 'USA',
+      addressType: 'DOMESTIC',
+      state: 'TX',
+      postalCode: '344546767'
+    },
+    childHasNoSsn: false,
     personWhoLivesWithChild: fixtures.fullName
   }
 
@@ -200,7 +206,7 @@ describe('21-686C schema', () => {
     invalid: [
       [{ fullName: 1 }],
       [_.omit(validDependent, 'marriedDate')],
-      [_.omit(validDependent, 'childHasNoSsnReason')],
+      [Object.assign({}, _.omit(validDependent, 'childHasNoSsnReason'), {childHasNoSsn: true})],
       [Object.assign({}, validDependent, {
         childPlaceOfBirth: {
           countryDropdown: 'Canada',
@@ -223,7 +229,7 @@ describe('21-686C schema', () => {
         addressType: 'DOMESTIC',
         street: '123 main st.',
         city: 'anywhere',
-        country: 'USA',
+        countryDropdown: 'USA',
         state: 'KY',
         postalCode: '55555'
       },
@@ -231,7 +237,7 @@ describe('21-686C schema', () => {
         addressType: 'MILITARY',
         street: '123 main st.',
         city: 'anywhere',
-        country: 'USA',
+        countryDropdown: 'USA',
         postOffice: 'APO',
         postalType: 'AA',
         postalCode: '55555'
@@ -240,13 +246,13 @@ describe('21-686C schema', () => {
         addressType: 'INTERNATIONAL',
         street: '123 main st.',
         city: 'anywhere',
-        country: 'Canada',
+        countryDropdown: 'Canada',
       },
       {
         addressType: 'INTERNATIONAL',
         street: '123 main st.',
         city: 'anywhere',
-        country: 'Country Not In List',
+        countryDropdown: 'Country Not In List',
         countryText: 'Independent Nation of Myself'
       },
     ],
@@ -256,7 +262,7 @@ describe('21-686C schema', () => {
         addressType: 'INTERNATIONAL',
         street: '123 main st.',
         city: 'anywhere',
-        country: 'USA',
+        countryDropdown: 'USA',
       },
 
       // INTERNATIONAL (Country Not In List) with state and postalCode
@@ -264,7 +270,7 @@ describe('21-686C schema', () => {
         addressType: 'INTERNATIONAL',
         street: '123 main st.',
         city: 'anywhere',
-        country: 'Country Not In List',
+        countryDropdown: 'Country Not In List',
         state: 'KY',
         postalCode: '55555'
       },
@@ -275,7 +281,7 @@ describe('21-686C schema', () => {
         street: '123 main st.',
         city: 'anywhere',
         state: 'KY',
-        country: 'Bangladesh'
+        countryDropdown: 'Bangladesh'
       },
 
       // INTERNATIONAL with selected country (allowed) and countryText (not allowed)
@@ -283,7 +289,7 @@ describe('21-686C schema', () => {
         addressType: 'INTERNATIONAL',
         street: '123 main st.',
         city: 'anywhere',
-        country: 'Canada',
+        countryDropdown: 'Canada',
         countryText: 'Independent Nation of Myself'
       },
 
@@ -292,7 +298,7 @@ describe('21-686C schema', () => {
         addressType: 'DOMESTIC',
         street: '123 main st.',
         city: 'any  where',
-        country: 'USA',
+        countryDropdown: 'USA',
         state: 'KY',
         postalCode: '55555'
       }


### PR DESCRIPTION
Remove `suffix` from names.
rename `country` to `countryDropdown` in addresses to match it's naming in `location` object