### PR TITLE
781a attachments for uploading secondary sources

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -8,7 +8,8 @@
       "pattern": "^\\d{10}$"
     },
     "date": {
-      "pattern": "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$",
+      "pattern":
+        "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$",
       "type": "string"
     },
     "fullName": {
@@ -29,25 +30,17 @@
         },
         "suffix": {
           "type": "string",
-          "enum": [
-            "Jr.",
-            "Sr.",
-            "II",
-            "III",
-            "IV"
-          ]
+          "enum": ["Jr.", "Sr.", "II", "III", "IV"]
         }
       },
-      "required": [
-        "first",
-        "last"
-      ]
+      "required": ["first", "last"]
     },
     "email": {
       "type": "string",
       "minLength": 6,
       "maxLength": 80,
-      "pattern": "^[_A-Za-z0-9-]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$"
+      "pattern":
+        "^[_A-Za-z0-9-]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$"
     },
     "specialIssues": {
       "type": "array",
@@ -67,11 +60,7 @@
     },
     "address": {
       "type": "object",
-      "required": [
-        "country",
-        "city",
-        "addressLine1"
-      ],
+      "required": ["country", "city", "addressLine1"],
       "properties": {
         "country": {
           "type": "string",
@@ -454,9 +443,7 @@
     },
     "vaTreatmentCenterAddress": {
       "type": "object",
-      "required": [
-        "country"
-      ],
+      "required": ["country"],
       "properties": {
         "country": {
           "type": "string",
@@ -839,10 +826,7 @@
           "$ref": "#/definitions/date"
         }
       },
-      "required": [
-        "from",
-        "to"
-      ]
+      "required": ["from", "to"]
     },
     "dateRangeFromRequired": {
       "type": "object",
@@ -854,32 +838,21 @@
           "$ref": "#/definitions/date"
         }
       },
-      "required": [
-        "from"
-      ]
+      "required": ["from"]
     },
     "ratedDisabilities": {
       "type": "array",
       "maxItems": 100,
       "items": {
         "type": "object",
-        "required": [
-          "name",
-          "disabilityActionType"
-        ],
+        "required": ["name", "disabilityActionType"],
         "properties": {
           "name": {
             "type": "string"
           },
           "disabilityActionType": {
             "type": "string",
-            "enum": [
-              "NONE",
-              "NEW",
-              "SECONDARY",
-              "INCREASE",
-              "REOPEN"
-            ]
+            "enum": ["NONE", "NEW", "SECONDARY", "INCREASE", "REOPEN"]
           },
           "specialIssues": {
             "$ref": "#/definitions/specialIssues"
@@ -901,23 +874,14 @@
             "maxItems": 100,
             "items": {
               "type": "object",
-              "required": [
-                "name",
-                "disabilityActionType"
-              ],
+              "required": ["name", "disabilityActionType"],
               "properties": {
                 "name": {
                   "type": "string"
                 },
                 "disabilityActionType": {
                   "type": "string",
-                  "enum": [
-                    "NONE",
-                    "NEW",
-                    "SECONDARY",
-                    "INCREASE",
-                    "REOPEN"
-                  ]
+                  "enum": ["NONE", "NEW", "SECONDARY", "INCREASE", "REOPEN"]
                 },
                 "specialIssues": {
                   "$ref": "#/definitions/specialIssues"
@@ -945,22 +909,14 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": [
-          "condition",
-          "cause"
-        ],
+        "required": ["condition", "cause"],
         "properties": {
           "condition": {
             "type": "string"
           },
           "cause": {
             "type": "string",
-            "enum": [
-              "NEW",
-              "SECONDARY",
-              "WORSENED",
-              "VA"
-            ]
+            "enum": ["NEW", "SECONDARY", "WORSENED", "VA"]
           },
           "primaryDescription": {
             "type": "string"
@@ -1578,9 +1534,7 @@
     },
     "serviceInformation": {
       "type": "object",
-      "required": [
-        "servicePeriods"
-      ],
+      "required": ["servicePeriods"],
       "properties": {
         "servicePeriods": {
           "type": "array",
@@ -1588,10 +1542,7 @@
           "maxItems": 100,
           "items": {
             "type": "object",
-            "required": [
-              "serviceBranch",
-              "dateRange"
-            ],
+            "required": ["serviceBranch", "dateRange"],
             "properties": {
               "serviceBranch": {
                 "type": "string",
@@ -1620,10 +1571,7 @@
         },
         "reservesNationalGuardService": {
           "type": "object",
-          "required": [
-            "unitName",
-            "obligationTermOfServiceDateRange"
-          ],
+          "required": ["unitName", "obligationTermOfServiceDateRange"],
           "properties": {
             "unitName": {
               "type": "string",
@@ -2096,10 +2044,7 @@
     },
     "phoneAndEmail": {
       "type": "object",
-      "required": [
-        "primaryPhone",
-        "emailAddress"
-      ],
+      "required": ["primaryPhone", "emailAddress"],
       "properties": {
         "primaryPhone": {
           "$ref": "#/definitions/phone"
@@ -2111,20 +2056,11 @@
     },
     "homelessOrAtRisk": {
       "type": "string",
-      "enum": [
-        "no",
-        "homeless",
-        "atRisk"
-      ]
+      "enum": ["no", "homeless", "atRisk"]
     },
     "homelessHousingSituation": {
       "type": "string",
-      "enum": [
-        "shelter",
-        "notShelter",
-        "anotherPerson",
-        "other"
-      ]
+      "enum": ["shelter", "notShelter", "anotherPerson", "other"]
     },
     "otherHomelessHousing": {
       "type": "string"
@@ -2134,11 +2070,7 @@
     },
     "atRiskHousingSituation": {
       "type": "string",
-      "enum": [
-        "losingHousing",
-        "leavingShelter",
-        "other"
-      ]
+      "enum": ["losingHousing", "leavingShelter", "other"]
     },
     "otherAtRiskHousing": {
       "type": "string"
@@ -2163,10 +2095,7 @@
       "maxItems": 100,
       "items": {
         "type": "object",
-        "required": [
-          "treatmentCenterName",
-          "treatedDisabilityNames"
-        ],
+        "required": ["treatmentCenterName", "treatedDisabilityNames"],
         "properties": {
           "treatmentCenterName": {
             "type": "string",
@@ -2194,10 +2123,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": [
-          "name",
-          "attachmentId"
-        ],
+        "required": ["name", "attachmentId"],
         "properties": {
           "name": {
             "type": "string"
@@ -2267,10 +2193,7 @@
     },
     "bankAccountType": {
       "type": "string",
-      "enum": [
-        "Checking",
-        "Savings"
-      ]
+      "enum": ["Checking", "Savings"]
     },
     "bankAccountNumber": {
       "type": "string",
@@ -2525,9 +2448,7 @@
           "minItems": 1,
           "items": {
             "type": "object",
-            "required": [
-              "personalAssault"
-            ],
+            "required": ["personalAssault"],
             "properties": {
               "personalAssault": {
                 "type": "boolean"
@@ -3038,10 +2959,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": [
-          "name",
-          "attachmentId"
-        ],
+        "required": ["name", "attachmentId"],
         "properties": {
           "name": {
             "type": "string"
@@ -3051,11 +2969,7 @@
           },
           "attachmentId": {
             "type": "string",
-            "enum": [
-              "L107",
-              "L023",
-              "L023"
-            ],
+            "enum": ["L107", "L023", "L023"],
             "enumNames": [
               "VA 21-4142 Authorization for Release of Information",
               "Multiple Documents",
@@ -3069,10 +2983,7 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": [
-          "name",
-          "attachmentId"
-        ],
+        "required": ["name", "attachmentId"],
         "properties": {
           "name": {
             "type": "string"
@@ -3082,6 +2993,48 @@
           },
           "attachmentId": {
             "type": "string"
+          }
+        }
+      }
+    },
+    "secondaryAttachments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "attachmentId"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "confirmationCode": {
+            "type": "string"
+          },
+          "attachmentId": {
+            "type": "string",
+            "enum": [
+              "L229",
+              "L018",
+              "L034",
+              "L048",
+              "L049",
+              "L029",
+              "L034",
+              "L034",
+              "L023",
+              "L015"
+            ],
+            "enumNames": [
+              "VA Form 21-0781a - Statement in Support of Claim for PTSD Secondary to Personal Assault",
+              "Civilian Police Reports",
+              "Military Personnel Record",
+              "Medical Treatment Record - Government Facility",
+              "Medical Treatment Record - Non-Government Facility",
+              "DD214",
+              "Military Personnel Record",
+              "Decorations/Awards/Medal Citations",
+              "Other Correspondence",
+              "Buddy/Lay Statement"
+            ]
           }
         }
       }


### PR DESCRIPTION
## Description
Display of document types for the 0781a 'Other Sources.' 
http://localhost:3001/disability-benefits/apply/form-526-all-claims/disabilities/ptsd-secondary-upload-supporting-sources-0
```bah-781a-dropdown``` in vets-website

## Testing done
No tests written

## Screenshots
<img width="490" alt="screen shot 2018-12-24 at 10 51 46 am" src="https://user-images.githubusercontent.com/41440372/50403105-f4b56580-0769-11e9-80a8-5ad35f8f87b1.png">


## Acceptance criteria
- [ ] During the 0781a interview if the user is uploading a general supporting document (not a specific form) then the document type list will be filtered and displayed to the user based on the options listed on the attached spreadsheet/tab _781-781a_in the VBMS Description Text column

- [ ] Document name field will no longer show, it will default to the file name

- [ ] User is able to delete the file if needed

- [ ] User can add another document

- User can continue to next step in the flow

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
