### PR TITLE
Fix states constants

### DIFF
--- a/dist/constants.json
+++ b/dist/constants.json
@@ -1,4 +1,741 @@
 {
+  "addressPou": {
+    "correspondence": "CORRESPONDENCE",
+    "residence": "RESIDENCE/CHOICE"
+  },
+  "addressTypes": {
+    "domestic": "DOMESTIC",
+    "international": "INTERNATIONAL",
+    "overseasMilitary": "OVERSEAS MILITARY"
+  },
+  "branchesServed": [
+    {
+      "value": "air force",
+      "label": "Air Force"
+    },
+    {
+      "value": "army",
+      "label": "Army"
+    },
+    {
+      "value": "coast guard",
+      "label": "Coast Guard"
+    },
+    {
+      "value": "marine corps",
+      "label": "Marine Corps"
+    },
+    {
+      "value": "merchant seaman",
+      "label": "Merchant Seaman"
+    },
+    {
+      "value": "navy",
+      "label": "Navy"
+    },
+    {
+      "value": "noaa",
+      "label": "Noaa"
+    },
+    {
+      "value": "usphs",
+      "label": "USPHS"
+    },
+    {
+      "value": "f.commonwealth",
+      "label": "Filipino Commonwealth Army"
+    },
+    {
+      "value": "f.guerilla",
+      "label": "Filipino Guerilla Forces"
+    },
+    {
+      "value": "f.scouts new",
+      "label": "Filipino New Scout"
+    },
+    {
+      "value": "f.scouts old",
+      "label": "Filipino Old Scout"
+    },
+    {
+      "value": "other",
+      "label": "Other"
+    }
+  ],
+  "caregiverProgramFacilities": {
+    "TX": [
+      {
+        "code": "740",
+        "label": "HARLINGEN VA CLINIC"
+      },
+      {
+        "code": "756",
+        "label": "EL PASO HCS"
+      },
+      {
+        "code": "580",
+        "label": "MICHAEL E. DEBAKEY VA MEDICAL CENTER"
+      },
+      {
+        "code": "504",
+        "label": "AMARILLO HCS"
+      },
+      {
+        "code": "519",
+        "label": "WEST TEXAS VA HEALTH CARE SYSTEM - BIG SPRING DIVISION"
+      },
+      {
+        "code": "549",
+        "label": "DALLAS VA MEDICAL CENTER"
+      },
+      {
+        "code": "671",
+        "label": "AUDIE L. MURPHY MEMORIAL HOSP"
+      },
+      {
+        "code": "674",
+        "label": "OLIN E. TEAGUE VET CENTER"
+      }
+    ],
+    "SD": [
+      {
+        "code": "568A4",
+        "label": "HOT SPRINGS, SD MC"
+      },
+      {
+        "code": "438",
+        "label": "SIOUX FALLS VA HCS"
+      },
+      {
+        "code": "568",
+        "label": "BLACK HILLS HEALTH CARE SYSTEM - FT. MEADE DIVISION"
+      }
+    ],
+    "KS": [
+      {
+        "code": "589A6",
+        "label": "DWIGHT D. EISENHOWER VAMC"
+      },
+      {
+        "code": "589A5",
+        "label": "COLMERY O NEIL VAMC"
+      },
+      {
+        "code": "589A7",
+        "label": "ROBERT J. DOLE VAMC"
+      }
+    ],
+    "CA": [
+      {
+        "code": "612A4",
+        "label": "SACRAMENTO VA MEDICAL CENTER"
+      },
+      {
+        "code": "570",
+        "label": "FRESNO VA MEDICAL CENTER"
+      },
+      {
+        "code": "640",
+        "label": "PALO ALTO VA MEDICAL CENTER"
+      },
+      {
+        "code": "662",
+        "label": "SAN FRANCISCO VAMC"
+      },
+      {
+        "code": "600",
+        "label": "VA LONG BEACH HEALTHCARE SYSTEM"
+      },
+      {
+        "code": "605",
+        "label": "LOMA LINDA HCS"
+      },
+      {
+        "code": "664",
+        "label": "VA SAN DIEGO HEALTHCARE SYSTEM (664)"
+      },
+      {
+        "code": "691",
+        "label": "VA GREATER LOS ANGELES HEALTHCARE SYSTEM - WEST LOS ANGELES DIVISION"
+      }
+    ],
+    "ME": [
+      {
+        "code": "402",
+        "label": "MAINE VA HCS"
+      }
+    ],
+    "VT": [
+      {
+        "code": "405",
+        "label": "WHITE RIVER JCT VAMROC"
+      }
+    ],
+    "MA": [
+      {
+        "code": "518",
+        "label": "EDITH NOURSE ROGERS VAMC"
+      },
+      {
+        "code": "523",
+        "label": "VA BOSTON HEALTHCARE SYSTEM - BOSTON DIVISION"
+      },
+      {
+        "code": "631",
+        "label": "VA CNTRL WSTRN MASSCHUSETS HCS"
+      }
+    ],
+    "NH": [
+      {
+        "code": "608",
+        "label": "MANCHESTER VAMC"
+      }
+    ],
+    "RI": [
+      {
+        "code": "650",
+        "label": "PROVIDENCE VAMC"
+      }
+    ],
+    "CT": [
+      {
+        "code": "689",
+        "label": "VA CONNECTICUT HEALTHCARE SYSTEM - WEST HAVEN DIVISION"
+      }
+    ],
+    "MI": [
+      {
+        "code": "506",
+        "label": "ANN ARBOR VA MEDICAL CENTER"
+      },
+      {
+        "code": "515",
+        "label": "BATTLE CREEK VA MEDICAL CENTER"
+      },
+      {
+        "code": "553",
+        "label": "JOHN D. DINGELL VAMC"
+      },
+      {
+        "code": "655",
+        "label": "ALEDA E. LUTZ VAMC"
+      },
+      {
+        "code": "585",
+        "label": "IRON MOUNTAIN VA MEDICAL CENTER"
+      }
+    ],
+    "OH": [
+      {
+        "code": "538",
+        "label": "CHILLICOTHE VA MEDICAL CENTER"
+      },
+      {
+        "code": "539",
+        "label": "CINCINNATI VAMC"
+      },
+      {
+        "code": "541",
+        "label": "CLEVELAND VAMC"
+      },
+      {
+        "code": "552",
+        "label": "DAYTON, OH VAMC"
+      },
+      {
+        "code": "757",
+        "label": "CHALMERS P. WYLIE VA AMBULATORY CARE CENTER (757)"
+      }
+    ],
+    "IN": [
+      {
+        "code": "583",
+        "label": "RICHARD L. ROUDEBUSH VAMC"
+      },
+      {
+        "code": "610",
+        "label": "MARION VA MEDICAL CENTER"
+      }
+    ],
+    "IL": [
+      {
+        "code": "537",
+        "label": "JESSE BROWN VA MEDICAL CENTER"
+      },
+      {
+        "code": "550",
+        "label": "DANVILLE VA MEDICAL CENTER"
+      },
+      {
+        "code": "556",
+        "label": "CAPTN JAMES LOVELL FED HLT CTR"
+      },
+      {
+        "code": "578",
+        "label": "EDWARD J. HINES JR. HOSPITAL"
+      },
+      {
+        "code": "657A5",
+        "label": "MARION VA MEDICAL CENTER"
+      }
+    ],
+    "WI": [
+      {
+        "code": "607",
+        "label": "WILLIAM S. MIDDLETON MEMORIAL VA HOSPITAL"
+      },
+      {
+        "code": "676",
+        "label": "TOMAH VAMC"
+      },
+      {
+        "code": "695",
+        "label": "CLEMENT J ZABLOCKI"
+      }
+    ],
+    "MO": [
+      {
+        "code": "589",
+        "label": "KANSAS CITY VAMC"
+      },
+      {
+        "code": "589A4",
+        "label": "HARRY S. TRUMAN VAMC"
+      },
+      {
+        "code": "657",
+        "label": "VA HEARTLAND-EAST, VISN 15 HCS JOHN COCHRAN MEMORIAL HOSPITAL"
+      },
+      {
+        "code": "657A4",
+        "label": "JOHN PERSHING VAMC"
+      }
+    ],
+    "LA": [
+      {
+        "code": "502",
+        "label": "ALEXANDRIA VA MEDICAL CENTER"
+      },
+      {
+        "code": "629",
+        "label": "NEW ORLEANS VAMC"
+      },
+      {
+        "code": "667",
+        "label": "OVERTON BROOKS VA MEDICAL CENTER"
+      }
+    ],
+    "MS": [
+      {
+        "code": "520",
+        "label": "BILOXI VA MEDICAL CENTER"
+      },
+      {
+        "code": "586",
+        "label": "G.V. (SONNY) MONTGOMERY"
+      }
+    ],
+    "AR": [
+      {
+        "code": "564",
+        "label": "FAYETTEVILLE VA MEDICAL"
+      },
+      {
+        "code": "598",
+        "label": "CENTRAL ARKANSAS HEALTH CARE SYSTEM - LITTLE ROCK"
+      }
+    ],
+    "MT": [
+      {
+        "code": "436",
+        "label": "FORT HARRISON MEDICAL CENTER"
+      }
+    ],
+    "WY": [
+      {
+        "code": "442",
+        "label": "CHEYENNE VA MEDICAL"
+      },
+      {
+        "code": "666",
+        "label": "SHERIDAN VA MEDICAL CENTER"
+      }
+    ],
+    "CO": [
+      {
+        "code": "554",
+        "label": "ROCKY MOUNTAIN REGIONAL VAMC"
+      },
+      {
+        "code": "575",
+        "label": "GRAND JUNCTION VAMC"
+      }
+    ],
+    "OK": [
+      {
+        "code": "623",
+        "label": "MUSKOGEE, OK VAMC"
+      },
+      {
+        "code": "635",
+        "label": "OKLAHOMA CITY VA MEDICAL CENTER"
+      }
+    ],
+    "UT": [
+      {
+        "code": "660",
+        "label": "GEORGE E. WAHLEN VAMC"
+      }
+    ],
+    "NY": [
+      {
+        "code": "526",
+        "label": "BRONX VA HOSPITAL"
+      },
+      {
+        "code": "528",
+        "label": "BUFFALO VA MEDICAL CENTER"
+      },
+      {
+        "code": "528A5",
+        "label": "CANANDAIGUA VA MEDICAL CENTER"
+      },
+      {
+        "code": "528A6",
+        "label": "BATH VA MEDICAL CENTER"
+      },
+      {
+        "code": "528A7",
+        "label": "SYRACUSE VA MEDICAL CENTER"
+      },
+      {
+        "code": "528A8",
+        "label": "SAMUEL S. STRATTON VAMC"
+      },
+      {
+        "code": "620",
+        "label": "VA HUDSON VALLEY HEALTH CARE SYSTEM - MONTROSE DIVISION"
+      },
+      {
+        "code": "630",
+        "label": "VA NEW YORK HARBOR HEALTHCARE SYSTEM - NEW YORK DIVISION"
+      },
+      {
+        "code": "632",
+        "label": "NORTHPORT VAMC NY"
+      }
+    ],
+    "NJ": [
+      {
+        "code": "561",
+        "label": "NEW JERSEY HEALTH CARE SYSTEM - EAST ORANGE"
+      }
+    ],
+    "AK": [
+      {
+        "code": "463",
+        "label": "ANCHORAGE VA MEDICAL CENTER"
+      }
+    ],
+    "ID": [
+      {
+        "code": "531",
+        "label": "BOISE VA MEDICAL CENTER"
+      }
+    ],
+    "OR": [
+      {
+        "code": "648",
+        "label": "PORTLAND VA MEDICAL CENTER"
+      },
+      {
+        "code": "653",
+        "label": "ROSEBURG VA MEDICAL CENTER"
+      },
+      {
+        "code": "692",
+        "label": "WHITE CITY VA MEDICAL CENTER"
+      }
+    ],
+    "WA": [
+      {
+        "code": "663",
+        "label": "SEATTLE VA MEDICAL CENTER"
+      },
+      {
+        "code": "668",
+        "label": "MANN-GRANDSTAFF VAMC"
+      },
+      {
+        "code": "687",
+        "label": "JONATHAN M. WAINWRIGHT VAMC"
+      }
+    ],
+    "HI": [
+      {
+        "code": "459",
+        "label": "SPARK M. MATSUNAGA VAMC"
+      }
+    ],
+    "NV": [
+      {
+        "code": "593",
+        "label": "SOUTHERN NEVADA HCS"
+      },
+      {
+        "code": "654",
+        "label": "IOANNIS A. LOUGARIS VAMC"
+      }
+    ],
+    "NM": [
+      {
+        "code": "501",
+        "label": "RAYMOND G. MURPHY VAMC"
+      }
+    ],
+    "AZ": [
+      {
+        "code": "644",
+        "label": "PHOENIX VAMC"
+      },
+      {
+        "code": "649",
+        "label": "NORTHERN ARIZONA HEALTH CARE SYSTEM - PRESCOTT DIVISION"
+      },
+      {
+        "code": "678",
+        "label": "SOUTHERN ARIZONA HEALTH CARE SYSTEM - TUCSON DIVISION"
+      }
+    ],
+    "ND": [
+      {
+        "code": "437",
+        "label": "FARGO VA HCS"
+      }
+    ],
+    "MN": [
+      {
+        "code": "618",
+        "label": "MINNEAPOLIS VA HCS"
+      },
+      {
+        "code": "656",
+        "label": "ST. CLOUD VA HEALTH CARE SYSTEM"
+      }
+    ],
+    "NE": [
+      {
+        "code": "636",
+        "label": "VA CENTRAL PLAINS HEALTH NETWORK - OMAHA DIVISION"
+      }
+    ],
+    "IA": [
+      {
+        "code": "636A6",
+        "label": "VA CIHS, DES MOINES DIVISION"
+      },
+      {
+        "code": "636A8",
+        "label": "IOWA CITY HCS"
+      }
+    ],
+    "DE": [
+      {
+        "code": "460",
+        "label": "WILMINGTON VA MEDICAL CENTER"
+      }
+    ],
+    "PA": [
+      {
+        "code": "503",
+        "label": "JAMES E VAN ZANDT VAMC"
+      },
+      {
+        "code": "529",
+        "label": "ABIE ABRAHAM VA CLINIC"
+      },
+      {
+        "code": "542",
+        "label": "COATESVILLE VA MEDICAL CENTER"
+      },
+      {
+        "code": "562",
+        "label": "ERIE VA MEDICAL CENTER"
+      },
+      {
+        "code": "595",
+        "label": "LEBANON VA MEDICAL CENTER"
+      },
+      {
+        "code": "642",
+        "label": "PHILADELPHIA, PA VAMC"
+      },
+      {
+        "code": "646",
+        "label": "PITTSBURGH VAMC UNIVERSITY DR."
+      },
+      {
+        "code": "693",
+        "label": "WILKES-BARRE VAMC"
+      }
+    ],
+    "MD": [
+      {
+        "code": "512",
+        "label": "VA MARYLAND HEALTH CARE SYS"
+      }
+    ],
+    "WV": [
+      {
+        "code": "517",
+        "label": "BECKLEY VA MEDICAL CENTER"
+      },
+      {
+        "code": "540",
+        "label": "LOUIS A JOHNSON VAMC"
+      },
+      {
+        "code": "581",
+        "label": "HUNTINGTON VAMC"
+      },
+      {
+        "code": "613",
+        "label": "MARTINSBURG VA MEDICAL CENTER"
+      }
+    ],
+    "DC": [
+      {
+        "code": "688",
+        "label": "WASHINGTON VA MEDICAL CENTER"
+      }
+    ],
+    "NC": [
+      {
+        "code": "558",
+        "label": "DURHAM VA MEDICAL CENTER"
+      },
+      {
+        "code": "565",
+        "label": "FAYETTEVILLE VA MEDICAL CENTER"
+      },
+      {
+        "code": "637",
+        "label": "CHARLES GEORGE VAMC"
+      },
+      {
+        "code": "659",
+        "label": "W.G. HEFNER SALISBURY VAMC"
+      }
+    ],
+    "VA": [
+      {
+        "code": "590",
+        "label": "HAMPTON VA MEDICAL CENTER"
+      },
+      {
+        "code": "652",
+        "label": "HUNTER HOLMES MCGUIRE HOSPITAL"
+      },
+      {
+        "code": "658",
+        "label": "SALEM VA MEDICAL CENTER"
+      }
+    ],
+    "GA": [
+      {
+        "code": "508",
+        "label": "ATLANTA VAMC"
+      },
+      {
+        "code": "509",
+        "label": "AUGUSTA VAMC"
+      },
+      {
+        "code": "557",
+        "label": "DUBLIN"
+      }
+    ],
+    "AL": [
+      {
+        "code": "521",
+        "label": "BIRMINGHAM VAMC"
+      },
+      {
+        "code": "619",
+        "label": "CENTRAL ALABAMA HEALTH CARE SYSTEM - MONTGOMERY DIVISION"
+      },
+      {
+        "code": "679",
+        "label": "TUSCALOOSA VA MEDICAL CENTER"
+      }
+    ],
+    "SC": [
+      {
+        "code": "534",
+        "label": "RALPH H. JOHNSON VA MEDICAL CENTER (534)"
+      },
+      {
+        "code": "544",
+        "label": "WM JENNINGS BRYAN DORN VETERANS AFFAIRS MEDICAL CENTER"
+      }
+    ],
+    "FL": [
+      {
+        "code": "516",
+        "label": "C.W. BILL YOUNG DEPT OF VAMC"
+      },
+      {
+        "code": "546",
+        "label": "BRUCE W. CARTER DEPT OF VAMC"
+      },
+      {
+        "code": "548",
+        "label": "WEST PALM BEACH VAMC"
+      },
+      {
+        "code": "573",
+        "label": "MALCOM RANDALL DEPT OF VAMC"
+      },
+      {
+        "code": "673",
+        "label": "JAMES A. HALEY VETERANS HOSP"
+      },
+      {
+        "code": "675",
+        "label": "ORLANDO VAMC"
+      }
+    ],
+    "PR": [
+      {
+        "code": "672",
+        "label": "SAN JUAN VA MEDICAL CENTER"
+      }
+    ],
+    "KY": [
+      {
+        "code": "596",
+        "label": "LEXINGTON VAMC-LEESTOWN"
+      },
+      {
+        "code": "603",
+        "label": "ROBLEY REX VAMC"
+      }
+    ],
+    "TN": [
+      {
+        "code": "614",
+        "label": "MEMPHIS VA MEDICAL CENTER"
+      },
+      {
+        "code": "621",
+        "label": "JAMES H. QUILLEN VAMC"
+      },
+      {
+        "code": "626",
+        "label": "TENNESSEE VALLEY HCS"
+      }
+    ]
+  },
   "countries": [
     {
       "value": "USA",
@@ -913,6 +1650,631 @@
       "label": "Zimbabwe"
     }
   ],
+  "days": {
+    "1": [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30",
+      "31"
+    ],
+    "2": [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29"
+    ],
+    "3": [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30",
+      "31"
+    ],
+    "4": [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30"
+    ],
+    "5": [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30",
+      "31"
+    ],
+    "6": [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30"
+    ],
+    "7": [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30",
+      "31"
+    ],
+    "8": [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30",
+      "31"
+    ],
+    "9": [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30"
+    ],
+    "10": [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30",
+      "31"
+    ],
+    "11": [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30"
+    ],
+    "12": [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "30",
+      "31"
+    ]
+  },
+  "dependentRelationships": [
+    "Daughter",
+    "Son",
+    "Stepson",
+    "Stepdaughter",
+    "Father",
+    "Mother",
+    "Spouse",
+    "Other"
+  ],
+  "dischargeTypes": [
+    {
+      "value": "honorable",
+      "label": "Honorable"
+    },
+    {
+      "value": "general",
+      "label": "General"
+    },
+    {
+      "value": "other",
+      "label": "Other Than Honorable"
+    },
+    {
+      "value": "bad-conduct",
+      "label": "Bad Conduct"
+    },
+    {
+      "value": "dishonorable",
+      "label": "Dishonorable"
+    },
+    {
+      "value": "undesirable",
+      "label": "Undesirable"
+    }
+  ],
+  "documentTypes526": [
+    {
+      "value": "L015",
+      "label": "Buddy/Lay Statement"
+    },
+    {
+      "value": "L018",
+      "label": "Civilian Police Reports"
+    },
+    {
+      "value": "L029",
+      "label": "Copy of a DD214"
+    },
+    {
+      "value": "L702",
+      "label": "Disability Benefits Questionnaire (DBQ)"
+    },
+    {
+      "value": "L703",
+      "label": "Goldmann Perimetry Chart/Field Of Vision Chart"
+    },
+    {
+      "value": "L034",
+      "label": "Military Personnel Record"
+    },
+    {
+      "value": "L478",
+      "label": "Medical Treatment Records - Furnished by SSA"
+    },
+    {
+      "value": "L048",
+      "label": "Medical Treatment Record - Government Facility"
+    },
+    {
+      "value": "L049",
+      "label": "Medical Treatment Record - Non-Government Facility"
+    },
+    {
+      "value": "L023",
+      "label": "Other Correspondence"
+    },
+    {
+      "value": "L070",
+      "label": "Photographs"
+    },
+    {
+      "value": "L450",
+      "label": "STR - Dental - Photocopy"
+    },
+    {
+      "value": "L451",
+      "label": "STR - Medical - Photocopy"
+    },
+    {
+      "value": "L222",
+      "label": "VA Form 21-0779 - Request for Nursing Home Information in Connection with Claim for Aid & Attendance"
+    },
+    {
+      "value": "L228",
+      "label": "VA Form 21-0781 - Statement in Support of Claim for PTSD"
+    },
+    {
+      "value": "L229",
+      "label": "VA Form 21-0781a - Statement in Support of Claim for PTSD Secondary to Personal Assault"
+    },
+    {
+      "value": "L102",
+      "label": "VA Form 21-2680 - Examination for Housebound Status or Permanent Need for Regular Aid & Attendance"
+    },
+    {
+      "value": "L107",
+      "label": "VA Form 21-4142 - Authorization To Disclose Information"
+    },
+    {
+      "value": "L827",
+      "label": "VA Form 21-4142a - General Release for Medical Provider Information"
+    },
+    {
+      "value": "L115",
+      "label": "VA Form 21-4192 - Request for Employment Information in Connection with Claim for Disability"
+    },
+    {
+      "value": "L117",
+      "label": "VA Form 21-4502 - Application for Automobile or Other Conveyance and Adaptive Equipment Under 38 U.S.C. 3901-3904"
+    },
+    {
+      "value": "L159",
+      "label": "VA Form 26-4555 - Application in Acquiring Specially Adapted Housing or Special Home Adaptation Grant"
+    },
+    {
+      "value": "L133",
+      "label": "VA Form 21-674 - Request for Approval of School Attendance"
+    },
+    {
+      "value": "L139",
+      "label": "VA Form 21-686c - Declaration of Status of Dependents"
+    },
+    {
+      "value": "L149",
+      "label": "VA Form 21-8940 - Veterans Application for Increased Compensation Based on Un-employability"
+    }
+  ],
+  "genders": [
+    {
+      "label": "Female",
+      "value": "F"
+    },
+    {
+      "label": "Male",
+      "value": "M"
+    }
+  ],
+  "maritalStatuses": [
+    "Married",
+    "Never Married",
+    "Separated",
+    "Widowed",
+    "Divorced"
+  ],
+  "militaryCities": [
+    {
+      "label": "Army Post Office",
+      "value": "APO"
+    },
+    {
+      "label": "Fleet Post Office",
+      "value": "FPO"
+    },
+    {
+      "label": "Diplomatic Post Office",
+      "value": "DPO"
+    }
+  ],
+  "militaryStates": [
+    {
+      "label": "Armed Forces Americas (AA)",
+      "value": "AA"
+    },
+    {
+      "label": "Armed Forces Europe (AE)",
+      "value": "AE"
+    },
+    {
+      "label": "Armed Forces Pacific (AP)",
+      "value": "AP"
+    }
+  ],
+  "months": [
+    {
+      "label": "Jan",
+      "value": 1
+    },
+    {
+      "label": "Feb",
+      "value": 2
+    },
+    {
+      "label": "Mar",
+      "value": 3
+    },
+    {
+      "label": "Apr",
+      "value": 4
+    },
+    {
+      "label": "May",
+      "value": 5
+    },
+    {
+      "label": "Jun",
+      "value": 6
+    },
+    {
+      "label": "Jul",
+      "value": 7
+    },
+    {
+      "label": "Aug",
+      "value": 8
+    },
+    {
+      "label": "Sep",
+      "value": 9
+    },
+    {
+      "label": "Oct",
+      "value": 10
+    },
+    {
+      "label": "Nov",
+      "value": 11
+    },
+    {
+      "label": "Dec",
+      "value": 12
+    }
+  ],
   "pciuCountries": [
     "Afghanistan",
     "Albania",
@@ -1127,529 +2489,6 @@
     "Zambia",
     "Zimbabwe"
   ],
-  "maritalStatuses": [
-    "Married",
-    "Never Married",
-    "Separated",
-    "Widowed",
-    "Divorced"
-  ],
-  "branchesServed": [
-    {
-      "value": "air force",
-      "label": "Air Force"
-    },
-    {
-      "value": "army",
-      "label": "Army"
-    },
-    {
-      "value": "coast guard",
-      "label": "Coast Guard"
-    },
-    {
-      "value": "marine corps",
-      "label": "Marine Corps"
-    },
-    {
-      "value": "merchant seaman",
-      "label": "Merchant Seaman"
-    },
-    {
-      "value": "navy",
-      "label": "Navy"
-    },
-    {
-      "value": "noaa",
-      "label": "Noaa"
-    },
-    {
-      "value": "usphs",
-      "label": "USPHS"
-    },
-    {
-      "value": "f.commonwealth",
-      "label": "Filipino Commonwealth Army"
-    },
-    {
-      "value": "f.guerilla",
-      "label": "Filipino Guerilla Forces"
-    },
-    {
-      "value": "f.scouts new",
-      "label": "Filipino New Scout"
-    },
-    {
-      "value": "f.scouts old",
-      "label": "Filipino Old Scout"
-    },
-    {
-      "value": "other",
-      "label": "Other"
-    }
-  ],
-  "dischargeTypes": [
-    {
-      "value": "honorable",
-      "label": "Honorable"
-    },
-    {
-      "value": "general",
-      "label": "General"
-    },
-    {
-      "value": "other",
-      "label": "Other Than Honorable"
-    },
-    {
-      "value": "bad-conduct",
-      "label": "Bad Conduct"
-    },
-    {
-      "value": "dishonorable",
-      "label": "Dishonorable"
-    },
-    {
-      "value": "undesirable",
-      "label": "Undesirable"
-    }
-  ],
-  "states": {
-    "CAN": [
-      {
-        "label": "Alberta",
-        "value": "AB"
-      },
-      {
-        "label": "British Columbia",
-        "value": "BC"
-      },
-      {
-        "label": "Manitoba",
-        "value": "MB"
-      },
-      {
-        "label": "New Brunswick",
-        "value": "NB"
-      },
-      {
-        "label": "Newfoundland",
-        "value": "NF"
-      },
-      {
-        "label": "Northwest Territories",
-        "value": "NT"
-      },
-      {
-        "label": "Nova Scotia",
-        "value": "NV"
-      },
-      {
-        "label": "Nunavut Province",
-        "value": "NU"
-      },
-      {
-        "label": "Ontario",
-        "value": "ON"
-      },
-      {
-        "label": "Prince Edward Island",
-        "value": "PE"
-      },
-      {
-        "label": "Quebec",
-        "value": "QC"
-      },
-      {
-        "label": "Saskatchewan",
-        "value": "SK"
-      },
-      {
-        "label": "Yukon Territory",
-        "value": "YT"
-      }
-    ],
-    "MEX": [
-      {
-        "label": "Aguascalientes",
-        "value": "aguascalientes"
-      },
-      {
-        "label": "Baja California Norte",
-        "value": "baja-california-norte"
-      },
-      {
-        "label": "Baja California Sur",
-        "value": "baja-california-sur"
-      },
-      {
-        "label": "Campeche",
-        "value": "campeche"
-      },
-      {
-        "label": "Chiapas",
-        "value": "chiapas"
-      },
-      {
-        "label": "Chihuahua",
-        "value": "chihuahua"
-      },
-      {
-        "label": "Coahuila",
-        "value": "coahuila"
-      },
-      {
-        "label": "Colima",
-        "value": "colima"
-      },
-      {
-        "label": "Distrito Federal",
-        "value": "distrito-federal"
-      },
-      {
-        "label": "Durango",
-        "value": "durango"
-      },
-      {
-        "label": "Guanajuato",
-        "value": "guanajuato"
-      },
-      {
-        "label": "Guerrero",
-        "value": "guerrero"
-      },
-      {
-        "label": "Hidalgo",
-        "value": "hidalgo"
-      },
-      {
-        "label": "Jalisco",
-        "value": "jalisco"
-      },
-      {
-        "label": "México",
-        "value": "mexico"
-      },
-      {
-        "label": "Michoacán",
-        "value": "michoacan"
-      },
-      {
-        "label": "Morelos",
-        "value": "morelos"
-      },
-      {
-        "label": "Nayarit",
-        "value": "nayarit"
-      },
-      {
-        "label": "Nuevo León",
-        "value": "nuevo-leon"
-      },
-      {
-        "label": "Oaxaca",
-        "value": "oaxaca"
-      },
-      {
-        "label": "Puebla",
-        "value": "puebla"
-      },
-      {
-        "label": "Querétaro",
-        "value": "queretaro"
-      },
-      {
-        "label": "Quintana Roo",
-        "value": "quintana-roo"
-      },
-      {
-        "label": "San Luis Potosí",
-        "value": "san-luis-potosi"
-      },
-      {
-        "label": "Sinaloa",
-        "value": "sinaloa"
-      },
-      {
-        "label": "Sonora",
-        "value": "sonora"
-      },
-      {
-        "label": "Tabasco",
-        "value": "tabasco"
-      },
-      {
-        "label": "Tamaulipas",
-        "value": "tamaulipas"
-      },
-      {
-        "label": "Tlaxcala",
-        "value": "tlaxcala"
-      },
-      {
-        "label": "Veracruz",
-        "value": "veracruz"
-      },
-      {
-        "label": "Yucatán",
-        "value": "yucatan"
-      },
-      {
-        "label": "Zacatecas",
-        "value": "zacatecas"
-      }
-    ],
-    "USA": [
-      {
-        "label": "Alabama",
-        "value": "AL"
-      },
-      {
-        "label": "Alaska",
-        "value": "AK"
-      },
-      {
-        "label": "American Samoa",
-        "value": "AS"
-      },
-      {
-        "label": "Arizona",
-        "value": "AZ"
-      },
-      {
-        "label": "Arkansas",
-        "value": "AR"
-      },
-      {
-        "label": "Armed Forces Americas (AA)",
-        "value": "AA"
-      },
-      {
-        "label": "Armed Forces Europe (AE)",
-        "value": "AE"
-      },
-      {
-        "label": "Armed Forces Pacific (AP)",
-        "value": "AP"
-      },
-      {
-        "label": "California",
-        "value": "CA"
-      },
-      {
-        "label": "Colorado",
-        "value": "CO"
-      },
-      {
-        "label": "Connecticut",
-        "value": "CT"
-      },
-      {
-        "label": "Delaware",
-        "value": "DE"
-      },
-      {
-        "label": "District Of Columbia",
-        "value": "DC"
-      },
-      {
-        "label": "Federated States Of Micronesia",
-        "value": "FM"
-      },
-      {
-        "label": "Florida",
-        "value": "FL"
-      },
-      {
-        "label": "Georgia",
-        "value": "GA"
-      },
-      {
-        "label": "Guam",
-        "value": "GU"
-      },
-      {
-        "label": "Hawaii",
-        "value": "HI"
-      },
-      {
-        "label": "Idaho",
-        "value": "ID"
-      },
-      {
-        "label": "Illinois",
-        "value": "IL"
-      },
-      {
-        "label": "Indiana",
-        "value": "IN"
-      },
-      {
-        "label": "Iowa",
-        "value": "IA"
-      },
-      {
-        "label": "Kansas",
-        "value": "KS"
-      },
-      {
-        "label": "Kentucky",
-        "value": "KY"
-      },
-      {
-        "label": "Louisiana",
-        "value": "LA"
-      },
-      {
-        "label": "Maine",
-        "value": "ME"
-      },
-      {
-        "label": "Marshall Islands",
-        "value": "MH"
-      },
-      {
-        "label": "Maryland",
-        "value": "MD"
-      },
-      {
-        "label": "Massachusetts",
-        "value": "MA"
-      },
-      {
-        "label": "Michigan",
-        "value": "MI"
-      },
-      {
-        "label": "Minnesota",
-        "value": "MN"
-      },
-      {
-        "label": "Mississippi",
-        "value": "MS"
-      },
-      {
-        "label": "Missouri",
-        "value": "MO"
-      },
-      {
-        "label": "Montana",
-        "value": "MT"
-      },
-      {
-        "label": "Nebraska",
-        "value": "NE"
-      },
-      {
-        "label": "Nevada",
-        "value": "NV"
-      },
-      {
-        "label": "New Hampshire",
-        "value": "NH"
-      },
-      {
-        "label": "New Jersey",
-        "value": "NJ"
-      },
-      {
-        "label": "New Mexico",
-        "value": "NM"
-      },
-      {
-        "label": "New York",
-        "value": "NY"
-      },
-      {
-        "label": "North Carolina",
-        "value": "NC"
-      },
-      {
-        "label": "North Dakota",
-        "value": "ND"
-      },
-      {
-        "label": "Northern Mariana Islands",
-        "value": "MP"
-      },
-      {
-        "label": "Ohio",
-        "value": "OH"
-      },
-      {
-        "label": "Oklahoma",
-        "value": "OK"
-      },
-      {
-        "label": "Oregon",
-        "value": "OR"
-      },
-      {
-        "label": "Palau",
-        "value": "PW"
-      },
-      {
-        "label": "Pennsylvania",
-        "value": "PA"
-      },
-      {
-        "label": "Puerto Rico",
-        "value": "PR"
-      },
-      {
-        "label": "Rhode Island",
-        "value": "RI"
-      },
-      {
-        "label": "South Carolina",
-        "value": "SC"
-      },
-      {
-        "label": "South Dakota",
-        "value": "SD"
-      },
-      {
-        "label": "Tennessee",
-        "value": "TN"
-      },
-      {
-        "label": "Texas",
-        "value": "TX"
-      },
-      {
-        "label": "Utah",
-        "value": "UT"
-      },
-      {
-        "label": "Vermont",
-        "value": "VT"
-      },
-      {
-        "label": "Virgin Islands",
-        "value": "VI"
-      },
-      {
-        "label": "Virginia",
-        "value": "VA"
-      },
-      {
-        "label": "Washington",
-        "value": "WA"
-      },
-      {
-        "label": "West Virginia",
-        "value": "WV"
-      },
-      {
-        "label": "Wisconsin",
-        "value": "WI"
-      },
-      {
-        "label": "Wyoming",
-        "value": "WY"
-      }
-    ]
-  },
   "pciuStates": [
     {
       "label": "Alabama",
@@ -1906,6 +2745,964 @@
     {
       "label": "Missouri",
       "value": "MO"
+    }
+  ],
+  "salesforceCountries": [
+    {
+      "label": "Afghanistan",
+      "value": "AFG"
+    },
+    {
+      "label": "Aland Islands",
+      "value": "ALA"
+    },
+    {
+      "label": "Albania",
+      "value": "ALB"
+    },
+    {
+      "label": "Algeria",
+      "value": "DZA"
+    },
+    {
+      "label": "Andorra",
+      "value": "AND"
+    },
+    {
+      "label": "Angola",
+      "value": "AGO"
+    },
+    {
+      "label": "Anguilla",
+      "value": "AIA"
+    },
+    {
+      "label": "Antarctica",
+      "value": "ATA"
+    },
+    {
+      "label": "Antigua and Barbuda",
+      "value": "ATG"
+    },
+    {
+      "label": "Argentina",
+      "value": "ARG"
+    },
+    {
+      "label": "Armenia",
+      "value": "ARM"
+    },
+    {
+      "label": "Aruba",
+      "value": "ABW"
+    },
+    {
+      "label": "Australia",
+      "value": "AUS"
+    },
+    {
+      "label": "Austria",
+      "value": "AUT"
+    },
+    {
+      "label": "Azerbaijan",
+      "value": "AZE"
+    },
+    {
+      "label": "Bahamas",
+      "value": "BHS"
+    },
+    {
+      "label": "Bahrain",
+      "value": "BHR"
+    },
+    {
+      "label": "Bangladesh",
+      "value": "BGD"
+    },
+    {
+      "label": "Barbados",
+      "value": "BRB"
+    },
+    {
+      "label": "Belarus",
+      "value": "BLR"
+    },
+    {
+      "label": "Belgium",
+      "value": "BEL"
+    },
+    {
+      "label": "Belize",
+      "value": "BLZ"
+    },
+    {
+      "label": "Benin",
+      "value": "BEN"
+    },
+    {
+      "label": "Bermuda",
+      "value": "BMU"
+    },
+    {
+      "label": "Bhutan",
+      "value": "BTN"
+    },
+    {
+      "label": "Bolivia, Plurinational State of",
+      "value": "BOL"
+    },
+    {
+      "label": "Bonaire, Sint Eustatius and Saba",
+      "value": "BES"
+    },
+    {
+      "label": "Bosnia and Herzegovina",
+      "value": "BIH"
+    },
+    {
+      "label": "Botswana",
+      "value": "BWA"
+    },
+    {
+      "label": "Bouvet Island",
+      "value": "BVT"
+    },
+    {
+      "label": "Brazil",
+      "value": "BRA"
+    },
+    {
+      "label": "British Indian Ocean Territory",
+      "value": "IOT"
+    },
+    {
+      "label": "Brunei Darussalam",
+      "value": "BRN"
+    },
+    {
+      "label": "Bulgaria",
+      "value": "BGR"
+    },
+    {
+      "label": "Burkina Faso",
+      "value": "BFA"
+    },
+    {
+      "label": "Burundi",
+      "value": "BDI"
+    },
+    {
+      "label": "Cambodia",
+      "value": "KHM"
+    },
+    {
+      "label": "Cameroon",
+      "value": "CMR"
+    },
+    {
+      "label": "Canada",
+      "value": "CAN"
+    },
+    {
+      "label": "Cape Verde",
+      "value": "CPV"
+    },
+    {
+      "label": "Cayman Islands",
+      "value": "CYM"
+    },
+    {
+      "label": "Central African Republic",
+      "value": "CAF"
+    },
+    {
+      "label": "Chad",
+      "value": "TCD"
+    },
+    {
+      "label": "Chile",
+      "value": "CHL"
+    },
+    {
+      "label": "China",
+      "value": "CHN"
+    },
+    {
+      "label": "Chinese Taipei",
+      "value": "TWN"
+    },
+    {
+      "label": "Christmas Island",
+      "value": "CXR"
+    },
+    {
+      "label": "Cocos (Keeling) Islands",
+      "value": "CCK"
+    },
+    {
+      "label": "Colombia",
+      "value": "COL"
+    },
+    {
+      "label": "Comoros",
+      "value": "COM"
+    },
+    {
+      "label": "Congo",
+      "value": "COG"
+    },
+    {
+      "label": "Congo, the Democratic Republic of the",
+      "value": "COD"
+    },
+    {
+      "label": "Cook Islands",
+      "value": "COK"
+    },
+    {
+      "label": "Costa Rica",
+      "value": "CRI"
+    },
+    {
+      "label": "Cote d'Ivoire",
+      "value": "CIV"
+    },
+    {
+      "label": "Croatia",
+      "value": "HRV"
+    },
+    {
+      "label": "Cuba",
+      "value": "CUB"
+    },
+    {
+      "label": "Curaçao",
+      "value": "CUW"
+    },
+    {
+      "label": "Cyprus",
+      "value": "CYP"
+    },
+    {
+      "label": "Czech Republic",
+      "value": "CZE"
+    },
+    {
+      "label": "Denmark",
+      "value": "DNK"
+    },
+    {
+      "label": "Djibouti",
+      "value": "DJI"
+    },
+    {
+      "label": "Dominica",
+      "value": "DMA"
+    },
+    {
+      "label": "Dominican Republic",
+      "value": "DOM"
+    },
+    {
+      "label": "Ecuador",
+      "value": "ECU"
+    },
+    {
+      "label": "Egypt",
+      "value": "EGY"
+    },
+    {
+      "label": "El Salvador",
+      "value": "SLV"
+    },
+    {
+      "label": "Equatorial Guinea",
+      "value": "GNQ"
+    },
+    {
+      "label": "Eritrea",
+      "value": "ERI"
+    },
+    {
+      "label": "Estonia",
+      "value": "EST"
+    },
+    {
+      "label": "Ethiopia",
+      "value": "ETH"
+    },
+    {
+      "label": "Falkland Islands (Malvinas)",
+      "value": "FLK"
+    },
+    {
+      "label": "Faroe Islands",
+      "value": "FRO"
+    },
+    {
+      "label": "Fiji",
+      "value": "FJI"
+    },
+    {
+      "label": "Finland",
+      "value": "FIN"
+    },
+    {
+      "label": "France",
+      "value": "FRA"
+    },
+    {
+      "label": "French Guiana",
+      "value": "GUF"
+    },
+    {
+      "label": "French Polynesia",
+      "value": "PYF"
+    },
+    {
+      "label": "French Southern Territories",
+      "value": "ATF"
+    },
+    {
+      "label": "Gabon",
+      "value": "GAB"
+    },
+    {
+      "label": "Gambia",
+      "value": "GMB"
+    },
+    {
+      "label": "Georgia",
+      "value": "GEO"
+    },
+    {
+      "label": "Germany",
+      "value": "DEU"
+    },
+    {
+      "label": "Ghana",
+      "value": "GHA"
+    },
+    {
+      "label": "Gibraltar",
+      "value": "GIB"
+    },
+    {
+      "label": "Greece",
+      "value": "GRC"
+    },
+    {
+      "label": "Greenland",
+      "value": "GRL"
+    },
+    {
+      "label": "Grenada",
+      "value": "GRD"
+    },
+    {
+      "label": "Guadeloupe",
+      "value": "GLP"
+    },
+    {
+      "label": "Guatemala",
+      "value": "GTM"
+    },
+    {
+      "label": "Guernsey",
+      "value": "GGY"
+    },
+    {
+      "label": "Guinea",
+      "value": "GIN"
+    },
+    {
+      "label": "Guinea-Bissau",
+      "value": "GNB"
+    },
+    {
+      "label": "Guyana",
+      "value": "GUY"
+    },
+    {
+      "label": "Haiti",
+      "value": "HTI"
+    },
+    {
+      "label": "Heard Island and McDonald Islands",
+      "value": "HMD"
+    },
+    {
+      "label": "Holy See (Vatican City State)",
+      "value": "VAT"
+    },
+    {
+      "label": "Honduras",
+      "value": "HND"
+    },
+    {
+      "label": "Hungary",
+      "value": "HUN"
+    },
+    {
+      "label": "Iceland",
+      "value": "ISL"
+    },
+    {
+      "label": "India",
+      "value": "IND"
+    },
+    {
+      "label": "Indonesia",
+      "value": "IDN"
+    },
+    {
+      "label": "Iran, Islamic Republic of",
+      "value": "IRN"
+    },
+    {
+      "label": "Iraq",
+      "value": "IRQ"
+    },
+    {
+      "label": "Ireland",
+      "value": "IRL"
+    },
+    {
+      "label": "Isle of Man",
+      "value": "IMN"
+    },
+    {
+      "label": "Israel",
+      "value": "ISR"
+    },
+    {
+      "label": "Italy",
+      "value": "ITA"
+    },
+    {
+      "label": "Jamaica",
+      "value": "JAM"
+    },
+    {
+      "label": "Japan",
+      "value": "JPN"
+    },
+    {
+      "label": "Jersey",
+      "value": "JEY"
+    },
+    {
+      "label": "Jordan",
+      "value": "JOR"
+    },
+    {
+      "label": "Kazakhstan",
+      "value": "KAZ"
+    },
+    {
+      "label": "Kenya",
+      "value": "KEN"
+    },
+    {
+      "label": "Kiribati",
+      "value": "KIR"
+    },
+    {
+      "label": "Korea, Democratic People's Republic of",
+      "value": "PRK"
+    },
+    {
+      "label": "Korea, Republic of",
+      "value": "KOR"
+    },
+    {
+      "label": "Kuwait",
+      "value": "KWT"
+    },
+    {
+      "label": "Kyrgyzstan",
+      "value": "KGZ"
+    },
+    {
+      "label": "Lao People's Democratic Republic",
+      "value": "LAO"
+    },
+    {
+      "label": "Latvia",
+      "value": "LVA"
+    },
+    {
+      "label": "Lebanon",
+      "value": "LBN"
+    },
+    {
+      "label": "Lesotho",
+      "value": "LSO"
+    },
+    {
+      "label": "Liberia",
+      "value": "LBR"
+    },
+    {
+      "label": "Libyan Arab Jamahiriya",
+      "value": "LBY"
+    },
+    {
+      "label": "Liechtenstein",
+      "value": "LIE"
+    },
+    {
+      "label": "Lithuania",
+      "value": "LTU"
+    },
+    {
+      "label": "Luxembourg",
+      "value": "LUX"
+    },
+    {
+      "label": "Macao",
+      "value": "MAC"
+    },
+    {
+      "label": "Macedonia, the former Yugoslav Republic of",
+      "value": "MKD"
+    },
+    {
+      "label": "Madagascar",
+      "value": "MDG"
+    },
+    {
+      "label": "Malawi",
+      "value": "MWI"
+    },
+    {
+      "label": "Malaysia",
+      "value": "MYS"
+    },
+    {
+      "label": "Maldives",
+      "value": "MDV"
+    },
+    {
+      "label": "Mali",
+      "value": "MLI"
+    },
+    {
+      "label": "Malta",
+      "value": "MLT"
+    },
+    {
+      "label": "Martinique",
+      "value": "MTQ"
+    },
+    {
+      "label": "Mauritania",
+      "value": "MRT"
+    },
+    {
+      "label": "Mauritius",
+      "value": "MUS"
+    },
+    {
+      "label": "Mayotte",
+      "value": "MYT"
+    },
+    {
+      "label": "Mexico",
+      "value": "MEX"
+    },
+    {
+      "label": "Moldova, Republic of",
+      "value": "MDA"
+    },
+    {
+      "label": "Monaco",
+      "value": "MCO"
+    },
+    {
+      "label": "Mongolia",
+      "value": "MNG"
+    },
+    {
+      "label": "Montenegro",
+      "value": "MNE"
+    },
+    {
+      "label": "Montserrat",
+      "value": "MSR"
+    },
+    {
+      "label": "Morocco",
+      "value": "MAR"
+    },
+    {
+      "label": "Mozambique",
+      "value": "MOZ"
+    },
+    {
+      "label": "Myanmar",
+      "value": "MMR"
+    },
+    {
+      "label": "Namibia",
+      "value": "NAM"
+    },
+    {
+      "label": "Nauru",
+      "value": "NRU"
+    },
+    {
+      "label": "Nepal",
+      "value": "NPL"
+    },
+    {
+      "label": "Netherlands",
+      "value": "NLD"
+    },
+    {
+      "label": "New Caledonia",
+      "value": "NCL"
+    },
+    {
+      "label": "New Zealand",
+      "value": "NZL"
+    },
+    {
+      "label": "Nicaragua",
+      "value": "NIC"
+    },
+    {
+      "label": "Niger",
+      "value": "NER"
+    },
+    {
+      "label": "Nigeria",
+      "value": "NGA"
+    },
+    {
+      "label": "Niue",
+      "value": "NIU"
+    },
+    {
+      "label": "Norfolk Island",
+      "value": "NFK"
+    },
+    {
+      "label": "Norway",
+      "value": "NOR"
+    },
+    {
+      "label": "Oman",
+      "value": "OMN"
+    },
+    {
+      "label": "Pakistan",
+      "value": "PAK"
+    },
+    {
+      "label": "Palestinian Territory, Occupied",
+      "value": "PSE"
+    },
+    {
+      "label": "Panama",
+      "value": "PAN"
+    },
+    {
+      "label": "Papua New Guinea",
+      "value": "PNG"
+    },
+    {
+      "label": "Paraguay",
+      "value": "PRY"
+    },
+    {
+      "label": "Peru",
+      "value": "PER"
+    },
+    {
+      "label": "Philippines",
+      "value": "PHL"
+    },
+    {
+      "label": "Pitcairn",
+      "value": "PCN"
+    },
+    {
+      "label": "Poland",
+      "value": "POL"
+    },
+    {
+      "label": "Portugal",
+      "value": "PRT"
+    },
+    {
+      "label": "Qatar",
+      "value": "QAT"
+    },
+    {
+      "label": "Reunion",
+      "value": "REU"
+    },
+    {
+      "label": "Romania",
+      "value": "ROU"
+    },
+    {
+      "label": "Russian Federation",
+      "value": "RUS"
+    },
+    {
+      "label": "Rwanda",
+      "value": "RWA"
+    },
+    {
+      "label": "Saint Barthélemy",
+      "value": "BLM"
+    },
+    {
+      "label": "Saint Helena, Ascension and Tristan da Cunha",
+      "value": "SHN"
+    },
+    {
+      "label": "Saint Kitts and Nevis",
+      "value": "KNA"
+    },
+    {
+      "label": "Saint Lucia",
+      "value": "LCA"
+    },
+    {
+      "label": "Saint Martin (French part)",
+      "value": "MAF"
+    },
+    {
+      "label": "Saint Pierre and Miquelon",
+      "value": "SPM"
+    },
+    {
+      "label": "Saint Vincent and the Grenadines",
+      "value": "VCT"
+    },
+    {
+      "label": "Samoa",
+      "value": "WSM"
+    },
+    {
+      "label": "San Marino",
+      "value": "SMR"
+    },
+    {
+      "label": "Sao Tome and Principe",
+      "value": "STP"
+    },
+    {
+      "label": "Saudi Arabia",
+      "value": "SAU"
+    },
+    {
+      "label": "Senegal",
+      "value": "SEN"
+    },
+    {
+      "label": "Serbia",
+      "value": "SRB"
+    },
+    {
+      "label": "Seychelles",
+      "value": "SYC"
+    },
+    {
+      "label": "Sierra Leone",
+      "value": "SLE"
+    },
+    {
+      "label": "Singapore",
+      "value": "SGP"
+    },
+    {
+      "label": "Sint Maarten (Dutch part)",
+      "value": "SXM"
+    },
+    {
+      "label": "Slovakia",
+      "value": "SVK"
+    },
+    {
+      "label": "Slovenia",
+      "value": "SVN"
+    },
+    {
+      "label": "Solomon Islands",
+      "value": "SLB"
+    },
+    {
+      "label": "Somalia",
+      "value": "SOM"
+    },
+    {
+      "label": "South Africa",
+      "value": "ZAF"
+    },
+    {
+      "label": "South Georgia and the South Sandwich Islands",
+      "value": "SGS"
+    },
+    {
+      "label": "South Sudan",
+      "value": "SSD"
+    },
+    {
+      "label": "Spain",
+      "value": "ESP"
+    },
+    {
+      "label": "Sri Lanka",
+      "value": "LKA"
+    },
+    {
+      "label": "Sudan",
+      "value": "SDN"
+    },
+    {
+      "label": "Suriname",
+      "value": "SUR"
+    },
+    {
+      "label": "Svalbard and Jan Mayen",
+      "value": "SJM"
+    },
+    {
+      "label": "Swaziland",
+      "value": "SWZ"
+    },
+    {
+      "label": "Sweden",
+      "value": "SWE"
+    },
+    {
+      "label": "Switzerland",
+      "value": "CHE"
+    },
+    {
+      "label": "Syrian Arab Republic",
+      "value": "SYR"
+    },
+    {
+      "label": "Tajikistan",
+      "value": "TJK"
+    },
+    {
+      "label": "Tanzania, United Republic of",
+      "value": "TZA"
+    },
+    {
+      "label": "Thailand",
+      "value": "THA"
+    },
+    {
+      "label": "Timor-Leste",
+      "value": "TLS"
+    },
+    {
+      "label": "Togo",
+      "value": "TGO"
+    },
+    {
+      "label": "Tokelau",
+      "value": "TKL"
+    },
+    {
+      "label": "Tonga",
+      "value": "TON"
+    },
+    {
+      "label": "Trinidad and Tobago",
+      "value": "TTO"
+    },
+    {
+      "label": "Tunisia",
+      "value": "TUN"
+    },
+    {
+      "label": "Turkey",
+      "value": "TUR"
+    },
+    {
+      "label": "Turkmenistan",
+      "value": "TKM"
+    },
+    {
+      "label": "Turks and Caicos Islands",
+      "value": "TCA"
+    },
+    {
+      "label": "Tuvalu",
+      "value": "TUV"
+    },
+    {
+      "label": "Uganda",
+      "value": "UGA"
+    },
+    {
+      "label": "Ukraine",
+      "value": "UKR"
+    },
+    {
+      "label": "United Arab Emirates",
+      "value": "ARE"
+    },
+    {
+      "label": "United Kingdom",
+      "value": "GBR"
+    },
+    {
+      "label": "United States",
+      "value": "USA"
+    },
+    {
+      "label": "Uruguay",
+      "value": "URY"
+    },
+    {
+      "label": "Uzbekistan",
+      "value": "UZB"
+    },
+    {
+      "label": "Vanuatu",
+      "value": "VUT"
+    },
+    {
+      "label": "Venezuela, Bolivarian Republic of",
+      "value": "VEN"
+    },
+    {
+      "label": "Viet Nam",
+      "value": "VNM"
+    },
+    {
+      "label": "Virgin Islands, British",
+      "value": "VGB"
+    },
+    {
+      "label": "Wallis and Futuna",
+      "value": "WLF"
+    },
+    {
+      "label": "Western Sahara",
+      "value": "ESH"
+    },
+    {
+      "label": "Yemen",
+      "value": "YEM"
+    },
+    {
+      "label": "Zambia",
+      "value": "ZMB"
+    },
+    {
+      "label": "Zimbabwe",
+      "value": "ZWE"
     }
   ],
   "salesforceStates": {
@@ -3320,962 +5117,646 @@
       }
     ]
   },
