### PR TITLE
Make YAAS: Yet Another Address Schema

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -1303,7 +1303,34 @@
                       "type": "string"
                     },
                     "address": {
-                      "$ref": "#/definitions/address"
+                      "type": "object",
+                      "properties": {
+                        "country": {
+                          "$ref": "#/definitions/country"
+                        },
+                        "addressLine1": {
+                          "type": "string",
+                          "maxLength": 20,
+                          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+                        },
+                        "addressLine2": {
+                          "type": "string",
+                          "maxLength": 20,
+                          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+                        },
+                        "city": {
+                          "type": "string",
+                          "maxLength": 30,
+                          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
+                        },
+                        "state": {
+                          "$ref": "#/definitions/state"
+                        },
+                        "zipCode": {
+                          "type": "string",
+                          "pattern": "^\\d{5}(?:([-\\s]?)\\d{4})?$"
+                        }
+                      }
                     }
                   }
                 }

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -113,6 +113,15 @@ const form0781AddressDef = (addressSchema => {
   };
 })(baseAddressDef);
 
+const incidentSourceAddressDef = (addressSchema => {
+  return {
+    ..._.omit('required', addressSchema),
+    properties: {
+      ..._.omit('addressLine3', addressSchema.properties)
+    }
+  }
+})(baseAddressDef);
+
 const schema = {
   $schema: 'http://json-schema.org/draft-04/schema#',
   title: 'APPLICATION FOR DISABILITY BENEFITS',
@@ -684,9 +693,7 @@ const schema = {
                     name: {
                       type: 'string'
                     },
-                    address: {
-                      $ref: '#/definitions/address'
-                    }
+                    address: incidentSourceAddressDef
                   }
                 }
               }


### PR DESCRIPTION
The incident sources address doesn't populate the `addressLine3` to the PDF, so rather than having a veteran fill it in with some information only to be completely ignored, we'll just not show them the field.

I couldn't just hide the field on `vets-website` because throwing in a `'ui:options': { hideIf: () => true }` doesn't work on the first render, and the address schema was a reference to the definition (and I thus didn't have access to remove it or apply `ui:hidden`).