### PR TITLE
Revise 686 schema to make it compatible with the FE

### DIFF
--- a/dist/21-686C-schema.json
+++ b/dist/21-686C-schema.json
@@ -1213,6 +1213,65 @@
         }
       ]
     },
+    "marriages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "dateOfMarriage",
+          "locationOfMarriage",
+          "spouseFullName"
+        ],
+        "properties": {
+          "dateOfMarriage": {
+            "$ref": "#/definitions/date"
+          },
+          "locationOfMarriage": {
+            "$ref": "#/definitions/location"
+          },
+          "spouseFullName": {
+            "$ref": "#/definitions/fullName"
+          },
+          "dateOfSeparation": {
+            "$ref": "#/definitions/date"
+          },
+          "locationOfSeparation": {
+            "$ref": "#/definitions/location"
+          }
+        },
+        "oneOf": [
+          {
+            "properties": {
+              "reasonForSeparation": {
+                "type": "string",
+                "enum": [
+                  "Death",
+                  "Divorce"
+                ]
+              }
+            }
+          },
+          {
+            "required": [
+              "explainSeparation"
+            ],
+            "properties": {
+              "reasonForSeparation": {
+                "type": "string",
+                "enum": [
+                  "Other"
+                ]
+              },
+              "explainSeparation": {
+                "type": "string",
+                "maxLength": 500,
+                "pattern": "^(?!\\s)(?!.*?\\s{2,})[^<>%$#@!^&*]+$"
+              }
+            }
+          }
+        ]
+      }
+    },
     "previousMarriages": {
       "type": "array",
       "items": {
@@ -1349,9 +1408,6 @@
         "spouseFullName": {
           "$ref": "#/definitions/fullName"
         },
-        "spouseMarriages": {
-          "$ref": "#/definitions/previousMarriages"
-        },
         "spouseAddress": {
           "type": "object",
           "anyOf": [
@@ -1425,8 +1481,11 @@
         }
       ]
     },
-    "previousMarriages": {
+    "spouseMarriages": {
       "$ref": "#/definitions/previousMarriages"
+    },
+    "marriages": {
+      "$ref": "#/definitions/marriages"
     },
     "dependents": {
       "type": "array",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.115.0",
+  "version": "3.116.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/test/schemas/21-686C/schema.spec.js
+++ b/test/schemas/21-686C/schema.spec.js
@@ -116,8 +116,8 @@ describe('21-686C schema', () => {
     valid: ['MARRIED', 'DIVORCED', 'WIDOWED', 'SEPARATED', 'NEVERMARRIED'],
     invalid: ['Divorce']
   });
-  
-  schemaTestHelper.testValidAndInvalid('previousMarriages', {
+
+  schemaTestHelper.testValidAndInvalid('marriages', {
     valid: [
       [
         {


### PR DESCRIPTION
Limitations with the form system required

- rename `previousMarriages` to `marriages`
- move `spouseMarriages` from the `currentMarriage` object to the root
of the schema
- add post-submission translation notes to convert data from a
FE-friendly format to the format required by the final backend system