### PR TITLE
Add caret to homelessness contact name pattern

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -1006,7 +1006,7 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 100,
-          "pattern": "([a-zA-Z0-9-/']+( ?))*$"
+          "pattern": "^([a-zA-Z0-9-/']+( ?))*$"
         },
         "phoneNumber": {
           "$ref": "#/definitions/phone"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.137.6",
+  "version": "3.137.7",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -100,16 +100,16 @@ const form0781AddressDef = (addressSchema => {
     'addressLine2',
     'addressLine3',
     'postalCode',
-    'zipCode',
+    'zipCode'
   ];
   return {
     ..._.omit('required', addressSchema),
     properties: {
       ..._.omit(ptsdAddressOmitions, addressSchema.properties),
       additionalDetails: {
-        type: 'string',
-      },
-    },
+        type: 'string'
+      }
+    }
   };
 })(baseAddressDef);
 
@@ -119,7 +119,7 @@ const incidentSourceAddressDef = (addressSchema => {
     properties: {
       ..._.omit('addressLine3', addressSchema.properties)
     }
-  }
+  };
 })(baseAddressDef);
 
 const schema = {
@@ -478,7 +478,7 @@ const schema = {
           type: 'string',
           minLength: 1,
           maxLength: 100,
-          pattern: "([a-zA-Z0-9-/']+( ?))*$"
+          pattern: "^([a-zA-Z0-9-/']+( ?))*$"
         },
         phoneNumber: {
           $ref: '#/definitions/phone'


### PR DESCRIPTION
Adds caret in homelessness POC regex to match beginning of string, so that validations actually applied.

