### PR TITLE
Add 0994 fields to schema for 16819, 16795

### DIFF
--- a/dist/22-0994-schema.json
+++ b/dist/22-0994-schema.json
@@ -336,6 +336,27 @@
     "bankAccount": {
       "$ref": "#/definitions/bankAccount"
     },
+    "prefillBankAccount": {
+      "type": "object",
+      "properties": {
+        "bankAccountType": {
+          "type": "string",
+          "enum": [
+            "checking",
+            "savings"
+          ]
+        },
+        "bankAccountNumber": {
+          "type": "string"
+        },
+        "bankRoutingNumber": {
+          "type": "string"
+        },
+        "bankName": {
+          "type": "string"
+        }
+      }
+    },
     "vetTecPrograms": {
       "type": "array",
       "maxItems": 3,

--- a/dist/22-0994-schema.json
+++ b/dist/22-0994-schema.json
@@ -284,6 +284,11 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 51
+        },
+        "street3": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.136.3",
+  "version": "3.136.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/22-0994/schema.js
+++ b/src/schemas/22-0994/schema.js
@@ -25,7 +25,13 @@ const schema = {
       pattern:
         "^[_A-Za-z0-9-]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$"
     },
-    address: definitions.address,
+    address: {
+      ...definitions.address,
+      properties: {
+        ...definitions.address.properties,
+        street3: definitions.address.properties.street2,
+      },
+    },
     privacyAgreementAccepted: definitions.privacyAgreementAccepted
   },
   properties: {

--- a/src/schemas/22-0994/schema.js
+++ b/src/schemas/22-0994/schema.js
@@ -71,6 +71,24 @@ const schema = {
     bankAccount: {
       $ref: "#/definitions/bankAccount"
     },
+    prefillBankAccount: {
+      type: 'object',
+      properties: {
+        bankAccountType: {
+          type: 'string',
+          'enum': ['checking', 'savings']
+        },
+        bankAccountNumber: {
+          type: 'string',
+        },
+        bankRoutingNumber: {
+          type: 'string'
+        },
+        bankName: {
+          type: 'string',
+        }
+      }
+    },
     vetTecPrograms: {
       type: 'array',
       maxItems: 3,


### PR DESCRIPTION
- Add `street3` to the 0994 address definitions
- Add `prefillBankAccount` to the 0994 schema

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16819
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16795