### PR TITLE
All Claims - 781 - Changed PTSD incident source name type

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -2583,7 +2583,7 @@
                   "type": "object",
                   "properties": {
                     "name": {
-                      "$ref": "#/definitions/fullName"
+                      "type": "string"
                     },
                     "address": {
                       "$ref": "#/definitions/address"

--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -2573,6 +2573,9 @@
                     },
                     "unitAssigned": {
                       "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
                     }
                   }
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.121.0",
+  "version": "3.122.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -669,6 +669,9 @@ const schema = {
                     },
                     unitAssigned: {
                       type: 'string'
+                    },
+                    description: {
+                      type: 'string'
                     }
                   }
                 }

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -679,7 +679,7 @@ const schema = {
                   type: 'object',
                   properties: {
                     name: {
-                      $ref: '#/definitions/fullName'
+                      type: 'string'
                     },
                     address: {
                       $ref: '#/definitions/address'


### PR DESCRIPTION
Updating the PTSD incident source.name from a `fullName` to a string. I'd thought that this was an individual, but was incorrect and this will have to be a single name field.

Added `description` as a string property to the PTSD incident individual.