### PR TITLE
Fix 526 facility names regex

### DIFF
--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -479,7 +479,7 @@ const schema = {
           treatmentCenterName: {
             type: 'string',
             maxLength: 100,
-            pattern: "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$",
+            pattern: "([-a-zA-Z0-9\"\\/&()'.#]([-a-zA-Z0-9()'.# ])?)+$",
           },
           treatmentDateRange: {
             $ref: '#/definitions/dateRangeFromRequired',


### PR DESCRIPTION
## Description

While on a call with a veteran, they tried to select a facility named `William "Bill" Kling Department of Veterans Affairs Outpatient Clinic` in the facility autocomplete input which is supplied by this API (https://app.swaggerhub.com/apis-docs/annaswims/va-gov_api/1.0.0#/facilities/suggestedFacilities).

The regular expression set for the `vaTreatmentFacilities` does not allow double quotes, so an error is displayed to the user

![Screen Shot 2020-04-21 at 3 58 52 PM](https://user-images.githubusercontent.com/136959/79913327-0738c100-83e9-11ea-9630-99e4e8d10a24.png)

Given that the backend and EVSS will accept double quotes, we need to udpate form 526

Code that was shared from Silvio:

```
stringMin. Length:1Max. Length:100Reg. Exp.:([a-zA-Z0-9"\/&\(\)\-'.#]([a-zA-Z0-9(\)\-'.# ])?)+$
```

Associated ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8240