### PR TITLE
Remove unwanted property from 10203 schema

### DIFF
--- a/dist/22-10203-schema.json
+++ b/dist/22-10203-schema.json
@@ -357,9 +357,6 @@
     "bankAccount": {
       "$ref": "#/definitions/bankAccount"
     },
-    "serviceBefore1977": {
-      "$ref": "#/definitions/serviceBefore1977"
-    },
     "toursOfDuty": {
       "type": "array",
       "items": {

--- a/src/schemas/22-10203/schema.js
+++ b/src/schemas/22-10203/schema.js
@@ -58,9 +58,6 @@ const schema = {
     bankAccount: {
       $ref: '#/definitions/bankAccount',
     },
-    serviceBefore1977: {
-      $ref: '#/definitions/serviceBefore1977',
-    },
     toursOfDuty: {
       type: 'array',
       items: {


### PR DESCRIPTION
Removing the `serviceBefore1977`property  from the 10203 education benefit schema. 