### PR TITLE
Add treatedDisabilityNames

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -1589,7 +1589,8 @@
       "items": {
         "type": "object",
         "required": [
-          "treatmentCenterName"
+          "treatmentCenterName",
+          "treatedDisabilityNames"
         ],
         "properties": {
           "treatmentCenterName": {
@@ -1602,6 +1603,14 @@
           },
           "treatmentCenterAddress": {
             "$ref": "#/definitions/vaTreatmentCenterAddress"
+          },
+          "treatedDisabilityNames": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 100,
+            "items": {
+              "type": "string"
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.113.0",
+  "version": "3.114.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -400,7 +400,7 @@ const schema = {
       maxItems: 100,
       items: {
         type: 'object',
-        required: ['treatmentCenterName'],
+        required: ['treatmentCenterName', 'treatedDisabilityNames'],
         properties: {
           treatmentCenterName: {
             type: 'string',
@@ -412,6 +412,14 @@ const schema = {
           },
           treatmentCenterAddress: {
             $ref: '#/definitions/vaTreatmentCenterAddress'
+          },
+          treatedDisabilityNames: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 100,
+            items: {
+              type: 'string'
+            }
           }
         }
       }


### PR DESCRIPTION
Added a `treatedDisabilityNames` array to `vaTreatmentFacilities` items. On the front end, we call this `relatedDisabilities`, but EVSS' swagger calls it `treatedDisabilityNames`, which actually makes more sense, so I'm sticking with that one. We can change it on the front end.