### PR TITLE
Update alternate names schema, switch to ui:required

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -1499,13 +1499,10 @@
   "properties": {
     "alternateNames": {
       "type": "array",
+      "minItems": 1,
       "maxItems": 100,
       "items": {
         "type": "object",
-        "required": [
-          "first",
-          "last"
-        ],
         "properties": {
           "first": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.118.0",
+  "version": "3.119.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -215,10 +215,10 @@ const schema = {
   properties: {
     alternateNames: {
       type: 'array',
+      minItems: 1,
       maxItems: 100,
       items: {
         type: 'object',
-        required: ['first', 'last'],
         properties: {
           first: {
             type: 'string',


### PR DESCRIPTION
Removes `required` properties; we need to use `ui:required` on the front end in the uiSchema instead. Otherwise clicking yes, then no, then continuing will throw a silent validation error and the form won't advance.