### PR TITLE
change 21-526EZ and 21-526EZ-allclaims regex to eliminate warnings in vets-api

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -948,19 +948,19 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^([a-zA-Z0-9-/']+( ?))+$"
+            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
           },
           "middle": {
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^([a-zA-Z0-9-/']+( ?))+$"
+            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
           },
           "last": {
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^([a-zA-Z0-9-/']+( ?))+$"
+            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
           }
         }
       }
@@ -1575,7 +1575,7 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 100,
-          "pattern": "([a-zA-Z0-9-/']+( ?))*$"
+          "pattern": "([-a-zA-Z0-9/']+( ?))*$"
         },
         "phoneNumber": {
           "$ref": "#/definitions/phone"

--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1595,7 +1595,7 @@
                   "type": "string",
                   "minLength": 1,
                   "maxLength": 100,
-                  "pattern": "([a-zA-Z0-9-/']+( ?))*$"
+                  "pattern": "([-a-zA-Z0-9/']+( ?))*$"
                 },
                 "primaryPhone": {
                   "$ref": "#/definitions/phone"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.111.0",
+  "version": "3.112.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.112.0",
+  "version": "3.113.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -162,19 +162,19 @@ const schema = {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^([a-zA-Z0-9-/']+( ?))+$"
+            pattern: "^([-a-zA-Z0-9/']+( ?))+$"
           },
           middle: {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^([a-zA-Z0-9-/']+( ?))+$"
+            pattern: "^([-a-zA-Z0-9/']+( ?))+$"
           },
           last: {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^([a-zA-Z0-9-/']+( ?))+$"
+            pattern: "^([-a-zA-Z0-9/']+( ?))+$"
           }
         }
       }
@@ -387,7 +387,7 @@ const schema = {
           type: 'string',
           minLength: 1,
           maxLength: 100,
-          pattern: "([a-zA-Z0-9-/']+( ?))*$"
+          pattern: "([-a-zA-Z0-9/']+( ?))*$"
         },
         phoneNumber: {
           $ref: '#/definitions/phone'

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -225,7 +225,7 @@ let schema = {
                   type: 'string',
                   minLength: 1,
                   maxLength: 100,
-                  pattern: "([a-zA-Z0-9-/']+( ?))*$"
+                  pattern: "([-a-zA-Z0-9/']+( ?))*$"
                 },
                 primaryPhone: {
                   $ref: '#/definitions/phone'


### PR DESCRIPTION
These regex as written cause the vets-api to throw warnings when running specs.
Rewriting them this way eliminates the warnings.
<img width="1385" alt="screen shot 2018-11-08 at 11 28 19 am" src="https://user-images.githubusercontent.com/733873/48213341-949a6980-e34b-11e8-9d2b-cc960eff794a.png">
