### PR TITLE
Remove REAP option from 1995 schema

### DIFF
--- a/dist/22-1995-schema.json
+++ b/dist/22-1995-schema.json
@@ -398,8 +398,7 @@
         "chapter30",
         "chapter1606",
         "transferOfEntitlement",
-        "chapter32",
-        "chapter1607"
+        "chapter32"
       ]
     },
     "educationType": {

--- a/dist/22-1995S-schema.json
+++ b/dist/22-1995S-schema.json
@@ -398,8 +398,7 @@
         "chapter30",
         "chapter1606",
         "transferOfEntitlement",
-        "chapter32",
-        "chapter1607"
+        "chapter32"
       ]
     },
     "educationType": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.138.16",
+  "version": "3.138.15",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.138.15",
+  "version": "3.138.16",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/22-1995/schema.js
+++ b/src/schemas/22-1995/schema.js
@@ -57,7 +57,7 @@ const schema = {
     },
     benefit: {
       type: 'string',
-      enum: ['chapter33', 'chapter30', 'chapter1606', 'transferOfEntitlement', 'chapter32', 'chapter1607'],
+      enum: ['chapter33', 'chapter30', 'chapter1606', 'transferOfEntitlement', 'chapter32'],
     },
     educationType: {
       $ref: '#/definitions/educationType',

--- a/src/schemas/22-1995S/schema.js
+++ b/src/schemas/22-1995S/schema.js
@@ -57,7 +57,7 @@ const schema = {
     },
     benefit: {
       type: 'string',
-      enum: ['chapter33', 'chapter30', 'chapter1606', 'transferOfEntitlement', 'chapter32', 'chapter1607'],
+      enum: ['chapter33', 'chapter30', 'chapter1606', 'transferOfEntitlement', 'chapter32'],
     },
     educationType: {
       $ref: '#/definitions/educationType',


### PR DESCRIPTION
## Description
As a developer, I need to remove the production / feature flag for removing the REAP option from the 1995 so that the update is available in production.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/4939

## Testing done
Local testing completed

## Screenshots

## Acceptance criteria
- [x] Remove REAP option from 1995 form schema.


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
