### PR TITLE
4494 686c schema updates

### DIFF
--- a/dist/21-686C-schema.json
+++ b/dist/21-686C-schema.json
@@ -221,7 +221,8 @@
           ]
         },
         "postalCode": {
-          "$ref": "#/definitions/postalCode"
+          "type": "string",
+          "pattern": "^\\d{5}(?:([-\\s]?)\\d{4})?$"
         }
       },
       "additionalProperties": false
@@ -512,7 +513,8 @@
           ]
         },
         "postalCode": {
-          "$ref": "#/definitions/postalCode"
+          "type": "string",
+          "pattern": "^\\d{5}(?:([-\\s]?)\\d{4})?$"
         }
       },
       "additionalProperties": false
@@ -1504,14 +1506,6 @@
           "childSocialSecurityNumber": {
             "$ref": "#/definitions/ssn"
           },
-          "childRelationship": {
-            "type": "string",
-            "enum": [
-              "biological",
-              "adopted",
-              "stepchild"
-            ]
-          },
           "isSupportingStepchild": {
             "type": "boolean"
           },
@@ -1660,6 +1654,78 @@
                 }
               }
             ]
+          }
+        ],
+        "anyOf": [
+          {
+            "type": "object",
+            "oneOf": [
+              {
+                "required": [
+                  "isSupportingStepchild"
+                ],
+                "properties": {
+                  "childRelationship": {
+                    "type": "string",
+                    "enum": [
+                      "stepchild"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "financialSupportProvided"
+                ],
+                "properties": {
+                  "childRelationship": {
+                    "type": "string",
+                    "enum": [
+                      "stepChild"
+                    ]
+                  },
+                  "isSupportingStepchild": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "childRelationship": {
+                    "type": "string",
+                    "enum": [
+                      "adopted"
+                    ]
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "childRelationship": {
+                    "type": "string",
+                    "enum": [
+                      "biological"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "required": [
+              "dateStepchildLeftHousehold"
+            ],
+            "properties": {
+              "childInHousehold": {
+                "type": "boolean",
+                "enum": [
+                  false
+                ]
+              }
+            }
           }
         ]
       }

--- a/dist/21-686C-schema.json
+++ b/dist/21-686C-schema.json
@@ -38,6 +38,10 @@
       "type": "string",
       "pattern": "^[0-9]{9}$"
     },
+    "veteranServiceNumber": {
+      "type": "string",
+      "pattern": "^[A-Z]{0,2}\\d{5,8}$"
+    },
     "domesticAddress": {
       "type": "object",
       "required": [
@@ -820,13 +824,12 @@
           "minLength": 1,
           "pattern": "^(?!\\s)(?!.*?\\s{2,})[^<>%$#@!^&*0-9]+$"
         }
-      },
-      "additionalProperties": false
+      }
     },
-    "postalCode": {
+    "genericLocation": {
       "type": "string",
-      "maxLength": 10,
-      "pattern": "^\\d{5}(?:[- ]?\\d{4})?$"
+      "maxLength": 250,
+      "pattern": "^(?!\\s)(?!.*?\\s{2,})[^<>%$#@!^&*]+$"
     },
     "location": {
       "type": "object",
@@ -1220,14 +1223,18 @@
         "required": [
           "dateOfMarriage",
           "locationOfMarriage",
-          "spouseFullName"
+          "spouseFullName",
+          "marriageType"
         ],
         "properties": {
           "dateOfMarriage": {
             "$ref": "#/definitions/date"
           },
           "locationOfMarriage": {
-            "$ref": "#/definitions/location"
+            "$ref": "#/definitions/genericLocation"
+          },
+          "marriageType": {
+            "type": "string"
           },
           "spouseFullName": {
             "$ref": "#/definitions/fullName"
@@ -1236,7 +1243,7 @@
             "$ref": "#/definitions/date"
           },
           "locationOfSeparation": {
-            "$ref": "#/definitions/location"
+            "$ref": "#/definitions/genericLocation"
           }
         },
         "oneOf": [
@@ -1280,6 +1287,7 @@
           "dateOfMarriage",
           "locationOfMarriage",
           "spouseFullName",
+          "marriageType",
           "reasonForSeparation",
           "dateOfSeparation",
           "locationOfSeparation"
@@ -1289,7 +1297,10 @@
             "$ref": "#/definitions/date"
           },
           "locationOfMarriage": {
-            "$ref": "#/definitions/location"
+            "$ref": "#/definitions/genericLocation"
+          },
+          "marriageType": {
+            "type": "string"
           },
           "spouseFullName": {
             "$ref": "#/definitions/fullName"
@@ -1298,7 +1309,7 @@
             "$ref": "#/definitions/date"
           },
           "locationOfSeparation": {
-            "$ref": "#/definitions/location"
+            "$ref": "#/definitions/genericLocation"
           }
         },
         "oneOf": [
@@ -1373,6 +1384,9 @@
     },
     "veteranSocialSecurityNumber": {
       "$ref": "#/definitions/ssn"
+    },
+    "veteranServiceNumber": {
+      "$ref": "#/definitions/veteranServiceNumber"
     },
     "maritalStatus": {
       "type": "string",
@@ -1485,7 +1499,7 @@
             "$ref": "#/definitions/date"
           },
           "childPlaceOfBirth": {
-            "$ref": "#/definitions/location"
+            "$ref": "#/definitions/genericLocation"
           },
           "childSocialSecurityNumber": {
             "$ref": "#/definitions/ssn"
@@ -1498,6 +1512,20 @@
               "stepchild"
             ]
           },
+          "isSupportingStepchild": {
+            "type": "boolean"
+          },
+          "dateStepchildLeftHousehold": {
+            "$ref": "#/definitions/date"
+          },
+          "financialSupportProvided": {
+            "type": "string",
+            "enum": [
+              "More than half",
+              "Half",
+              "Less than half"
+            ]
+          },
           "attendingCollege": {
             "type": "boolean"
           },
@@ -1507,7 +1535,7 @@
           "previouslyMarried": {
             "type": "boolean"
           },
-          "marriedDate": {
+          "dateMarriageEnded": {
             "$ref": "#/definitions/date"
           },
           "childInHousehold": {
@@ -1551,7 +1579,7 @@
             "oneOf": [
               {
                 "required": [
-                  "marriedDate"
+                  "dateMarriageEnded"
                 ],
                 "properties": {
                   "previouslyMarried": {
@@ -1559,6 +1587,37 @@
                     "enum": [
                       true
                     ]
+                  },
+                  "reasonMarriageEnded": {
+                    "type": "string",
+                    "enum": [
+                      "Annulled",
+                      "Declared void"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "dateMarriageEnded"
+                ],
+                "properties": {
+                  "previouslyMarried": {
+                    "type": "boolean",
+                    "enum": [
+                      true
+                    ]
+                  },
+                  "reasonMarriageEnded": {
+                    "type": "string",
+                    "enum": [
+                      "Other"
+                    ]
+                  },
+                  "explainSeparation": {
+                    "type": "string",
+                    "maxLength": 500,
+                    "pattern": "^(?!\\s)(?!.*?\\s{2,})[^<>%$#@!^&*]+$"
                   }
                 }
               },

--- a/dist/definitions.json
+++ b/dist/definitions.json
@@ -523,6 +523,10 @@
     "type": "string",
     "pattern": "^[cC]{0,1}\\d{7,9}$"
   },
+  "veteranServiceNumber": {
+    "type": "string",
+    "pattern": "^[A-Z]{0,2}\\d{5,8}$"
+  },
   "relationship": {
     "type": "string",
     "enum": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.138.12",
+  "version": "3.138.13",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/common/definitions.js
+++ b/src/common/definitions.js
@@ -126,6 +126,13 @@ const ssn = {
   pattern: '^[0-9]{9}$'
 };
 
+// Historically a veteran's service number has been between 5 and 8 digits, 
+// with the possibility of an alphabetical prefix of up to two capital letters.
+const veteranServiceNumber = {
+  type: 'string',
+  pattern: '^[A-Z]{0,2}\\d{5,8}$'
+}
+
 // The last four digits (or serial number) must be a number from 0001 to 9999
 // https://www.ssa.gov/history/ssn/geocard.html
 const ssnLastFour = {

--- a/src/common/definitions.js
+++ b/src/common/definitions.js
@@ -124,12 +124,12 @@ const ssn = {
   pattern: '^[0-9]{9}$',
 };
 
-// Historically a veteran's service number has been between 5 and 8 digits, 
+// Historically a veteran's service number has been between 5 and 8 digits,
 // with the possibility of an alphabetical prefix of up to two capital letters.
 const veteranServiceNumber = {
   type: 'string',
-  pattern: '^[A-Z]{0,2}\\d{5,8}$'
-}
+  pattern: '^[A-Z]{0,2}\\d{5,8}$',
+};
 
 // The last four digits (or serial number) must be a number from 0001 to 9999
 // https://www.ssa.gov/history/ssn/geocard.html
@@ -583,6 +583,7 @@ export default {
   nonMilitaryJobs,
   secondaryContact,
   vaFileNumber,
+  veteranServiceNumber,
   relationship,
   toursOfDuty,
   educationProgram,

--- a/src/schemas/21-686C/schema.js
+++ b/src/schemas/21-686C/schema.js
@@ -469,7 +469,7 @@ let schema = {
           disabled: {
             type: 'boolean'
           },
-          previouslyMarried: { // 4494 Note - I think this can be removed from here but....
+          previouslyMarried: {
             type: 'boolean'
           },
           dateMarriageEnded: schemaHelpers.getDefinition('date'),

--- a/src/schemas/21-686C/schema.js
+++ b/src/schemas/21-686C/schema.js
@@ -67,7 +67,7 @@ const commonAddressFields = {
 };
 
 // 4494 NOTE: It isn't immediately clear to me why these definitions are used for marriage instead
-// of the ones found in ../common/definitions.js. This will require additional investigation. 
+// of the ones found in ../common/definitions.js. This will require additional investigation.
 // For now, I've added marriageType directly to the defintion below.
 
 const commonMarriageDef = {
@@ -75,10 +75,10 @@ const commonMarriageDef = {
   properties: {
     dateOfMarriage: schemaHelpers.getDefinition('date'),
     locationOfMarriage: {
-      $ref: '#/definitions/genericLocation'
+      $ref: '#/definitions/genericLocation',
     },
     marriageType: {
-      type: 'string'
+      type: 'string',
     },
     spouseFullName: schemaHelpers.getDefinition('fullName'),
   },
@@ -93,8 +93,8 @@ const commonMarriagesDef = {
       ...commonMarriageDef.properties,
       dateOfSeparation: schemaHelpers.getDefinition('date'),
       locationOfSeparation: {
-        $ref: '#/definitions/genericLocation'
-      }
+        $ref: '#/definitions/genericLocation',
+      },
     },
     oneOf: [
       {
@@ -232,35 +232,35 @@ const schema = {
           pattern: textRegex,
         },
       },
-      genericLocation: {
-        type: 'string',
-          maxLength: 250,
-          pattern: textAndNumbersRegex  
-      },
-      location: {
-        type: 'object',
-        properties: {},
-        oneOf: [
-          {
-            required: ['countryDropdown', 'city', 'state'],
-            properties: {
-              countryDropdown: {
-                type: 'string',
-                'enum': [countryUSA],
-                default: countryUSA
-              },
-              city: {
-                type: 'string',
-                maxLength: 30,
-                minLength: 1,
-                pattern: textRegex
-              },
-              state: {
-                type: 'string',
-                maxLength: 50,
-                'enum': states50AndDC.map(state => state.value),
-                enumNames: states50AndDC.map(state => state.label)
-              }
+    },
+    genericLocation: {
+      type: 'string',
+      maxLength: 250,
+      pattern: textAndNumbersRegex,
+    },
+    location: {
+      type: 'object',
+      properties: {},
+      oneOf: [
+        {
+          required: ['countryDropdown', 'city', 'state'],
+          properties: {
+            countryDropdown: {
+              type: 'string',
+              enum: [countryUSA],
+              default: countryUSA,
+            },
+            city: {
+              type: 'string',
+              maxLength: 30,
+              minLength: 1,
+              pattern: textRegex,
+            },
+            state: {
+              type: 'string',
+              maxLength: 50,
+              enum: states50AndDC.map(state => state.value),
+              enumNames: states50AndDC.map(state => state.label),
             },
           },
           additionalProperties: false,
@@ -313,6 +313,7 @@ const schema = {
       format: 'email',
     },
     veteranSocialSecurityNumber: { $ref: '#/definitions/ssn' },
+    veteranServiceNumber: { $ref: '#/definitions/veteranServiceNumber' },
     maritalStatus: {
       type: 'string',
       enum: ['MARRIED', 'DIVORCED', 'WIDOWED', 'SEPARATED', 'NEVERMARRIED'],
@@ -389,7 +390,7 @@ const schema = {
           fullName: schemaHelpers.getDefinition('fullName'),
           childDateOfBirth: schemaHelpers.getDefinition('date'),
           childPlaceOfBirth: {
-            $ref: '#/definitions/genericLocation'
+            $ref: '#/definitions/genericLocation',
           },
           childSocialSecurityNumber: { $ref: '#/definitions/ssn' },
           childRelationship: {
@@ -397,18 +398,14 @@ const schema = {
             enum: ['biological', 'adopted', 'stepchild'],
           },
           isSupportingStepchild: {
-            type: 'boolean'
+            type: 'boolean',
           },
           dateStepchildLeftHousehold: {
-            $ref: '#/definitions/date'
+            $ref: '#/definitions/date',
           },
           financialSupportProvided: {
             type: 'string',
-            enum: [
-              'More than half',
-              'Half',
-              'Less than half'
-            ]
+            enum: ['More than half', 'Half', 'Less than half'],
           },
           attendingCollege: {
             type: 'boolean',
@@ -447,36 +444,31 @@ const schema = {
                 properties: {
                   previouslyMarried: {
                     type: 'boolean',
-                    enum: [true]
+                    enum: [true],
                   },
                   reasonMarriageEnded: {
                     type: 'string',
-                    enum: [
-                      'Annulled',
-                      'Declared void'
-                    ]
-                  }
-                }
+                    enum: ['Annulled', 'Declared void'],
+                  },
+                },
               },
               {
                 required: ['dateMarriageEnded'],
                 properties: {
                   previouslyMarried: {
                     type: 'boolean',
-                    enum: [true]
+                    enum: [true],
                   },
                   reasonMarriageEnded: {
                     type: 'string',
-                    enum: [
-                      'Other',
-                    ]
+                    enum: ['Other'],
                   },
                   explainSeparation: {
                     type: 'string',
                     maxLength: 500,
-                    pattern: textAndNumbersRegex
-                  }
-                }
+                    pattern: textAndNumbersRegex,
+                  },
+                },
               },
               {
                 properties: {

--- a/src/schemas/21-686C/schema.js
+++ b/src/schemas/21-686C/schema.js
@@ -19,7 +19,7 @@ const textRegex = '^(?!\\s)(?!.*?\\s{2,})[^<>%$#@!^&*0-9]+$';
 const textAndNumbersRegex = '^(?!\\s)(?!.*?\\s{2,})[^<>%$#@!^&*]+$';
 
 let definitions = _.cloneDeep(originalDefinitions);
-definitions =  _.pick(definitions, 'fullName', 'date', 'ssn');
+definitions =  _.pick(definitions, 'fullName', 'date', 'ssn', 'veteranServiceNumber');
 
 definitions.fullName.properties.first.pattern = textRegex;
 definitions.fullName.properties.last.pattern = textRegex;
@@ -74,12 +74,19 @@ const commonAddressFields = {
   }
 }
 
+// 4494 NOTE: It isn't immediately clear to me why these definitions are used for marriage instead
+// of the ones found in ../common/definitions.js. This will require additional investigation. 
+// For now, I've added marriageType directly to the defintion below.
+
 const commonMarriageDef = {
-  required: ['dateOfMarriage', 'locationOfMarriage', 'spouseFullName'],
+  required: ['dateOfMarriage', 'locationOfMarriage', 'spouseFullName', 'marriageType'],
   properties: {
     dateOfMarriage: schemaHelpers.getDefinition('date'),
     locationOfMarriage: {
       $ref: '#/definitions/location'
+    },
+    marriageType: {
+      type: 'string'
     },
     spouseFullName: schemaHelpers.getDefinition('fullName')
   }
@@ -443,10 +450,10 @@ let schema = {
           disabled: {
             type: 'boolean'
           },
-          previouslyMarried: {
+          previouslyMarried: { // 4494 Note - I think this can be removed from here but....
             type: 'boolean'
           },
-          marriedDate: schemaHelpers.getDefinition('date'),
+          dateMarriageEnded: schemaHelpers.getDefinition('date'),
           childInHousehold: {
             type: 'boolean'
           },
@@ -474,11 +481,38 @@ let schema = {
             type: 'object',
             oneOf: [
               {
-                required: ['marriedDate'],
+                required: ['dateMarriageEnded'],
                 properties: {
                   previouslyMarried: {
                     type: 'boolean',
                     enum: [true]
+                  },
+                  reasonMarriageEnded: {
+                    type: 'string',
+                    enum: [
+                      'Annulled',
+                      'Declared void'
+                    ]
+                  }
+                }
+              },
+              {
+                required: ['dateMarriageEnded'],
+                properties: {
+                  previouslyMarried: {
+                    type: 'boolean',
+                    enum: [true]
+                  },
+                  reasonMarriageEnded: {
+                    type: 'string',
+                    enum: [
+                      'Other',
+                    ]
+                  },
+                  explainSeparation: {
+                    type: 'string',
+                    maxLength: 500,
+                    pattern: textAndNumbersRegex
                   }
                 }
               },

--- a/src/schemas/21-686C/schema.js
+++ b/src/schemas/21-686C/schema.js
@@ -83,7 +83,7 @@ const commonMarriageDef = {
   properties: {
     dateOfMarriage: schemaHelpers.getDefinition('date'),
     locationOfMarriage: {
-      $ref: '#/definitions/location'
+      $ref: '#/definitions/genericLocation'
     },
     marriageType: {
       type: 'string'
@@ -101,7 +101,7 @@ const commonMarriagesDef = {
       ...commonMarriageDef.properties,
       dateOfSeparation: schemaHelpers.getDefinition('date'),
       locationOfSeparation: {
-        $ref: '#/definitions/location'
+        $ref: '#/definitions/genericLocation'
       }
     },
     oneOf: [
@@ -264,6 +264,11 @@ let schema = {
         type: 'string',
         maxLength: 10,
         pattern: '^\\d{5}(?:[- ]?\\d{4})?$'
+      },
+      genericLocation: {
+        type: 'string',
+          maxLength: 250,
+          pattern: textAndNumbersRegex  
       },
       location: {
         type: 'object',
@@ -433,7 +438,7 @@ let schema = {
           fullName: schemaHelpers.getDefinition('fullName'),
           childDateOfBirth: schemaHelpers.getDefinition('date'),
           childPlaceOfBirth: {
-            $ref: '#/definitions/location'
+            $ref: '#/definitions/genericLocation'
           },
           childSocialSecurityNumber: { $ref: '#/definitions/ssn' },
           childRelationship: {
@@ -442,6 +447,20 @@ let schema = {
               'biological',
               'adopted',
               'stepchild'
+            ]
+          },
+          isSupportingStepchild: {
+            type: 'boolean'
+          },
+          dateStepchildLeftHousehold: {
+            $ref: '#/definitions/date'
+          },
+          financialSupportProvided: {
+            type: 'string',
+            enum: [
+              'More than half',
+              'Half',
+              'Less than half'
             ]
           },
           attendingCollege: {

--- a/src/schemas/21-686C/schema.js
+++ b/src/schemas/21-686C/schema.js
@@ -153,7 +153,8 @@ const schema = {
           enumNames: states.map(state => state.label),
         },
         postalCode: {
-          $ref: '#/definitions/postalCode',
+          type: 'string',
+          pattern: '^\\d{5}(?:([-\\s]?)\\d{4})?$',
         },
         countryDropdown: {
           type: 'string',
@@ -188,7 +189,8 @@ const schema = {
           ],
         },
         postalCode: {
-          $ref: '#/definitions/postalCode',
+          type: 'string',
+          pattern: '^\\d{5}(?:([-\\s]?)\\d{4})?$',
         },
       },
       additionalProperties: false,
@@ -393,10 +395,6 @@ const schema = {
             $ref: '#/definitions/genericLocation',
           },
           childSocialSecurityNumber: { $ref: '#/definitions/ssn' },
-          childRelationship: {
-            type: 'string',
-            enum: ['biological', 'adopted', 'stepchild'],
-          },
           isSupportingStepchild: {
             type: 'boolean',
           },
@@ -501,6 +499,60 @@ const schema = {
                 },
               },
             ],
+          },
+        ],
+        anyOf: [
+          {
+            type: 'object',
+            oneOf: [
+              {
+                required: ['isSupportingStepchild'],
+                properties: {
+                  childRelationship: {
+                    type: 'string',
+                    enum: ['stepchild'],
+                  },
+                },
+              },
+              {
+                required: ['financialSupportProvided'],
+                properties: {
+                  childRelationship: {
+                    type: 'string',
+                    enum: ['stepChild'],
+                  },
+                  isSupportingStepchild: {
+                    type: 'boolean',
+                    enum: [true],
+                  },
+                },
+              },
+              {
+                properties: {
+                  childRelationship: {
+                    type: 'string',
+                    enum: ['adopted'],
+                  },
+                },
+              },
+              {
+                properties: {
+                  childRelationship: {
+                    type: 'string',
+                    enum: ['biological'],
+                  },
+                },
+              },
+            ],
+          },
+          {
+            required: ['dateStepchildLeftHousehold'],
+            properties: {
+              childInHousehold: {
+                type: 'boolean',
+                enum: [false],
+              },
+            },
           },
         ],
       },

--- a/test/schemas/21-686C/schema.spec.js
+++ b/test/schemas/21-686C/schema.spec.js
@@ -1,17 +1,17 @@
+import _ from 'lodash';
+import { expect } from 'chai';
 import SchemaTestHelper from '../../support/schema-test-helper';
 import schemas from '../../../dist/schemas';
 import fixtures from '../../support/fixtures';
-import _ from 'lodash';
 import SharedTests from '../../support/shared-tests';
-import { expect } from 'chai';
 
 const schema = schemas['21-686C'];
-let schemaWithoutRequired = _.cloneDeep(schema);
+const schemaWithoutRequired = _.cloneDeep(schema);
 delete schemaWithoutRequired.required;
 delete schemaWithoutRequired.anyOf;
 
-let schemaTestHelper = new SchemaTestHelper(schemaWithoutRequired);
-let sharedTests = new SharedTests(schemaTestHelper);
+const schemaTestHelper = new SchemaTestHelper(schemaWithoutRequired);
+const sharedTests = new SharedTests(schemaTestHelper);
 
 describe('21-686C schema', () => {
   it('should have the right required fields', () => {
@@ -19,15 +19,15 @@ describe('21-686C schema', () => {
       'privacyAgreementAccepted',
       'veteranFullName',
       'veteranAddress',
-      'maritalStatus'
-    ])
+      'maritalStatus',
+    ]);
   });
 
   sharedTests.runTest('fullName', ['veteranFullName']);
   sharedTests.runTest('email', ['veteranEmail']);
   sharedTests.runTest('vaFileNumber', ['vaFileNumber']);
-  sharedTests.runTest('ssn', ['veteranSocialSecurityNumber'])
-  sharedTests.runTest('usaPhone', ['dayPhone', 'nightPhone'])
+  sharedTests.runTest('ssn', ['veteranSocialSecurityNumber']);
+  sharedTests.runTest('usaPhone', ['dayPhone', 'nightPhone']);
 
   const validDependent = {
     fullName: fixtures.fullName,
@@ -36,7 +36,8 @@ describe('21-686C schema', () => {
     childRelationship: 'adopted',
     attendingCollege: true,
     disabled: true,
-    marriedDate: fixtures.date,
+    dateMarriageEnded: fixtures.date,
+    reasonMarriageEnded: 'Declared void',
     previouslyMarried: true,
     childInHousehold: true,
     childAddress: {
@@ -45,68 +46,69 @@ describe('21-686C schema', () => {
       countryDropdown: 'USA',
       addressType: 'DOMESTIC',
       state: 'TX',
-      postalCode: '344546767'
+      postalCode: '344546767',
     },
     childHasNoSsn: false,
-    personWhoLivesWithChild: fixtures.fullName
-  }
+    childHasNoSsnReason: 'NONRESIDENTALIEN',
+    personWhoLivesWithChild: fixtures.fullName,
+  };
 
   schemaTestHelper.testValidAndInvalid('currentMarriage', {
     valid: [
       {
         spouseFullName: fixtures.fullName,
         spouseSocialSecurityNumber: fixtures.ssn,
-        spouseVaFileNumber: 'C1234567'
+        spouseVaFileNumber: 'C1234567',
       },
       {
         spouseFullName: fixtures.fullName,
         spouseHasNoSsn: true,
-        spouseHasNoSsnReason: 'NONRESIDENTALIEN'
-      }
+        spouseHasNoSsnReason: 'NONRESIDENTALIEN',
+      },
     ],
     invalid: [
       {
         dateOfMarriage: fixtures.date,
         locationOfMarriage: {
-          countryDropdown: 'Canada'
+          countryDropdown: 'Canada',
         },
-        spouseFullName: fixtures.fullName
+        spouseFullName: fixtures.fullName,
       },
       {
         dateOfMarriage: fixtures.date,
         locationOfMarriage: {
           countryDropdown: 'Country Not In List',
-          countryText: 'My Island'
+          countryText: 'My Island',
         },
         spouseFullname: fixtures.fullName,
-        spouseSocialSecurityNumber: 'blah'
+        spouseSocialSecurityNumber: 'blah',
       },
       // invalid spouseVaFileNumber
       {
         dateOfMarriage: fixtures.date,
         locationOfMarriage: {
-          countryDropdown: 'Canada'
+          countryDropdown: 'Canada',
         },
         spouseFullName: fixtures.fullName,
         spouseSocialSecurityNumber: fixtures.ssn,
-        spouseVaFileNumber: 'C12345679999'
+        spouseVaFileNumber: 'C12345679999',
       },
       // invalid spouseDateOfBirth
       {
         dateOfMarriage: fixtures.date,
         locationOfMarriage: {
-          countryDropdown: 'Canada'
+          countryDropdown: 'Canada',
         },
         spouseFullName: fixtures.fullName,
         spouseSocialSecurityNumber: fixtures.ssn,
-        spouseDateOfBirth: 'in the past'
+        spouseDateOfBirth: 'in the past',
       },
-    ]
+    ],
   });
 
   schemaTestHelper.testValidAndInvalid('maritalStatus', {
     valid: ['MARRIED', 'DIVORCED', 'WIDOWED', 'SEPARATED', 'NEVERMARRIED'],
-    invalid: ['Divorce']
+    invalid: ['Divorce'],
   });
 
   schemaTestHelper.testValidAndInvalid('marriages', {
@@ -114,105 +116,55 @@ describe('21-686C schema', () => {
       [
         {
           dateOfMarriage: fixtures.date,
-          locationOfMarriage: {
-            countryDropdown: 'Country Not In List',
-            countryText: 'My Island'
-          },
+          locationOfMarriage: 'Washington, DC',
           spouseFullName: fixtures.fullName,
           reasonForSeparation: 'Divorce',
           dateOfSeparation: fixtures.date,
-          locationOfSeparation: {
-            countryDropdown: 'USA',
-            city: 'somewhere',
-            state: 'VA'
-          }
+          locationOfSeparation: 'Washington, DC',
+          marriageType: 'common-law',
         },
         {
           dateOfMarriage: fixtures.date,
-          locationOfMarriage: {
-            countryDropdown: 'Country Not In List',
-            countryText: 'My Island'
-          },
+          locationOfMarriage: 'Washington, DC',
           spouseFullName: fixtures.fullName,
           reasonForSeparation: 'Other',
           explainSeparation: 'irreconcilable differences',
           dateOfSeparation: fixtures.date,
-          locationOfSeparation: {
-            countryDropdown: 'USA',
-            city: 'somewhere',
-            state: 'VA'
-          }
-        }
-      ]
+          locationOfSeparation: 'Washington, DC',
+          marriageType: 'common-law',
+        },
+      ],
     ],
     invalid: [
       [
-        {reasonForSeparation: 'fadsf'},
+        { reasonForSeparation: 'fadsf' },
         // 'Other' without explanation
         {
           dateOfMarriage: fixtures.date,
-          locationOfMarriage: {
-            countryDropdown: 'Country Not In List',
-            countryText: 'My Island'
-          },
+          locationOfMarriage: 'Washington, DC',
           spouseFullName: fixtures.fullName,
           reasonForSeparation: 'Other',
           dateOfSeparation: fixtures.date,
-          locationOfSeparation: {
-            countryDropdown: 'USA',
-            city: 'somewhere',
-            state: 'VA'
-          }
-        }
-      ]
-    ]
+          locationOfSeparation: 'Washington, DC',
+        },
+      ],
+    ],
   });
 
   schemaTestHelper.testValidAndInvalid('dependents', {
     valid: [
       [
-        Object.assign({}, validDependent, {
-          childPlaceOfBirth: {
-            countryDropdown: 'USA',
-            city: 'somewhere',
-            state: 'VA'
-          }
-        })
+        {
+          ...validDependent,
+          childPlaceOfBirth: 'Washington, DC',
+        },
       ],
-      [
-        Object.assign({}, validDependent, {
-          childPlaceOfBirth: {
-            countryDropdown: 'Country Not In List',
-            countryText: 'somewhere'
-          }
-        })
-      ],
-      [
-        Object.assign({}, validDependent, {
-          childPlaceOfBirth: {
-            countryDropdown: 'Canada'
-          }
-        })
-      ]
     ],
     invalid: [
       [{ fullName: 1 }],
-      [_.omit(validDependent, 'marriedDate')],
-      [Object.assign({}, _.omit(validDependent, 'childHasNoSsnReason'), {childHasNoSsn: true})],
-      [Object.assign({}, validDependent, {
-        childPlaceOfBirth: {
-          countryDropdown: 'Canada',
-          city: 'somewhere',
-          state: 'VA'
-        }
-      })],
-      [Object.assign({}, validDependent, {
-        childPlaceOfBirth: {
-          countryDropdown: 'Country Not In List',
-          city: 'somewhere'
-        }
-      })]
-    ]
+      [_.omit(validDependent, 'dateMarriageEnded')],
+      [{ ..._.omit(validDependent, 'childHasNoSsnReason'), childHasNoSsn: true }],
+    ],
   });
 
   schemaTestHelper.testValidAndInvalid('veteranAddress', {
@@ -223,7 +175,7 @@ describe('21-686C schema', () => {
         city: 'anywhere',
         countryDropdown: 'USA',
         state: 'KY',
-        postalCode: '55555'
+        postalCode: '55555',
       },
       {
         addressType: 'MILITARY',
@@ -232,7 +184,7 @@ describe('21-686C schema', () => {
         countryDropdown: 'USA',
         postOffice: 'APO',
         postalType: 'AA',
-        postalCode: '55555'
+        postalCode: '55555',
       },
       {
         addressType: 'INTERNATIONAL',
@@ -245,7 +197,7 @@ describe('21-686C schema', () => {
         street: '123 main st.',
         city: 'anywhere',
         countryDropdown: 'Country Not In List',
-        countryText: 'Independent Nation of Myself'
+        countryText: 'Independent Nation of Myself',
       },
     ],
     invalid: [
@@ -264,7 +216,7 @@ describe('21-686C schema', () => {
         city: 'anywhere',
         countryDropdown: 'Country Not In List',
         state: 'KY',
-        postalCode: '55555'
+        postalCode: '55555',
       },
 
       // INTERNATIONAL with state and postalCode
@@ -273,7 +225,7 @@ describe('21-686C schema', () => {
         street: '123 main st.',
         city: 'anywhere',
         state: 'KY',
-        countryDropdown: 'Bangladesh'
+        countryDropdown: 'Bangladesh',
       },
 
       // INTERNATIONAL with selected country (allowed) and countryText (not allowed)
@@ -282,7 +234,7 @@ describe('21-686C schema', () => {
         street: '123 main st.',
         city: 'anywhere',
         countryDropdown: 'Canada',
-        countryText: 'Independent Nation of Myself'
+        countryText: 'Independent Nation of Myself',
       },
 
       // consecutive spaces present
@@ -292,8 +244,8 @@ describe('21-686C schema', () => {
         city: 'any  where',
         countryDropdown: 'USA',
         state: 'KY',
-        postalCode: '55555'
-      }
-    ]
+        postalCode: '55555',
+      },
+    ],
   });
 });

--- a/test/support/schema-test-helper.js
+++ b/test/support/schema-test-helper.js
@@ -4,17 +4,20 @@ import Ajv from 'ajv';
 const objectBuilder = (keys, value) => {
   let object = {};
 
-  keys.split('.').reverse().forEach((key, i) => {
-    if (i === 0) {
-      object = {
-        [key]: value
-      };
-    } else {
-      object = {
-        [key]: object
-      };
-    }
-  });
+  keys
+    .split('.')
+    .reverse()
+    .forEach((key, i) => {
+      if (i === 0) {
+        object = {
+          [key]: value,
+        };
+      } else {
+        object = {
+          [key]: object,
+        };
+      }
+    });
 
   return object;
 };
@@ -27,7 +30,7 @@ export default class SchemaTestHelper {
   }
 
   validateSchema(data) {
-    return this.ajv.validate(this.schema, Object.assign({}, this.defaults, data));
+    return this.ajv.validate(this.schema, { ...this.defaults, ...data });
   }
 
   schemaExpect(valid, data) {
@@ -39,14 +42,14 @@ export default class SchemaTestHelper {
   }
 
   testValidAndInvalid(parentKey, fields) {
-    ['valid', 'invalid'].forEach((fieldType) => {
+    ['valid', 'invalid'].forEach(fieldType => {
       const valid = fieldType === 'valid';
 
-      fields[fieldType].forEach((values) => {
+      fields[fieldType].forEach(values => {
         it(`should${valid ? '' : "n't"} allow ${parentKey} with ${JSON.stringify(values)}`, () => {
           this.schemaExpect(valid, objectBuilder(parentKey, values));
         });
       });
     });
   }
-};
+}


### PR DESCRIPTION
[Original ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/4494)

## Summary of Issue
- The current workflow in the the 686 supports two of the 8 possible workflows the form can be used for. This ticket is to add fields that are missing to the schema file as well as to create a generic location schema that can be used for multiple location inputs on the form, including the location(s) of marriage(s), so that the existing workflows can map 1 to 1 with the paper form of the 686.
- This PR addresses these issues:
    * Amending how a user enters their location of marriage
    * Adding new properties to the schema that weren't there before.
    * Updating the names for some properties to more closely align with their purpose.

## Considerations
- This is the first of potentially several PRs that will be made to update the 686 schema. As more workflows are added, additional properties will need to be included.