### PR TITLE
Updated 8940 care dates

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -2891,11 +2891,8 @@
                   "address": {
                     "$ref": "#/definitions/address"
                   },
-                  "phoneNumber": {
-                    "$ref": "#/definitions/phone"
-                  },
                   "dates": {
-                    "$ref": "#/definitions/dateRange"
+                    "type": "string"
                   }
                 }
               }
@@ -2906,168 +2903,10 @@
                 "type": "object",
                 "properties": {
                   "name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
+                    "type": "string"
                   },
                   "address": {
-                    "type": "object",
-                    "properties": {
-                      "addressLine1": {
-                        "type": "string",
-                        "maxLength": 20,
-                        "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
-                      },
-                      "addressLine2": {
-                        "type": "string",
-                        "maxLength": 20,
-                        "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
-                      },
-                      "city": {
-                        "type": "string",
-                        "maxLength": 30,
-                        "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
-                      },
-                      "state": {
-                        "type": "string",
-                        "enum": [
-                          "AL",
-                          "UM",
-                          "AS",
-                          "AZ",
-                          "AR",
-                          "AA",
-                          "AE",
-                          "AP",
-                          "CA",
-                          "CO",
-                          "CT",
-                          "DE",
-                          "DC",
-                          "FM",
-                          "FL",
-                          "GA",
-                          "GU",
-                          "HI",
-                          "ID",
-                          "IL",
-                          "IN",
-                          "IA",
-                          "KS",
-                          "KY",
-                          "LA",
-                          "ME",
-                          "MH",
-                          "MD",
-                          "MA",
-                          "MI",
-                          "MN",
-                          "MS",
-                          "AK",
-                          "MT",
-                          "NE",
-                          "NV",
-                          "NH",
-                          "NJ",
-                          "NM",
-                          "NY",
-                          "NC",
-                          "ND",
-                          "MP",
-                          "OH",
-                          "OK",
-                          "OR",
-                          "PW",
-                          "PA",
-                          "PR",
-                          "RI",
-                          "SC",
-                          "SD",
-                          "TN",
-                          "TX",
-                          "UT",
-                          "VT",
-                          "VI",
-                          "VA",
-                          "WA",
-                          "WV",
-                          "WI",
-                          "WY",
-                          "PI",
-                          "MO"
-                        ],
-                        "enumNames": [
-                          "Alabama",
-                          "U.S. Minor Outlying Islands",
-                          "American Samoa",
-                          "Arizona",
-                          "Arkansas",
-                          "Armed Forces Americas (AA)",
-                          "Armed Forces Europe (AE)",
-                          "Armed Forces Pacific (AP)",
-                          "California",
-                          "Colorado",
-                          "Connecticut",
-                          "Delaware",
-                          "District Of Columbia",
-                          "Federated States Of Micronesia",
-                          "Florida",
-                          "Georgia",
-                          "Guam",
-                          "Hawaii",
-                          "Idaho",
-                          "Illinois",
-                          "Indiana",
-                          "Iowa",
-                          "Kansas",
-                          "Kentucky",
-                          "Louisiana",
-                          "Maine",
-                          "Marshall Islands",
-                          "Maryland",
-                          "Massachusetts",
-                          "Michigan",
-                          "Minnesota",
-                          "Mississippi",
-                          "Alaska",
-                          "Montana",
-                          "Nebraska",
-                          "Nevada",
-                          "New Hampshire",
-                          "New Jersey",
-                          "New Mexico",
-                          "New York",
-                          "North Carolina",
-                          "North Dakota",
-                          "Northern Mariana Islands",
-                          "Ohio",
-                          "Oklahoma",
-                          "Oregon",
-                          "Palau",
-                          "Pennsylvania",
-                          "Puerto Rico",
-                          "Rhode Island",
-                          "South Carolina",
-                          "South Dakota",
-                          "Tennessee",
-                          "Texas",
-                          "Utah",
-                          "Vermont",
-                          "Virgin Islands",
-                          "Virginia",
-                          "Washington",
-                          "West Virginia",
-                          "Wisconsin",
-                          "Wyoming",
-                          "Philippine Islands",
-                          "Missouri"
-                        ]
-                      },
-                      "zipCode": {
-                        "type": "string",
-                        "pattern": "^\\d{5}(?:([-\\s]?)\\d{4})?$"
-                      }
-                    }
+                    "$ref": "#/definitions/address"
                   },
                   "dates": {
                     "type": "string"

--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -3092,12 +3092,10 @@
             "type": "string",
             "enum": [
               "L107",
-              "L023",
               "L023"
             ],
             "enumNames": [
               "VA 21-4142 Authorization for Release of Information",
-              "Multiple Documents",
               "Other"
             ]
           }
