### PR TITLE
[VET TEC] - Update employment question field names

### DIFF
--- a/dist/22-0994-schema.json
+++ b/dist/22-0994-schema.json
@@ -502,10 +502,10 @@
         }
       }
     },
-    "currentHighTechnologyEmployment": {
+    "pastHighTechnologyEmployment": {
       "type": "boolean"
     },
-    "pastHighTechnologyEmployment": {
+    "currentHighTechnologyEmployment": {
       "type": "boolean"
     },
     "highTechnologyEmploymentTypes": {

--- a/dist/22-0994-schema.json
+++ b/dist/22-0994-schema.json
@@ -502,10 +502,10 @@
         }
       }
     },
-    "currentEmployment": {
+    "currentHighTechnologyEmployment": {
       "type": "boolean"
     },
-    "currentHighTechnologyEmployment": {
+    "pastHighTechnologyEmployment": {
       "type": "boolean"
     },
     "highTechnologyEmploymentTypes": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.136.2",
+  "version": "3.136.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/22-0994/schema.js
+++ b/src/schemas/22-0994/schema.js
@@ -102,10 +102,10 @@ const schema = {
         },
       },
     },
-    currentHighTechnologyEmployment: {
+    pastHighTechnologyEmployment: {
       type: "boolean"
     },
-    pastHighTechnologyEmployment: {
+    currentHighTechnologyEmployment: {
       type: "boolean"
     },
     highTechnologyEmploymentTypes: {

--- a/src/schemas/22-0994/schema.js
+++ b/src/schemas/22-0994/schema.js
@@ -102,10 +102,10 @@ const schema = {
         },
       },
     },
-    currentEmployment: {
+    currentHighTechnologyEmployment: {
       type: "boolean"
     },
-    currentHighTechnologyEmployment: {
+    pastHighTechnologyEmployment: {
       type: "boolean"
     },
     highTechnologyEmploymentTypes: {


### PR DESCRIPTION
UI content doc updates changed the wording of a question enough to mean that the schema field name is inaccurate and needs to be updated.

Renamed `currentEmployment` to `pastHighTechnologyEmployment`