### PR TITLE
add new properties and unit tests to 686c

### DIFF
--- a/dist/21-686C-schema.json
+++ b/dist/21-686C-schema.json
@@ -1730,6 +1730,17 @@
         ]
       }
     },
+    "reportMarriageOfChild": {
+      "type": "object",
+      "properties": {
+        "marriedChildName": {
+          "$ref": "#/definitions/fullName"
+        },
+        "dateChildMarried": {
+          "$ref": "#/definitions/date"
+        }
+      }
+    },
     "privacyAgreementAccepted": {
       "$ref": "#/definitions/privacyAgreementAccepted"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.138.13",
+  "version": "3.138.14",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-686C/schema.js
+++ b/src/schemas/21-686C/schema.js
@@ -557,6 +557,13 @@ const schema = {
         ],
       },
     },
+    reportMarriageOfChild: {
+      type: 'object',
+      properties: {
+        marriedChildName: schemaHelpers.getDefinition('fullName'),
+        dateChildMarried: schemaHelpers.getDefinition('date'),
+      },
+    },
   },
   required: ['privacyAgreementAccepted', 'veteranFullName', 'veteranAddress', 'maritalStatus'],
   anyOf: [

--- a/test/schemas/21-686C/schema.spec.js
+++ b/test/schemas/21-686C/schema.spec.js
@@ -167,6 +167,21 @@ describe('21-686C schema', () => {
     ],
   });
 
+  schemaTestHelper.testValidAndInvalid('reportMarriageOfChild', {
+    valid: [
+      {
+        marriedChildName: fixtures.fullName,
+        dateChildMarried: fixtures.date,
+      },
+    ],
+    invalid: [
+      {
+        marriedChildName: '',
+        dateChildMarried: fixtures.date,
+      },
+    ],
+  });
+
   schemaTestHelper.testValidAndInvalid('veteranAddress', {
     valid: [
       {


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/4908)

The 686c has multiple uses, one of which is reporting the marriage of a child currently on an award. New properties need to be added to the schema which account for this workflow so there can be a 1-1 mapping between schema and frontend form. 

There is an open PR for the corresponding changes into `vets-website` [here](https://github.com/department-of-veterans-affairs/vets-website/pull/11520)

## Testing Done
- Unit tests have been updated to include the new fields. 