### PR TITLE
alter regex to eliminate warnings that appear in `vets-api` when running specs

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -762,19 +762,19 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^([a-zA-Z0-9-/']+( ?))+$"
+            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
           },
           "middle": {
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^([a-zA-Z0-9-/']+( ?))+$"
+            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
           },
           "last": {
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^([a-zA-Z0-9-/']+( ?))+$"
+            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
           }
         }
       }
@@ -1009,7 +1009,7 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 100,
-          "pattern": "^([a-zA-Z0-9-/']+( ?))*$"
+          "pattern": "^([-a-zA-Z0-9/']+( ?))*$"
         },
         "phoneNumber": {
           "$ref": "#/definitions/phone"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.138.2",
+  "version": "3.138.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -286,19 +286,19 @@ const schema = {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^([a-zA-Z0-9-/']+( ?))+$"
+            pattern: "^([-a-zA-Z0-9/']+( ?))+$"
           },
           middle: {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^([a-zA-Z0-9-/']+( ?))+$"
+            pattern: "^([-a-zA-Z0-9/']+( ?))+$"
           },
           last: {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^([a-zA-Z0-9-/']+( ?))+$"
+            pattern: "^([-a-zA-Z0-9/']+( ?))+$"
           }
         }
       }
@@ -481,7 +481,7 @@ const schema = {
           type: 'string',
           minLength: 1,
           maxLength: 100,
-          pattern: "^([a-zA-Z0-9-/']+( ?))*$"
+          pattern: "^([-a-zA-Z0-9/']+( ?))*$"
         },
         phoneNumber: {
           $ref: '#/definitions/phone'


### PR DESCRIPTION
These regex as written cause the vets-api to throw warnings when running specs.
Rewriting them this way eliminates the warnings.

[StackOverflow reference](https://stackoverflow.com/questions/24843335/rails-regex-warning-character-class-has-without-escape/24843354)