### PR TITLE
Upcase dir names in ruby lib

### DIFF
--- a/lib/vets_json_schema.rb
+++ b/lib/vets_json_schema.rb
@@ -8,7 +8,7 @@ module VetsJsonSchema
     return_val = {}
 
     ScriptUtils.directories("#{base_dir}src/schemas").each do |schema|
-      schema = File.basename(schema)
+      schema = File.basename(schema).upcase
       return_val[schema] = MultiJson.load(File.read("#{base_dir}dist/#{schema}-schema.json"))
     end
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.111.0",
+  "version": "3.112.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"


### PR DESCRIPTION
There was an error while trying to load the gem 'vets_json_schema'. (Bundler::GemRequireError)
Gem Load Error is: No such file or directory @ rb_sysopen - /home/lihan/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/vets-json-schema-d5794dc6370c/lib/../dist/21-526EZ-allclaims-schema.json