-  "salesforceCountries": [
-    {
-      "label": "Afghanistan",
-      "value": "AFG"
-    },
-    {
-      "label": "Aland Islands",
-      "value": "ALA"
-    },
-    {
-      "label": "Albania",
-      "value": "ALB"
-    },
-    {
-      "label": "Algeria",
-      "value": "DZA"
-    },
-    {
-      "label": "Andorra",
-      "value": "AND"
-    },
-    {
-      "label": "Angola",
-      "value": "AGO"
-    },
-    {
-      "label": "Anguilla",
-      "value": "AIA"
-    },
-    {
-      "label": "Antarctica",
-      "value": "ATA"
-    },
-    {
-      "label": "Antigua and Barbuda",
-      "value": "ATG"
-    },
-    {
-      "label": "Argentina",
-      "value": "ARG"
-    },
-    {
-      "label": "Armenia",
-      "value": "ARM"
-    },
-    {
-      "label": "Aruba",
-      "value": "ABW"
-    },
-    {
-      "label": "Australia",
-      "value": "AUS"
-    },
-    {
-      "label": "Austria",
-      "value": "AUT"
-    },
-    {
-      "label": "Azerbaijan",
-      "value": "AZE"
-    },
-    {
-      "label": "Bahamas",
-      "value": "BHS"
-    },
-    {
-      "label": "Bahrain",
-      "value": "BHR"
-    },
-    {
-      "label": "Bangladesh",
-      "value": "BGD"
-    },
-    {
-      "label": "Barbados",
-      "value": "BRB"
-    },
-    {
-      "label": "Belarus",
-      "value": "BLR"
-    },
-    {
-      "label": "Belgium",
-      "value": "BEL"
-    },
-    {
-      "label": "Belize",
-      "value": "BLZ"
-    },
-    {
-      "label": "Benin",
-      "value": "BEN"
-    },
-    {
-      "label": "Bermuda",
-      "value": "BMU"
-    },
-    {
-      "label": "Bhutan",
-      "value": "BTN"
-    },
-    {
-      "label": "Bolivia, Plurinational State of",
-      "value": "BOL"
-    },
-    {
-      "label": "Bonaire, Sint Eustatius and Saba",
-      "value": "BES"
-    },
-    {
-      "label": "Bosnia and Herzegovina",
-      "value": "BIH"
-    },
-    {
-      "label": "Botswana",
-      "value": "BWA"
-    },
-    {
-      "label": "Bouvet Island",
-      "value": "BVT"
-    },
-    {
-      "label": "Brazil",
-      "value": "BRA"
-    },
-    {
-      "label": "British Indian Ocean Territory",
-      "value": "IOT"
-    },
-    {
-      "label": "Brunei Darussalam",
-      "value": "BRN"
-    },
-    {
-      "label": "Bulgaria",
-      "value": "BGR"
-    },
-    {
-      "label": "Burkina Faso",
-      "value": "BFA"
-    },
-    {
-      "label": "Burundi",
-      "value": "BDI"
-    },
-    {
-      "label": "Cambodia",
-      "value": "KHM"
-    },
-    {
-      "label": "Cameroon",
-      "value": "CMR"
-    },
-    {
-      "label": "Canada",
-      "value": "CAN"
-    },
-    {
-      "label": "Cape Verde",
-      "value": "CPV"
-    },
-    {
-      "label": "Cayman Islands",
-      "value": "CYM"
-    },
-    {
-      "label": "Central African Republic",
-      "value": "CAF"
-    },
-    {
-      "label": "Chad",
-      "value": "TCD"
-    },
-    {
-      "label": "Chile",
-      "value": "CHL"
-    },
-    {
-      "label": "China",
-      "value": "CHN"
-    },
-    {
-      "label": "Chinese Taipei",
-      "value": "TWN"
-    },
-    {
-      "label": "Christmas Island",
-      "value": "CXR"
-    },
-    {
-      "label": "Cocos (Keeling) Islands",
-      "value": "CCK"
-    },
-    {
-      "label": "Colombia",
-      "value": "COL"
-    },
-    {
-      "label": "Comoros",
-      "value": "COM"
-    },
-    {
-      "label": "Congo",
-      "value": "COG"
-    },
-    {
-      "label": "Congo, the Democratic Republic of the",
-      "value": "COD"
-    },
-    {
-      "label": "Cook Islands",
-      "value": "COK"
-    },
-    {
-      "label": "Costa Rica",
-      "value": "CRI"
-    },
-    {
-      "label": "Cote d'Ivoire",
-      "value": "CIV"
-    },
-    {
-      "label": "Croatia",
-      "value": "HRV"
-    },
-    {
-      "label": "Cuba",
-      "value": "CUB"
-    },
-    {
-      "label": "Curaçao",
-      "value": "CUW"
-    },
-    {
-      "label": "Cyprus",
-      "value": "CYP"
-    },
-    {
-      "label": "Czech Republic",
-      "value": "CZE"
-    },
-    {
-      "label": "Denmark",
-      "value": "DNK"
-    },
-    {
-      "label": "Djibouti",
-      "value": "DJI"
-    },
-    {
-      "label": "Dominica",
-      "value": "DMA"
-    },
-    {
-      "label": "Dominican Republic",
-      "value": "DOM"
-    },
-    {
-      "label": "Ecuador",
-      "value": "ECU"
-    },
-    {
-      "label": "Egypt",
-      "value": "EGY"
-    },
-    {
-      "label": "El Salvador",
-      "value": "SLV"
-    },
-    {
-      "label": "Equatorial Guinea",
-      "value": "GNQ"
-    },
-    {
-      "label": "Eritrea",
-      "value": "ERI"
-    },
-    {
-      "label": "Estonia",
-      "value": "EST"
-    },
-    {
-      "label": "Ethiopia",
-      "value": "ETH"
-    },
-    {
-      "label": "Falkland Islands (Malvinas)",
-      "value": "FLK"
-    },
-    {
-      "label": "Faroe Islands",
-      "value": "FRO"
-    },
-    {
-      "label": "Fiji",
-      "value": "FJI"
-    },
-    {
-      "label": "Finland",
-      "value": "FIN"
-    },
-    {
-      "label": "France",
-      "value": "FRA"
-    },
-    {
-      "label": "French Guiana",
-      "value": "GUF"
-    },
-    {
-      "label": "French Polynesia",
-      "value": "PYF"
-    },
-    {
-      "label": "French Southern Territories",
-      "value": "ATF"
-    },
-    {
-      "label": "Gabon",
-      "value": "GAB"
-    },
-    {
-      "label": "Gambia",
-      "value": "GMB"
+  "states": {
+    "CAN": [
+      {
+        "label": "Alberta",
+        "value": "AB"
+      },
+      {
+        "label": "British Columbia",
+        "value": "BC"
+      },
+      {
+        "label": "Manitoba",
+        "value": "MB"
+      },
+      {
+        "label": "New Brunswick",
+        "value": "NB"
+      },
+      {
+        "label": "Newfoundland",
+        "value": "NF"
+      },
+      {
+        "label": "Northwest Territories",
+        "value": "NT"
+      },
+      {
+        "label": "Nova Scotia",
+        "value": "NV"
+      },
+      {
+        "label": "Nunavut Province",
+        "value": "NU"
+      },
+      {
+        "label": "Ontario",
+        "value": "ON"
+      },
+      {
+        "label": "Prince Edward Island",
+        "value": "PE"
+      },
+      {
+        "label": "Quebec",
+        "value": "QC"
+      },
+      {
+        "label": "Saskatchewan",
+        "value": "SK"
+      },
+      {
+        "label": "Yukon Territory",
+        "value": "YT"
+      }
+    ],
+    "MEX": [
+      {
+        "label": "Aguascalientes",
+        "value": "aguascalientes"
+      },
+      {
+        "label": "Baja California Norte",
+        "value": "baja-california-norte"
+      },
+      {
+        "label": "Baja California Sur",
+        "value": "baja-california-sur"
+      },
+      {
+        "label": "Campeche",
+        "value": "campeche"
+      },
+      {
+        "label": "Chiapas",
+        "value": "chiapas"
+      },
+      {
+        "label": "Chihuahua",
+        "value": "chihuahua"
+      },
+      {
+        "label": "Coahuila",
+        "value": "coahuila"
+      },
+      {
+        "label": "Colima",
+        "value": "colima"
+      },
+      {
+        "label": "Distrito Federal",
+        "value": "distrito-federal"
+      },
+      {
+        "label": "Durango",
+        "value": "durango"
+      },
+      {
+        "label": "Guanajuato",
+        "value": "guanajuato"
+      },
+      {
+        "label": "Guerrero",
+        "value": "guerrero"
+      },
+      {
+        "label": "Hidalgo",
+        "value": "hidalgo"
+      },
+      {
+        "label": "Jalisco",
+        "value": "jalisco"
+      },
+      {
+        "label": "México",
+        "value": "mexico"
+      },
+      {
+        "label": "Michoacán",
+        "value": "michoacan"
+      },
+      {
+        "label": "Morelos",
+        "value": "morelos"
+      },
+      {
+        "label": "Nayarit",
+        "value": "nayarit"
+      },
+      {
+        "label": "Nuevo León",
+        "value": "nuevo-leon"
+      },
+      {
+        "label": "Oaxaca",
+        "value": "oaxaca"
+      },
+      {
+        "label": "Puebla",
+        "value": "puebla"
+      },
+      {
+        "label": "Querétaro",
+        "value": "queretaro"
+      },
+      {
+        "label": "Quintana Roo",
+        "value": "quintana-roo"
+      },
+      {
+        "label": "San Luis Potosí",
+        "value": "san-luis-potosi"
+      },
+      {
+        "label": "Sinaloa",
+        "value": "sinaloa"
+      },
+      {
+        "label": "Sonora",
+        "value": "sonora"
+      },
+      {
+        "label": "Tabasco",
+        "value": "tabasco"
+      },
+      {
+        "label": "Tamaulipas",
+        "value": "tamaulipas"
+      },
+      {
+        "label": "Tlaxcala",
+        "value": "tlaxcala"
+      },
+      {
+        "label": "Veracruz",
+        "value": "veracruz"
+      },
+      {
+        "label": "Yucatán",
+        "value": "yucatan"
+      },
+      {
+        "label": "Zacatecas",
+        "value": "zacatecas"
+      }
+    ],
+    "USA": [
+      {
+        "label": "Alabama",
+        "value": "AL"
+      },
+      {
+        "label": "Alaska",
+        "value": "AK"
+      },
+      {
+        "label": "American Samoa",
+        "value": "AS"
+      },
+      {
+        "label": "Arizona",
+        "value": "AZ"
+      },
+      {
+        "label": "Arkansas",
+        "value": "AR"
+      },
+      {
+        "label": "Armed Forces Americas (AA)",
+        "value": "AA"
+      },
+      {
+        "label": "Armed Forces Europe (AE)",
+        "value": "AE"
+      },
+      {
+        "label": "Armed Forces Pacific (AP)",
+        "value": "AP"
+      },
+      {
+        "label": "California",
+        "value": "CA"
+      },
+      {
+        "label": "Colorado",
+        "value": "CO"
+      },
+      {
+        "label": "Connecticut",
+        "value": "CT"
+      },
+      {
+        "label": "Delaware",
+        "value": "DE"
+      },
+      {
+        "label": "District Of Columbia",
+        "value": "DC"
+      },
+      {
+        "label": "Federated States Of Micronesia",
+        "value": "FM"
+      },
+      {
+        "label": "Florida",
+        "value": "FL"
+      },
+      {
+        "label": "Georgia",
+        "value": "GA"
+      },
+      {
+        "label": "Guam",
+        "value": "GU"
+      },
+      {
+        "label": "Hawaii",
+        "value": "HI"
+      },
+      {
+        "label": "Idaho",
+        "value": "ID"
+      },
+      {
+        "label": "Illinois",
+        "value": "IL"
+      },
+      {
+        "label": "Indiana",
+        "value": "IN"
+      },
+      {
+        "label": "Iowa",
+        "value": "IA"
+      },
+      {
+        "label": "Kansas",
+        "value": "KS"
+      },
+      {
+        "label": "Kentucky",
+        "value": "KY"
+      },
+      {
+        "label": "Louisiana",
+        "value": "LA"
+      },
+      {
+        "label": "Maine",
+        "value": "ME"
+      },
+      {
+        "label": "Marshall Islands",
+        "value": "MH"
+      },
+      {
+        "label": "Maryland",
+        "value": "MD"
+      },
+      {
+        "label": "Massachusetts",
+        "value": "MA"
+      },
+      {
+        "label": "Michigan",
+        "value": "MI"
+      },
+      {
+        "label": "Minnesota",
+        "value": "MN"
+      },
+      {
+        "label": "Mississippi",
+        "value": "MS"
+      },
+      {
+        "label": "Missouri",
+        "value": "MO"
+      },
+      {
+        "label": "Montana",
+        "value": "MT"
+      },
+      {
+        "label": "Nebraska",
+        "value": "NE"
+      },
+      {
+        "label": "Nevada",
+        "value": "NV"
+      },
+      {
+        "label": "New Hampshire",
+        "value": "NH"
+      },
+      {
+        "label": "New Jersey",
+        "value": "NJ"
+      },
+      {
+        "label": "New Mexico",
+        "value": "NM"
+      },
+      {
+        "label": "New York",
+        "value": "NY"
+      },
+      {
+        "label": "North Carolina",
+        "value": "NC"
+      },
+      {
+        "label": "North Dakota",
+        "value": "ND"
+      },
+      {
+        "label": "Northern Mariana Islands",
+        "value": "MP"
+      },
+      {
+        "label": "Ohio",
+        "value": "OH"
+      },
+      {
+        "label": "Oklahoma",
+        "value": "OK"
+      },
+      {
+        "label": "Oregon",
+        "value": "OR"
+      },
+      {
+        "label": "Palau",
+        "value": "PW"
+      },
+      {
+        "label": "Pennsylvania",
+        "value": "PA"
+      },
+      {
+        "label": "Puerto Rico",
+        "value": "PR"
+      },
+      {
+        "label": "Rhode Island",
+        "value": "RI"
+      },
+      {
+        "label": "South Carolina",
+        "value": "SC"
+      },
+      {
+        "label": "South Dakota",
+        "value": "SD"
+      },
+      {
+        "label": "Tennessee",
+        "value": "TN"
+      },
+      {
+        "label": "Texas",
+        "value": "TX"
+      },
+      {
+        "label": "Utah",
+        "value": "UT"
+      },
+      {
+        "label": "Vermont",
+        "value": "VT"
+      },
+      {
+        "label": "Virgin Islands",
+        "value": "VI"
+      },
+      {
+        "label": "Virginia",
+        "value": "VA"
+      },
+      {
+        "label": "Washington",
+        "value": "WA"
+      },
+      {
+        "label": "West Virginia",
+        "value": "WV"
+      },
+      {
+        "label": "Wisconsin",
+        "value": "WI"
+      },
+      {
+        "label": "Wyoming",
+        "value": "WY"
+      }
+    ]
+  },
+  "states50AndDC": [
+    {
+      "label": "Alabama",
+      "value": "AL"
+    },
+    {
+      "label": "Alaska",
+      "value": "AK"
+    },
+    {
+      "label": "Arizona",
+      "value": "AZ"
+    },
+    {
+      "label": "Arkansas",
+      "value": "AR"
+    },
+    {
+      "label": "California",
+      "value": "CA"
+    },
+    {
+      "label": "Colorado",
+      "value": "CO"
+    },
+    {
+      "label": "Connecticut",
+      "value": "CT"
+    },
+    {
+      "label": "Delaware",
+      "value": "DE"
+    },
+    {
+      "label": "District Of Columbia",
+      "value": "DC"
+    },
+    {
+      "label": "Florida",
+      "value": "FL"
     },
     {
       "label": "Georgia",
-      "value": "GEO"
+      "value": "GA"
     },
     {
-      "label": "Germany",
-      "value": "DEU"
+      "label": "Hawaii",
+      "value": "HI"
     },
     {
-      "label": "Ghana",
-      "value": "GHA"
+      "label": "Idaho",
+      "value": "ID"
     },
     {
-      "label": "Gibraltar",
-      "value": "GIB"
+      "label": "Illinois",
+      "value": "IL"
     },
     {
-      "label": "Greece",
-      "value": "GRC"
+      "label": "Indiana",
+      "value": "IN"
     },
     {
-      "label": "Greenland",
-      "value": "GRL"
+      "label": "Iowa",
+      "value": "IA"
     },
     {
-      "label": "Grenada",
-      "value": "GRD"
+      "label": "Kansas",
+      "value": "KS"
     },
     {
-      "label": "Guadeloupe",
-      "value": "GLP"
+      "label": "Kentucky",
+      "value": "KY"
     },
     {
-      "label": "Guatemala",
-      "value": "GTM"
+      "label": "Louisiana",
+      "value": "LA"
     },
     {
-      "label": "Guernsey",
-      "value": "GGY"
+      "label": "Maine",
+      "value": "ME"
     },
     {
-      "label": "Guinea",
-      "value": "GIN"
+      "label": "Maryland",
+      "value": "MD"
     },
     {
-      "label": "Guinea-Bissau",
-      "value": "GNB"
+      "label": "Massachusetts",
+      "value": "MA"
     },
     {
-      "label": "Guyana",
-      "value": "GUY"
+      "label": "Michigan",
+      "value": "MI"
     },
     {
-      "label": "Haiti",
-      "value": "HTI"
+      "label": "Minnesota",
+      "value": "MN"
     },
     {
-      "label": "Heard Island and McDonald Islands",
-      "value": "HMD"
+      "label": "Mississippi",
+      "value": "MS"
     },
     {
-      "label": "Holy See (Vatican City State)",
-      "value": "VAT"
+      "label": "Missouri",
+      "value": "MO"
     },
     {
-      "label": "Honduras",
-      "value": "HND"
+      "label": "Montana",
+      "value": "MT"
     },
     {
-      "label": "Hungary",
-      "value": "HUN"
+      "label": "Nebraska",
+      "value": "NE"
     },
     {
-      "label": "Iceland",
-      "value": "ISL"
+      "label": "Nevada",
+      "value": "NV"
     },
     {
-      "label": "India",
-      "value": "IND"
+      "label": "New Hampshire",
+      "value": "NH"
     },
     {
-      "label": "Indonesia",
-      "value": "IDN"
+      "label": "New Jersey",
+      "value": "NJ"
     },
     {
-      "label": "Iran, Islamic Republic of",
-      "value": "IRN"
+      "label": "New Mexico",
+      "value": "NM"
     },
     {
-      "label": "Iraq",
-      "value": "IRQ"
+      "label": "New York",
+      "value": "NY"
     },
     {
-      "label": "Ireland",
-      "value": "IRL"
+      "label": "North Carolina",
+      "value": "NC"
     },
     {
-      "label": "Isle of Man",
-      "value": "IMN"
+      "label": "North Dakota",
+      "value": "ND"
     },
     {
-      "label": "Israel",
-      "value": "ISR"
+      "label": "Ohio",
+      "value": "OH"
     },
     {
-      "label": "Italy",
-      "value": "ITA"
+      "label": "Oklahoma",
+      "value": "OK"
     },
     {
-      "label": "Jamaica",
-      "value": "JAM"
+      "label": "Oregon",
+      "value": "OR"
     },
     {
-      "label": "Japan",
-      "value": "JPN"
+      "label": "Pennsylvania",
+      "value": "PA"
     },
     {
-      "label": "Jersey",
-      "value": "JEY"
+      "label": "Rhode Island",
+      "value": "RI"
     },
     {
-      "label": "Jordan",
-      "value": "JOR"
+      "label": "South Carolina",
+      "value": "SC"
     },
     {
-      "label": "Kazakhstan",
-      "value": "KAZ"
+      "label": "South Dakota",
+      "value": "SD"
     },
     {
-      "label": "Kenya",
-      "value": "KEN"
+      "label": "Tennessee",
+      "value": "TN"
     },
     {
-      "label": "Kiribati",
-      "value": "KIR"
+      "label": "Texas",
+      "value": "TX"
     },
     {
-      "label": "Korea, Democratic People's Republic of",
-      "value": "PRK"
+      "label": "Utah",
+      "value": "UT"
     },
     {
-      "label": "Korea, Republic of",
-      "value": "KOR"
+      "label": "Vermont",
+      "value": "VT"
     },
     {
-      "label": "Kuwait",
-      "value": "KWT"
+      "label": "Virginia",
+      "value": "VA"
     },
     {
-      "label": "Kyrgyzstan",
-      "value": "KGZ"
+      "label": "Washington",
+      "value": "WA"
     },
     {
-      "label": "Lao People's Democratic Republic",
-      "value": "LAO"
+      "label": "West Virginia",
+      "value": "WV"
     },
     {
-      "label": "Latvia",
-      "value": "LVA"
+      "label": "Wisconsin",
+      "value": "WI"
     },
     {
-      "label": "Lebanon",
-      "value": "LBN"
-    },
-    {
-      "label": "Lesotho",
-      "value": "LSO"
-    },
-    {
-      "label": "Liberia",
-      "value": "LBR"
-    },
-    {
-      "label": "Libyan Arab Jamahiriya",
-      "value": "LBY"
-    },
-    {
-      "label": "Liechtenstein",
-      "value": "LIE"
-    },
-    {
-      "label": "Lithuania",
-      "value": "LTU"
-    },
-    {
-      "label": "Luxembourg",
-      "value": "LUX"
-    },
-    {
-      "label": "Macao",
-      "value": "MAC"
-    },
-    {
-      "label": "Macedonia, the former Yugoslav Republic of",
-      "value": "MKD"
-    },
-    {
-      "label": "Madagascar",
-      "value": "MDG"
-    },
-    {
-      "label": "Malawi",
-      "value": "MWI"
-    },
-    {
-      "label": "Malaysia",
-      "value": "MYS"
-    },
-    {
-      "label": "Maldives",
-      "value": "MDV"
-    },
-    {
-      "label": "Mali",
-      "value": "MLI"
-    },
-    {
-      "label": "Malta",
-      "value": "MLT"
-    },
-    {
-      "label": "Martinique",
-      "value": "MTQ"
-    },
-    {
-      "label": "Mauritania",
-      "value": "MRT"
-    },
-    {
-      "label": "Mauritius",
-      "value": "MUS"
-    },
-    {
-      "label": "Mayotte",
-      "value": "MYT"
-    },
-    {
-      "label": "Mexico",
-      "value": "MEX"
-    },
-    {
-      "label": "Moldova, Republic of",
-      "value": "MDA"
-    },
-    {
-      "label": "Monaco",
-      "value": "MCO"
-    },
-    {
-      "label": "Mongolia",
-      "value": "MNG"
-    },
-    {
-      "label": "Montenegro",
-      "value": "MNE"
-    },
-    {
-      "label": "Montserrat",
-      "value": "MSR"
-    },
-    {
-      "label": "Morocco",
-      "value": "MAR"
-    },
-    {
-      "label": "Mozambique",
-      "value": "MOZ"
-    },
-    {
-      "label": "Myanmar",
-      "value": "MMR"
-    },
-    {
-      "label": "Namibia",
-      "value": "NAM"
-    },
-    {
-      "label": "Nauru",
-      "value": "NRU"
-    },
-    {
-      "label": "Nepal",
-      "value": "NPL"
-    },
-    {
-      "label": "Netherlands",
-      "value": "NLD"
-    },
-    {
-      "label": "New Caledonia",
-      "value": "NCL"
-    },
-    {
-      "label": "New Zealand",
-      "value": "NZL"
-    },
-    {
-      "label": "Nicaragua",
-      "value": "NIC"
-    },
-    {
-      "label": "Niger",
-      "value": "NER"
-    },
-    {
-      "label": "Nigeria",
-      "value": "NGA"
-    },
-    {
-      "label": "Niue",
-      "value": "NIU"
-    },
-    {
-      "label": "Norfolk Island",
-      "value": "NFK"
-    },
-    {
-      "label": "Norway",
-      "value": "NOR"
-    },
-    {
-      "label": "Oman",
-      "value": "OMN"
-    },
-    {
-      "label": "Pakistan",
-      "value": "PAK"
-    },
-    {
-      "label": "Palestinian Territory, Occupied",
-      "value": "PSE"
-    },
-    {
-      "label": "Panama",
-      "value": "PAN"
-    },
-    {
-      "label": "Papua New Guinea",
-      "value": "PNG"
-    },
-    {
-      "label": "Paraguay",
-      "value": "PRY"
-    },
-    {
-      "label": "Peru",
-      "value": "PER"
-    },
-    {
-      "label": "Philippines",
-      "value": "PHL"
-    },
-    {
-      "label": "Pitcairn",
-      "value": "PCN"
-    },
-    {
-      "label": "Poland",
-      "value": "POL"
-    },
-    {
-      "label": "Portugal",
-      "value": "PRT"
-    },
-    {
-      "label": "Qatar",
-      "value": "QAT"
-    },
-    {
-      "label": "Reunion",
-      "value": "REU"
-    },
-    {
-      "label": "Romania",
-      "value": "ROU"
-    },
-    {
-      "label": "Russian Federation",
-      "value": "RUS"
-    },
-    {
-      "label": "Rwanda",
-      "value": "RWA"
-    },
-    {
-      "label": "Saint Barthélemy",
-      "value": "BLM"
-    },
-    {
-      "label": "Saint Helena, Ascension and Tristan da Cunha",
-      "value": "SHN"
-    },
-    {
-      "label": "Saint Kitts and Nevis",
-      "value": "KNA"
-    },
-    {
-      "label": "Saint Lucia",
-      "value": "LCA"
-    },
-    {
-      "label": "Saint Martin (French part)",
-      "value": "MAF"
-    },
-    {
-      "label": "Saint Pierre and Miquelon",
-      "value": "SPM"
-    },
-    {
-      "label": "Saint Vincent and the Grenadines",
-      "value": "VCT"
-    },
-    {
-      "label": "Samoa",
-      "value": "WSM"
-    },
-    {
-      "label": "San Marino",
-      "value": "SMR"
-    },
-    {
-      "label": "Sao Tome and Principe",
-      "value": "STP"
-    },
-    {
-      "label": "Saudi Arabia",
-      "value": "SAU"
-    },
-    {
-      "label": "Senegal",
-      "value": "SEN"
-    },
-    {
-      "label": "Serbia",
-      "value": "SRB"
-    },
-    {
-      "label": "Seychelles",
-      "value": "SYC"
-    },
-    {
-      "label": "Sierra Leone",
-      "value": "SLE"
-    },
-    {
-      "label": "Singapore",
-      "value": "SGP"
-    },
-    {
-      "label": "Sint Maarten (Dutch part)",
-      "value": "SXM"
-    },
-    {
-      "label": "Slovakia",
-      "value": "SVK"
-    },
-    {
-      "label": "Slovenia",
-      "value": "SVN"
-    },
-    {
-      "label": "Solomon Islands",
-      "value": "SLB"
-    },
-    {
-      "label": "Somalia",
-      "value": "SOM"
-    },
-    {
-      "label": "South Africa",
-      "value": "ZAF"
-    },
-    {
-      "label": "South Georgia and the South Sandwich Islands",
-      "value": "SGS"
-    },
-    {
-      "label": "South Sudan",
-      "value": "SSD"
-    },
-    {
-      "label": "Spain",
-      "value": "ESP"
-    },
-    {
-      "label": "Sri Lanka",
-      "value": "LKA"
-    },
-    {
-      "label": "Sudan",
-      "value": "SDN"
-    },
-    {
-      "label": "Suriname",
-      "value": "SUR"
-    },
-    {
-      "label": "Svalbard and Jan Mayen",
-      "value": "SJM"
-    },
-    {
-      "label": "Swaziland",
-      "value": "SWZ"
-    },
-    {
-      "label": "Sweden",
-      "value": "SWE"
-    },
-    {
-      "label": "Switzerland",
-      "value": "CHE"
-    },
-    {
-      "label": "Syrian Arab Republic",
-      "value": "SYR"
-    },
-    {
-      "label": "Tajikistan",
-      "value": "TJK"
-    },
-    {
-      "label": "Tanzania, United Republic of",
-      "value": "TZA"
-    },
-    {
-      "label": "Thailand",
-      "value": "THA"
-    },
-    {
-      "label": "Timor-Leste",
-      "value": "TLS"
-    },
-    {
-      "label": "Togo",
-      "value": "TGO"
-    },
-    {
-      "label": "Tokelau",
-      "value": "TKL"
-    },
-    {
-      "label": "Tonga",
-      "value": "TON"
-    },
-    {
-      "label": "Trinidad and Tobago",
-      "value": "TTO"
-    },
-    {
-      "label": "Tunisia",
-      "value": "TUN"
-    },
-    {
-      "label": "Turkey",
-      "value": "TUR"
-    },
-    {
-      "label": "Turkmenistan",
-      "value": "TKM"
-    },
-    {
-      "label": "Turks and Caicos Islands",
-      "value": "TCA"
-    },
-    {
-      "label": "Tuvalu",
-      "value": "TUV"
-    },
-    {
-      "label": "Uganda",
-      "value": "UGA"
-    },
-    {
-      "label": "Ukraine",
-      "value": "UKR"
-    },
-    {
-      "label": "United Arab Emirates",
-      "value": "ARE"
-    },
-    {
-      "label": "United Kingdom",
-      "value": "GBR"
-    },
-    {
-      "label": "United States",
-      "value": "USA"
-    },
-    {
-      "label": "Uruguay",
-      "value": "URY"
-    },
-    {
-      "label": "Uzbekistan",
-      "value": "UZB"
-    },
-    {
-      "label": "Vanuatu",
-      "value": "VUT"
-    },
-    {
-      "label": "Venezuela, Bolivarian Republic of",
-      "value": "VEN"
-    },
-    {
-      "label": "Viet Nam",
-      "value": "VNM"
-    },
-    {
-      "label": "Virgin Islands, British",
-      "value": "VGB"
-    },
-    {
-      "label": "Wallis and Futuna",
-      "value": "WLF"
-    },
-    {
-      "label": "Western Sahara",
-      "value": "ESH"
-    },
-    {
-      "label": "Yemen",
-      "value": "YEM"
-    },
-    {
-      "label": "Zambia",
-      "value": "ZMB"
-    },
-    {
-      "label": "Zimbabwe",
-      "value": "ZWE"
+      "label": "Wyoming",
+      "value": "WY"
     }
   ],
   "suffixes": [
@@ -4285,458 +5766,70 @@
     "III",
     "IV"
   ],
-  "genders": [
-    {
-      "label": "Female",
-      "value": "F"
-    },
-    {
-      "label": "Male",
-      "value": "M"
-    }
+  "usaStates": [
+    "AL",
+    "AK",
+    "AS",
+    "AZ",
+    "AR",
+    "AA",
+    "AE",
+    "AP",
+    "CA",
+    "CO",
+    "CT",
+    "DE",
+    "DC",
+    "FM",
+    "FL",
+    "GA",
+    "GU",
+    "HI",
+    "ID",
+    "IL",
+    "IN",
+    "IA",
+    "KS",
+    "KY",
+    "LA",
+    "ME",
+    "MH",
+    "MD",
+    "MA",
+    "MI",
+    "MN",
+    "MS",
+    "MO",
+    "MT",
+    "NE",
+    "NV",
+    "NH",
+    "NJ",
+    "NM",
+    "NY",
+    "NC",
+    "ND",
+    "MP",
+    "OH",
+    "OK",
+    "OR",
+    "PW",
+    "PA",
+    "PR",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "UT",
+    "VT",
+    "VI",
+    "VA",
+    "WA",
+    "WV",
+    "WI",
+    "WY"
   ],
-  "months": [
-    {
-      "label": "Jan",
-      "value": 1
-    },
-    {
-      "label": "Feb",
-      "value": 2
-    },
-    {
-      "label": "Mar",
-      "value": 3
-    },
-    {
-      "label": "Apr",
-      "value": 4
-    },
-    {
-      "label": "May",
-      "value": 5
-    },
-    {
-      "label": "Jun",
-      "value": 6
-    },
-    {
-      "label": "Jul",
-      "value": 7
-    },
-    {
-      "label": "Aug",
-      "value": 8
-    },
-    {
-      "label": "Sep",
-      "value": 9
-    },
-    {
-      "label": "Oct",
-      "value": 10
-    },
-    {
-      "label": "Nov",
-      "value": 11
-    },
-    {
-      "label": "Dec",
-      "value": 12
-    }
-  ],
-  "days": {
-    "1": [
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-      "9",
-      "10",
-      "11",
-      "12",
-      "13",
-      "14",
-      "15",
-      "16",
-      "17",
-      "18",
-      "19",
-      "20",
-      "21",
-      "22",
-      "23",
-      "24",
-      "25",
-      "26",
-      "27",
-      "28",
-      "29",
-      "30",
-      "31"
-    ],
-    "2": [
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-      "9",
-      "10",
-      "11",
-      "12",
-      "13",
-      "14",
-      "15",
-      "16",
-      "17",
-      "18",
-      "19",
-      "20",
-      "21",
-      "22",
-      "23",
-      "24",
-      "25",
-      "26",
-      "27",
-      "28",
-      "29"
-    ],
-    "3": [
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-      "9",
-      "10",
-      "11",
-      "12",
-      "13",
-      "14",
-      "15",
-      "16",
-      "17",
-      "18",
-      "19",
-      "20",
-      "21",
-      "22",
-      "23",
-      "24",
-      "25",
-      "26",
-      "27",
-      "28",
-      "29",
-      "30",
-      "31"
-    ],
-    "4": [
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-      "9",
-      "10",
-      "11",
-      "12",
-      "13",
-      "14",
-      "15",
-      "16",
-      "17",
-      "18",
-      "19",
-      "20",
-      "21",
-      "22",
-      "23",
-      "24",
-      "25",
-      "26",
-      "27",
-      "28",
-      "29",
-      "30"
-    ],
-    "5": [
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-      "9",
-      "10",
-      "11",
-      "12",
-      "13",
-      "14",
-      "15",
-      "16",
-      "17",
-      "18",
-      "19",
-      "20",
-      "21",
-      "22",
-      "23",
-      "24",
-      "25",
-      "26",
-      "27",
-      "28",
-      "29",
-      "30",
-      "31"
-    ],
-    "6": [
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-      "9",
-      "10",
-      "11",
-      "12",
-      "13",
-      "14",
-      "15",
-      "16",
-      "17",
-      "18",
-      "19",
-      "20",
-      "21",
-      "22",
-      "23",
-      "24",
-      "25",
-      "26",
-      "27",
-      "28",
-      "29",
-      "30"
-    ],
-    "7": [
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-      "9",
-      "10",
-      "11",
-      "12",
-      "13",
-      "14",
-      "15",
-      "16",
-      "17",
-      "18",
-      "19",
-      "20",
-      "21",
-      "22",
-      "23",
-      "24",
-      "25",
-      "26",
-      "27",
-      "28",
-      "29",
-      "30",
-      "31"
-    ],
-    "8": [
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-      "9",
-      "10",
-      "11",
-      "12",
-      "13",
-      "14",
-      "15",
-      "16",
-      "17",
-      "18",
-      "19",
-      "20",
-      "21",
-      "22",
-      "23",
-      "24",
-      "25",
-      "26",
-      "27",
-      "28",
-      "29",
-      "30",
-      "31"
-    ],
-    "9": [
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-      "9",
-      "10",
-      "11",
-      "12",
-      "13",
-      "14",
-      "15",
-      "16",
-      "17",
-      "18",
-      "19",
-      "20",
-      "21",
-      "22",
-      "23",
-      "24",
-      "25",
-      "26",
-      "27",
-      "28",
-      "29",
-      "30"
-    ],
-    "10": [
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-      "9",
-      "10",
-      "11",
-      "12",
-      "13",
-      "14",
-      "15",
-      "16",
-      "17",
-      "18",
-      "19",
-      "20",
-      "21",
-      "22",
-      "23",
-      "24",
-      "25",
-      "26",
-      "27",
-      "28",
-      "29",
-      "30",
-      "31"
-    ],
-    "11": [
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-      "9",
-      "10",
-      "11",
-      "12",
-      "13",
-      "14",
-      "15",
-      "16",
-      "17",
-      "18",
-      "19",
-      "20",
-      "21",
-      "22",
-      "23",
-      "24",
-      "25",
-      "26",
-      "27",
-      "28",
-      "29",
-      "30"
-    ],
-    "12": [
-      "1",
-      "2",
-      "3",
-      "4",
-      "5",
-      "6",
-      "7",
-      "8",
-      "9",
-      "10",
-      "11",
-      "12",
-      "13",
-      "14",
-      "15",
-      "16",
-      "17",
-      "18",
-      "19",
-      "20",
-      "21",
-      "22",
-      "23",
-      "24",
-      "25",
-      "26",
-      "27",
-      "28",
-      "29",
-      "30",
-      "31"
-    ]
-  },
   "vaMedicalFacilities": {
     "VT": [
       {
@@ -9013,690 +10106,6 @@
       }
     ]
   },
-  "caregiverProgramFacilities": {
-    "TX": [
-      {
-        "code": "740",
-        "label": "HARLINGEN VA CLINIC"
-      },
-      {
-        "code": "756",
-        "label": "EL PASO HCS"
-      },
-      {
-        "code": "580",
-        "label": "MICHAEL E. DEBAKEY VA MEDICAL CENTER"
-      },
-      {
-        "code": "504",
-        "label": "AMARILLO HCS"
-      },
-      {
-        "code": "519",
-        "label": "WEST TEXAS VA HEALTH CARE SYSTEM - BIG SPRING DIVISION"
-      },
-      {
-        "code": "549",
-        "label": "DALLAS VA MEDICAL CENTER"
-      },
-      {
-        "code": "671",
-        "label": "AUDIE L. MURPHY MEMORIAL HOSP"
-      },
-      {
-        "code": "674",
-        "label": "OLIN E. TEAGUE VET CENTER"
-      }
-    ],
-    "SD": [
-      {
-        "code": "568A4",
-        "label": "HOT SPRINGS, SD MC"
-      },
-      {
-        "code": "438",
-        "label": "SIOUX FALLS VA HCS"
-      },
-      {
-        "code": "568",
-        "label": "BLACK HILLS HEALTH CARE SYSTEM - FT. MEADE DIVISION"
-      }
-    ],
-    "KS": [
-      {
-        "code": "589A6",
-        "label": "DWIGHT D. EISENHOWER VAMC"
-      },
-      {
-        "code": "589A5",
-        "label": "COLMERY O NEIL VAMC"
-      },
-      {
-        "code": "589A7",
-        "label": "ROBERT J. DOLE VAMC"
-      }
-    ],
-    "CA": [
-      {
-        "code": "612A4",
-        "label": "SACRAMENTO VA MEDICAL CENTER"
-      },
-      {
-        "code": "570",
-        "label": "FRESNO VA MEDICAL CENTER"
-      },
-      {
-        "code": "640",
-        "label": "PALO ALTO VA MEDICAL CENTER"
-      },
-      {
-        "code": "662",
-        "label": "SAN FRANCISCO VAMC"
-      },
-      {
-        "code": "600",
-        "label": "VA LONG BEACH HEALTHCARE SYSTEM"
-      },
-      {
-        "code": "605",
-        "label": "LOMA LINDA HCS"
-      },
-      {
-        "code": "664",
-        "label": "VA SAN DIEGO HEALTHCARE SYSTEM (664)"
-      },
-      {
-        "code": "691",
-        "label": "VA GREATER LOS ANGELES HEALTHCARE SYSTEM - WEST LOS ANGELES DIVISION"
-      }
-    ],
-    "ME": [
-      {
-        "code": "402",
-        "label": "MAINE VA HCS"
-      }
-    ],
-    "VT": [
-      {
-        "code": "405",
-        "label": "WHITE RIVER JCT VAMROC"
-      }
-    ],
-    "MA": [
-      {
-        "code": "518",
-        "label": "EDITH NOURSE ROGERS VAMC"
-      },
-      {
-        "code": "523",
-        "label": "VA BOSTON HEALTHCARE SYSTEM - BOSTON DIVISION"
-      },
-      {
-        "code": "631",
-        "label": "VA CNTRL WSTRN MASSCHUSETS HCS"
-      }
-    ],
-    "NH": [
-      {
-        "code": "608",
-        "label": "MANCHESTER VAMC"
-      }
-    ],
-    "RI": [
-      {
-        "code": "650",
-        "label": "PROVIDENCE VAMC"
-      }
-    ],
-    "CT": [
-      {
-        "code": "689",
-        "label": "VA CONNECTICUT HEALTHCARE SYSTEM - WEST HAVEN DIVISION"
-      }
-    ],
-    "MI": [
-      {
-        "code": "506",
-        "label": "ANN ARBOR VA MEDICAL CENTER"
-      },
-      {
-        "code": "515",
-        "label": "BATTLE CREEK VA MEDICAL CENTER"
-      },
-      {
-        "code": "553",
-        "label": "JOHN D. DINGELL VAMC"
-      },
-      {
-        "code": "655",
-        "label": "ALEDA E. LUTZ VAMC"
-      },
-      {
-        "code": "585",
-        "label": "IRON MOUNTAIN VA MEDICAL CENTER"
-      }
-    ],
-    "OH": [
-      {
-        "code": "538",
-        "label": "CHILLICOTHE VA MEDICAL CENTER"
-      },
-      {
-        "code": "539",
-        "label": "CINCINNATI VAMC"
-      },
-      {
-        "code": "541",
-        "label": "CLEVELAND VAMC"
-      },
-      {
-        "code": "552",
-        "label": "DAYTON, OH VAMC"
-      },
-      {
-        "code": "757",
-        "label": "CHALMERS P. WYLIE VA AMBULATORY CARE CENTER (757)"
-      }
-    ],
-    "IN": [
-      {
-        "code": "583",
-        "label": "RICHARD L. ROUDEBUSH VAMC"
-      },
-      {
-        "code": "610",
-        "label": "MARION VA MEDICAL CENTER"
-      }
-    ],
-    "IL": [
-      {
-        "code": "537",
-        "label": "JESSE BROWN VA MEDICAL CENTER"
-      },
-      {
-        "code": "550",
-        "label": "DANVILLE VA MEDICAL CENTER"
-      },
-      {
-        "code": "556",
-        "label": "CAPTN JAMES LOVELL FED HLT CTR"
-      },
-      {
-        "code": "578",
-        "label": "EDWARD J. HINES JR. HOSPITAL"
-      },
-      {
-        "code": "657A5",
-        "label": "MARION VA MEDICAL CENTER"
-      }
-    ],
-    "WI": [
-      {
-        "code": "607",
-        "label": "WILLIAM S. MIDDLETON MEMORIAL VA HOSPITAL"
-      },
-      {
-        "code": "676",
-        "label": "TOMAH VAMC"
-      },
-      {
-        "code": "695",
-        "label": "CLEMENT J ZABLOCKI"
-      }
-    ],
-    "MO": [
-      {
-        "code": "589",
-        "label": "KANSAS CITY VAMC"
-      },
-      {
-        "code": "589A4",
-        "label": "HARRY S. TRUMAN VAMC"
-      },
-      {
-        "code": "657",
-        "label": "VA HEARTLAND-EAST, VISN 15 HCS JOHN COCHRAN MEMORIAL HOSPITAL"
-      },
-      {
-        "code": "657A4",
-        "label": "JOHN PERSHING VAMC"
-      }
-    ],
-    "LA": [
-      {
-        "code": "502",
-        "label": "ALEXANDRIA VA MEDICAL CENTER"
-      },
-      {
-        "code": "629",
-        "label": "NEW ORLEANS VAMC"
-      },
-      {
-        "code": "667",
-        "label": "OVERTON BROOKS VA MEDICAL CENTER"
-      }
-    ],
-    "MS": [
-      {
-        "code": "520",
-        "label": "BILOXI VA MEDICAL CENTER"
-      },
-      {
-        "code": "586",
-        "label": "G.V. (SONNY) MONTGOMERY"
-      }
-    ],
-    "AR": [
-      {
-        "code": "564",
-        "label": "FAYETTEVILLE VA MEDICAL"
-      },
-      {
-        "code": "598",
-        "label": "CENTRAL ARKANSAS HEALTH CARE SYSTEM - LITTLE ROCK"
-      }
-    ],
-    "MT": [
-      {
-        "code": "436",
-        "label": "FORT HARRISON MEDICAL CENTER"
-      }
-    ],
-    "WY": [
-      {
-        "code": "442",
-        "label": "CHEYENNE VA MEDICAL"
-      },
-      {
-        "code": "666",
-        "label": "SHERIDAN VA MEDICAL CENTER"
-      }
-    ],
-    "CO": [
-      {
-        "code": "554",
-        "label": "ROCKY MOUNTAIN REGIONAL VAMC"
-      },
-      {
-        "code": "575",
-        "label": "GRAND JUNCTION VAMC"
-      }
-    ],
-    "OK": [
-      {
-        "code": "623",
-        "label": "MUSKOGEE, OK VAMC"
-      },
-      {
-        "code": "635",
-        "label": "OKLAHOMA CITY VA MEDICAL CENTER"
-      }
-    ],
-    "UT": [
-      {
-        "code": "660",
-        "label": "GEORGE E. WAHLEN VAMC"
-      }
-    ],
-    "NY": [
-      {
-        "code": "526",
-        "label": "BRONX VA HOSPITAL"
-      },
-      {
-        "code": "528",
-        "label": "BUFFALO VA MEDICAL CENTER"
-      },
-      {
-        "code": "528A5",
-        "label": "CANANDAIGUA VA MEDICAL CENTER"
-      },
-      {
-        "code": "528A6",
-        "label": "BATH VA MEDICAL CENTER"
-      },
-      {
-        "code": "528A7",
-        "label": "SYRACUSE VA MEDICAL CENTER"
-      },
-      {
-        "code": "528A8",
-        "label": "SAMUEL S. STRATTON VAMC"
-      },
-      {
-        "code": "620",
-        "label": "VA HUDSON VALLEY HEALTH CARE SYSTEM - MONTROSE DIVISION"
-      },
-      {
-        "code": "630",
-        "label": "VA NEW YORK HARBOR HEALTHCARE SYSTEM - NEW YORK DIVISION"
-      },
-      {
-        "code": "632",
-        "label": "NORTHPORT VAMC NY"
-      }
-    ],
-    "NJ": [
-      {
-        "code": "561",
-        "label": "NEW JERSEY HEALTH CARE SYSTEM - EAST ORANGE"
-      }
-    ],
-    "AK": [
-      {
-        "code": "463",
-        "label": "ANCHORAGE VA MEDICAL CENTER"
-      }
-    ],
-    "ID": [
-      {
-        "code": "531",
-        "label": "BOISE VA MEDICAL CENTER"
-      }
-    ],
-    "OR": [
-      {
-        "code": "648",
-        "label": "PORTLAND VA MEDICAL CENTER"
-      },
-      {
-        "code": "653",
-        "label": "ROSEBURG VA MEDICAL CENTER"
-      },
-      {
-        "code": "692",
-        "label": "WHITE CITY VA MEDICAL CENTER"
-      }
-    ],
-    "WA": [
-      {
-        "code": "663",
-        "label": "SEATTLE VA MEDICAL CENTER"
-      },
-      {
-        "code": "668",
-        "label": "MANN-GRANDSTAFF VAMC"
-      },
-      {
-        "code": "687",
-        "label": "JONATHAN M. WAINWRIGHT VAMC"
-      }
-    ],
-    "HI": [
-      {
-        "code": "459",
-        "label": "SPARK M. MATSUNAGA VAMC"
-      }
-    ],
-    "NV": [
-      {
-        "code": "593",
-        "label": "SOUTHERN NEVADA HCS"
-      },
-      {
-        "code": "654",
-        "label": "IOANNIS A. LOUGARIS VAMC"
-      }
-    ],
-    "NM": [
-      {
-        "code": "501",
-        "label": "RAYMOND G. MURPHY VAMC"
-      }
-    ],
-    "AZ": [
-      {
-        "code": "644",
-        "label": "PHOENIX VAMC"
-      },
-      {
-        "code": "649",
-        "label": "NORTHERN ARIZONA HEALTH CARE SYSTEM - PRESCOTT DIVISION"
-      },
-      {
-        "code": "678",
-        "label": "SOUTHERN ARIZONA HEALTH CARE SYSTEM - TUCSON DIVISION"
-      }
-    ],
-    "ND": [
-      {
-        "code": "437",
-        "label": "FARGO VA HCS"
-      }
-    ],
-    "MN": [
-      {
-        "code": "618",
-        "label": "MINNEAPOLIS VA HCS"
-      },
-      {
-        "code": "656",
-        "label": "ST. CLOUD VA HEALTH CARE SYSTEM"
-      }
-    ],
-    "NE": [
-      {
-        "code": "636",
-        "label": "VA CENTRAL PLAINS HEALTH NETWORK - OMAHA DIVISION"
-      }
-    ],
-    "IA": [
-      {
-        "code": "636A6",
-        "label": "VA CIHS, DES MOINES DIVISION"
-      },
-      {
-        "code": "636A8",
-        "label": "IOWA CITY HCS"
-      }
-    ],
-    "DE": [
-      {
-        "code": "460",
-        "label": "WILMINGTON VA MEDICAL CENTER"
-      }
-    ],
-    "PA": [
-      {
-        "code": "503",
-        "label": "JAMES E VAN ZANDT VAMC"
-      },
-      {
-        "code": "529",
-        "label": "ABIE ABRAHAM VA CLINIC"
-      },
-      {
-        "code": "542",
-        "label": "COATESVILLE VA MEDICAL CENTER"
-      },
-      {
-        "code": "562",
-        "label": "ERIE VA MEDICAL CENTER"
-      },
-      {
-        "code": "595",
-        "label": "LEBANON VA MEDICAL CENTER"
-      },
-      {
-        "code": "642",
-        "label": "PHILADELPHIA, PA VAMC"
-      },
-      {
-        "code": "646",
-        "label": "PITTSBURGH VAMC UNIVERSITY DR."
-      },
-      {
-        "code": "693",
-        "label": "WILKES-BARRE VAMC"
-      }
-    ],
-    "MD": [
-      {
-        "code": "512",
-        "label": "VA MARYLAND HEALTH CARE SYS"
-      }
-    ],
-    "WV": [
-      {
-        "code": "517",
-        "label": "BECKLEY VA MEDICAL CENTER"
-      },
-      {
-        "code": "540",
-        "label": "LOUIS A JOHNSON VAMC"
-      },
-      {
-        "code": "581",
-        "label": "HUNTINGTON VAMC"
-      },
-      {
-        "code": "613",
-        "label": "MARTINSBURG VA MEDICAL CENTER"
-      }
-    ],
-    "DC": [
-      {
-        "code": "688",
-        "label": "WASHINGTON VA MEDICAL CENTER"
-      }
-    ],
-    "NC": [
-      {
-        "code": "558",
-        "label": "DURHAM VA MEDICAL CENTER"
-      },
-      {
-        "code": "565",
-        "label": "FAYETTEVILLE VA MEDICAL CENTER"
-      },
-      {
-        "code": "637",
-        "label": "CHARLES GEORGE VAMC"
-      },
-      {
-        "code": "659",
-        "label": "W.G. HEFNER SALISBURY VAMC"
-      }
-    ],
-    "VA": [
-      {
-        "code": "590",
-        "label": "HAMPTON VA MEDICAL CENTER"
-      },
-      {
-        "code": "652",
-        "label": "HUNTER HOLMES MCGUIRE HOSPITAL"
-      },
-      {
-        "code": "658",
-        "label": "SALEM VA MEDICAL CENTER"
-      }
-    ],
-    "GA": [
-      {
-        "code": "508",
-        "label": "ATLANTA VAMC"
-      },
-      {
-        "code": "509",
-        "label": "AUGUSTA VAMC"
-      },
-      {
-        "code": "557",
-        "label": "DUBLIN"
-      }
-    ],
-    "AL": [
-      {
-        "code": "521",
-        "label": "BIRMINGHAM VAMC"
-      },
-      {
-        "code": "619",
-        "label": "CENTRAL ALABAMA HEALTH CARE SYSTEM - MONTGOMERY DIVISION"
-      },
-      {
-        "code": "679",
-        "label": "TUSCALOOSA VA MEDICAL CENTER"
-      }
-    ],
-    "SC": [
-      {
-        "code": "534",
-        "label": "RALPH H. JOHNSON VA MEDICAL CENTER (534)"
-      },
-      {
-        "code": "544",
-        "label": "WM JENNINGS BRYAN DORN VETERANS AFFAIRS MEDICAL CENTER"
-      }
-    ],
-    "FL": [
-      {
-        "code": "516",
-        "label": "C.W. BILL YOUNG DEPT OF VAMC"
-      },
-      {
-        "code": "546",
-        "label": "BRUCE W. CARTER DEPT OF VAMC"
-      },
-      {
-        "code": "548",
-        "label": "WEST PALM BEACH VAMC"
-      },
-      {
-        "code": "573",
-        "label": "MALCOM RANDALL DEPT OF VAMC"
-      },
-      {
-        "code": "673",
-        "label": "JAMES A. HALEY VETERANS HOSP"
-      },
-      {
-        "code": "675",
-        "label": "ORLANDO VAMC"
-      }
-    ],
-    "PR": [
-      {
-        "code": "672",
-        "label": "SAN JUAN VA MEDICAL CENTER"
-      }
-    ],
-    "KY": [
-      {
-        "code": "596",
-        "label": "LEXINGTON VAMC-LEESTOWN"
-      },
-      {
-        "code": "603",
-        "label": "ROBLEY REX VAMC"
-      }
-    ],
-    "TN": [
-      {
-        "code": "614",
-        "label": "MEMPHIS VA MEDICAL CENTER"
-      },
-      {
-        "code": "621",
-        "label": "JAMES H. QUILLEN VAMC"
-      },
-      {
-        "code": "626",
-        "label": "TENNESSEE VALLEY HCS"
-      }
-    ]
-  },
-  "dependentRelationships": [
-    "Daughter",
-    "Son",
-    "Stepson",
-    "Stepdaughter",
-    "Father",
-    "Mother",
-    "Spouse",
-    "Other"
-  ],
   "yesNo": [
     {
       "label": "Yes",
@@ -9705,378 +10114,6 @@
     {
       "label": "No",
       "value": "N"
-    }
-  ],
-  "usaStates": [
-    "AL",
-    "AK",
-    "AS",
-    "AZ",
-    "AR",
-    "AA",
-    "AE",
-    "AP",
-    "CA",
-    "CO",
-    "CT",
-    "DE",
-    "DC",
-    "FM",
-    "FL",
-    "GA",
-    "GU",
-    "HI",
-    "ID",
-    "IL",
-    "IN",
-    "IA",
-    "KS",
-    "KY",
-    "LA",
-    "ME",
-    "MH",
-    "MD",
-    "MA",
-    "MI",
-    "MN",
-    "MS",
-    "MO",
-    "MT",
-    "NE",
-    "NV",
-    "NH",
-    "NJ",
-    "NM",
-    "NY",
-    "NC",
-    "ND",
-    "MP",
-    "OH",
-    "OK",
-    "OR",
-    "PW",
-    "PA",
-    "PR",
-    "RI",
-    "SC",
-    "SD",
-    "TN",
-    "TX",
-    "UT",
-    "VT",
-    "VI",
-    "VA",
-    "WA",
-    "WV",
-    "WI",
-    "WY"
-  ],
-  "documentTypes526": [
-    {
-      "value": "L015",
-      "label": "Buddy/Lay Statement"
-    },
-    {
-      "value": "L018",
-      "label": "Civilian Police Reports"
-    },
-    {
-      "value": "L029",
-      "label": "Copy of a DD214"
-    },
-    {
-      "value": "L702",
-      "label": "Disability Benefits Questionnaire (DBQ)"
-    },
-    {
-      "value": "L703",
-      "label": "Goldmann Perimetry Chart/Field Of Vision Chart"
-    },
-    {
-      "value": "L034",
-      "label": "Military Personnel Record"
-    },
-    {
-      "value": "L478",
-      "label": "Medical Treatment Records - Furnished by SSA"
-    },
-    {
-      "value": "L048",
-      "label": "Medical Treatment Record - Government Facility"
-    },
-    {
-      "value": "L049",
-      "label": "Medical Treatment Record - Non-Government Facility"
-    },
-    {
-      "value": "L023",
-      "label": "Other Correspondence"
-    },
-    {
-      "value": "L070",
-      "label": "Photographs"
-    },
-    {
-      "value": "L450",
-      "label": "STR - Dental - Photocopy"
-    },
-    {
-      "value": "L451",
-      "label": "STR - Medical - Photocopy"
-    },
-    {
-      "value": "L222",
-      "label": "VA Form 21-0779 - Request for Nursing Home Information in Connection with Claim for Aid & Attendance"
-    },
-    {
-      "value": "L228",
-      "label": "VA Form 21-0781 - Statement in Support of Claim for PTSD"
-    },
-    {
-      "value": "L229",
-      "label": "VA Form 21-0781a - Statement in Support of Claim for PTSD Secondary to Personal Assault"
-    },
-    {
-      "value": "L102",
-      "label": "VA Form 21-2680 - Examination for Housebound Status or Permanent Need for Regular Aid & Attendance"
-    },
-    {
-      "value": "L107",
-      "label": "VA Form 21-4142 - Authorization To Disclose Information"
-    },
-    {
-      "value": "L827",
-      "label": "VA Form 21-4142a - General Release for Medical Provider Information"
-    },
-    {
-      "value": "L115",
-      "label": "VA Form 21-4192 - Request for Employment Information in Connection with Claim for Disability"
-    },
-    {
-      "value": "L117",
-      "label": "VA Form 21-4502 - Application for Automobile or Other Conveyance and Adaptive Equipment Under 38 U.S.C. 3901-3904"
-    },
-    {
-      "value": "L159",
-      "label": "VA Form 26-4555 - Application in Acquiring Specially Adapted Housing or Special Home Adaptation Grant"
-    },
-    {
-      "value": "L133",
-      "label": "VA Form 21-674 - Request for Approval of School Attendance"
-    },
-    {
-      "value": "L139",
-      "label": "VA Form 21-686c - Declaration of Status of Dependents"
-    },
-    {
-      "value": "L149",
-      "label": "VA Form 21-8940 - Veterans Application for Increased Compensation Based on Un-employability"
-    }
-  ],
-  "states50AndDC": [
-    {
-      "label": "Alabama",
-      "value": "AL"
-    },
-    {
-      "label": "Alaska",
-      "value": "AK"
-    },
-    {
-      "label": "Arizona",
-      "value": "AZ"
-    },
-    {
-      "label": "Arkansas",
-      "value": "AR"
-    },
-    {
-      "label": "California",
-      "value": "CA"
-    },
-    {
-      "label": "Colorado",
-      "value": "CO"
-    },
-    {
-      "label": "Connecticut",
-      "value": "CT"
-    },
-    {
-      "label": "Delaware",
-      "value": "DE"
-    },
-    {
-      "label": "District Of Columbia",
-      "value": "DC"
-    },
-    {
-      "label": "Florida",
-      "value": "FL"
-    },
-    {
-      "label": "Georgia",
-      "value": "GA"
-    },
-    {
-      "label": "Hawaii",
-      "value": "HI"
-    },
-    {
-      "label": "Idaho",
-      "value": "ID"
-    },
-    {
-      "label": "Illinois",
-      "value": "IL"
-    },
-    {
-      "label": "Indiana",
-      "value": "IN"
-    },
-    {
-      "label": "Iowa",
-      "value": "IA"
-    },
-    {
-      "label": "Kansas",
-      "value": "KS"
-    },
-    {
-      "label": "Kentucky",
-      "value": "KY"
-    },
-    {
-      "label": "Louisiana",
-      "value": "LA"
-    },
-    {
-      "label": "Maine",
-      "value": "ME"
-    },
-    {
-      "label": "Maryland",
-      "value": "MD"
-    },
-    {
-      "label": "Massachusetts",
-      "value": "MA"
-    },
-    {
-      "label": "Michigan",
-      "value": "MI"
-    },
-    {
-      "label": "Minnesota",
-      "value": "MN"
-    },
-    {
-      "label": "Mississippi",
-      "value": "MS"
-    },
-    {
-      "label": "Missouri",
-      "value": "MO"
-    },
-    {
-      "label": "Montana",
-      "value": "MT"
-    },
-    {
-      "label": "Nebraska",
-      "value": "NE"
-    },
-    {
-      "label": "Nevada",
-      "value": "NV"
-    },
-    {
-      "label": "New Hampshire",
-      "value": "NH"
-    },
-    {
-      "label": "New Jersey",
-      "value": "NJ"
-    },
-    {
-      "label": "New Mexico",
-      "value": "NM"
-    },
-    {
-      "label": "New York",
-      "value": "NY"
-    },
-    {
-      "label": "North Carolina",
-      "value": "NC"
-    },
-    {
-      "label": "North Dakota",
-      "value": "ND"
-    },
-    {
-      "label": "Ohio",
-      "value": "OH"
-    },
-    {
-      "label": "Oklahoma",
-      "value": "OK"
-    },
-    {
-      "label": "Oregon",
-      "value": "OR"
-    },
-    {
-      "label": "Pennsylvania",
-      "value": "PA"
-    },
-    {
-      "label": "Rhode Island",
-      "value": "RI"
-    },
-    {
-      "label": "South Carolina",
-      "value": "SC"
-    },
-    {
-      "label": "South Dakota",
-      "value": "SD"
-    },
-    {
-      "label": "Tennessee",
-      "value": "TN"
-    },
-    {
-      "label": "Texas",
-      "value": "TX"
-    },
-    {
-      "label": "Utah",
-      "value": "UT"
-    },
-    {
-      "label": "Vermont",
-      "value": "VT"
-    },
-    {
-      "label": "Virginia",
-      "value": "VA"
-    },
-    {
-      "label": "Washington",
-      "value": "WA"
-    },
-    {
-      "label": "West Virginia",
-      "value": "WV"
-    },
-    {
-      "label": "Wisconsin",
-      "value": "WI"
-    },
-    {
-      "label": "Wyoming",
-      "value": "WY"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/common/address.js
+++ b/src/common/address.js
@@ -384,7 +384,7 @@ const states = {
     .sort((stateA, stateB) => stateA.label.localeCompare(stateB.label)),
 };
 
-const usaStates = Object.values(states.USA);
+const usaStates = states.USA.map(state => state.value);
 
 const salesforceCountries = [
   {


### PR DESCRIPTION
When I split out the address data from the `constants.json` file (https://github.com/department-of-veterans-affairs/vets-json-schema/pull/395), I also removed lodash.

In the process, I changed

```js
const usaStates = _.map(states.USA, stateData => {
  return stateData.value;
});
```

to

```js
const usaStates = Object.values(states.USA);
```

which was a silly mistake.

This PR changes that code to:

```js
const usaStates = states.USA.map(state => state.value);
```