### PR TITLE
Update MDOT Schema to Include `lastFourSsn`

### DIFF
--- a/dist/MDOT-schema.json
+++ b/dist/MDOT-schema.json
@@ -301,6 +301,10 @@
       "enum": [
         true
       ]
+    },
+    "ssnLastFour": {
+      "type": "string",
+      "pattern": "^(?!0000)[0-9]{4}$"
     }
   },
   "properties": {
@@ -318,6 +322,9 @@
     },
     "temporaryAddress": {
       "$ref": "#/definitions/address"
+    },
+    "ssnLastFour": {
+      "$ref": "#/definitions/ssnLastFour"
     },
     "gender": {
       "$ref": "#/definitions/gender"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.142.0",
+  "version": "3.145.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "3.144.2",
+  "version": "3.145.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/MDOT/schema.js
+++ b/src/schemas/MDOT/schema.js
@@ -1,7 +1,7 @@
 import commonDefinitions from '../../common/definitions';
 import schemaHelpers from '../../common/schema-helpers';
 
-const { fullName, email, gender, date, address } = commonDefinitions;
+const { fullName, ssnLastFour, email, gender, date, address } = commonDefinitions;
 
 const supplies = {
   type: 'array',
@@ -62,6 +62,7 @@ const schema = {
   ['fullName', 'fullName'],
   ['address', 'permanentAddress'],
   ['address', 'temporaryAddress'],
+  ['ssnLastFour', 'ssnLastFour'],
   ['gender'],
   ['date', 'dateOfBirth'],
   ['supplies']


### PR DESCRIPTION
Adds a `lastFourSsn` field to the schema for MDOT. This is required in our mockups as part of our validation veterans will check prior to going through the flow to order medical devices and/or accessories.