@@ -3149,8 +3147,6 @@
               "L048",
               "L049",
               "L029",
-              "L034",
-              "L034",
               "L023",
               "L015"
             ],
@@ -3161,10 +3157,64 @@
               "Medical Treatment Record - Government Facility",
               "Medical Treatment Record - Non-Government Facility",
               "DD214",
-              "Military Personnel Record",
-              "Decorations/Awards/Medal Citations",
               "Other Correspondence",
               "Buddy/Lay Statement"
+            ]
+          }
+        }
+      }
+    },
+    "unemployabilityAttachments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "attachmentId"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "confirmationCode": {
+            "type": "string"
+          },
+          "attachmentId": {
+            "type": "string",
+            "enum": [
+              "L149",
+              "L023"
+            ],
+            "enumNames": [
+              "VA 21-8940 Veterans Application for Increased Compensation Based on Unemployability",
+              "Other"
+            ]
+          }
+        }
+      }
+    },
+    "employmentRequestAttachments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "attachmentId"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "confirmationCode": {
+            "type": "string"
+          },
+          "attachmentId": {
+            "type": "string",
+            "enum": [
+              "L115"
+            ],
+            "enumNames": [
+              "A 21-4192 Request for Employment Information in Connection with Claim for Disability"
             ]
           }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.127.0",
+  "version": "3.128.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -976,10 +976,9 @@ const schema = {
           },
           attachmentId: {
             type: 'string',
-            enum: ['L107', 'L023', 'L023'],
+            enum: ['L107', 'L023'],
             enumNames: [
               'VA 21-4142 Authorization for Release of Information',
-              'Multiple Documents',
               'Other'
             ]
           }
@@ -1025,8 +1024,6 @@ const schema = {
               'L048',
               'L049',
               'L029',
-              'L034',
-              'L034',
               'L023',
               'L015'
             ],
@@ -1037,14 +1034,56 @@ const schema = {
               'Medical Treatment Record - Government Facility',
               'Medical Treatment Record - Non-Government Facility',
               'DD214',
-              'Military Personnel Record',
-              'Decorations/Awards/Medal Citations',
               'Other Correspondence',
               'Buddy/Lay Statement'
             ]
           }
         }
-
+      }
+    },
+    unemployabilityAttachments: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['name', 'attachmentId'],
+        properties: {
+          name: {
+            type: 'string',
+          },
+          confirmationCode: {
+            type: 'string',
+          },
+          attachmentId: {
+            type: 'string',
+            enum: ['L149', 'L023'],
+            enumNames: [
+              'VA 21-8940 Veterans Application for Increased Compensation Based on Unemployability',
+              'Other',
+            ],
+          },
+        },
+      },
+    }, 
+    employmentRequestAttachments: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["name", "attachmentId"],
+        properties: {
+          name: {
+            type: "string"
+          },
+          confirmationCode: {
+            type: "string"
+          },
+          attachmentId: {
+            type: "string",
+            enum: ["L115"],
+            enumNames: [
+              "A 21-4192 Request for Employment Information in Connection with Claim for Disability"
+            ]
+          }
+        }
       }
     }
   }

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -780,11 +780,8 @@ const schema = {
                   address: {
                     $ref: '#/definitions/address'
                   },
-                  phoneNumber: {
-                    $ref: '#/definitions/phone',
-                  },
                   dates: {
-                    $ref: '#/definitions/dateRange'
+                    type: "string"
                   }
                 }
               }
@@ -795,16 +792,10 @@ const schema = {
                 type: 'object',
                 properties: {
                   name: {
-                    type: 'string',
-                    minLength: 1,
-                    maxLength: 100
+                    type: 'string'
                   },
                   address: {
-                    type: 'object',
-                    properties: _.omit(
-                      ['addressLine3', 'country'],
-                      baseAddressDef.properties
-                    )
+                    $ref: '#/definitions/address'
                   },
                   dates: {
                     type: "string"


### PR DESCRIPTION
`form8940` - Standardized `doctorProvidedCare` and `hospitalProvidedCare` property fields.

`address` is simplified to the standard address because all address fields are supported on the 8940 PDF.

`phoneNumber` was removed because it is not supported on the 8940 PDF.

Removed duplicate attachment enum values from `secondaryAttachment`, and `privateMedicalRecordAttachments`

Added `unemployabilityAttachments` and `employmentRequestAttachments`