### PR TITLE
Rearrange address definitions

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -1220,7 +1220,23 @@
                 "$ref": "#/definitions/date"
               },
               "incidentLocation": {
-                "type": "string"
+                "type": "object",
+                "properties": {
+                  "country": {
+                    "$ref": "#/definitions/country"
+                  },
+                  "city": {
+                    "type": "string",
+                    "maxLength": 30,
+                    "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
+                  },
+                  "state": {
+                    "$ref": "#/definitions/state"
+                  },
+                  "additionalDetails": {
+                    "type": "string"
+                  }
+                }
               },
               "incidentDescription": {
                 "type": "string"
@@ -1287,23 +1303,7 @@
                       "type": "string"
                     },
                     "address": {
-                      "type": "object",
-                      "properties": {
-                        "country": {
-                          "$ref": "#/definitions/country"
-                        },
-                        "city": {
-                          "type": "string",
-                          "maxLength": 30,
-                          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
-                        },
-                        "state": {
-                          "$ref": "#/definitions/state"
-                        },
-                        "additionalDetails": {
-                          "type": "string"
-                        }
-                      }
+                      "$ref": "#/definitions/address"
                     }
                   }
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.136.5",
+  "version": "3.136.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -619,9 +619,7 @@ const schema = {
               incidentDate: {
                 $ref: '#/definitions/date'
               },
-              incidentLocation: {
-                type: 'string'
-              },
+              incidentLocation: form0781AddressDef,
               incidentDescription: {
                 type: 'string'
               },
@@ -686,7 +684,9 @@ const schema = {
                     name: {
                       type: 'string'
                     },
-                    address: form0781AddressDef
+                    address: {
+                      $ref: '#/definitions/address'
+                    }
                   }
                 }
               }


### PR DESCRIPTION
In #333, I should have used the `form0781AddressDef` for `incidentLocation`, not the `sources` address. :man_facepalming: 

This fixes that.

It's been updated in the [implementing PR](https://github.com/department-of-veterans-affairs/vets-website/compare/8235ca609a3508d309f00cb1b90b7a0bfe1b6575..c5443b4085f0119c781e33e0f141ac93906e3b46?expand=1).