### PR TITLE
8296-Update-property-names

### DIFF
--- a/dist/686C-674-schema.json
+++ b/dist/686C-674-schema.json
@@ -771,7 +771,7 @@
         "veteranInformation": {
           "type": "object",
           "properties": {
-            "veteranFullName": {
+            "fullName": {
               "$ref": "#/definitions/fullName"
             },
             "ssn": {
@@ -919,7 +919,7 @@
                         "$ref": "#/definitions/fullName"
                       },
                       "address": {
-                        "$ref": "#/definitions/address"
+                        "$ref": "#/definitions/addressSchema"
                       }
                     }
                   }
@@ -954,7 +954,7 @@
             "ssn": {
               "$ref": "#/definitions/ssn"
             },
-            "dob": {
+            "birthDate": {
               "$ref": "#/definitions/date"
             },
             "isVeteran": {
@@ -1274,7 +1274,7 @@
     "reportChildStoppedAttendingSchool": {
       "type": "object",
       "properties": {
-        "childNoLongerAtSchoolName": {
+        "fullName": {
           "$ref": "#/definitions/fullName"
         },
         "dateChildLeftSchool": {

--- a/dist/686C-674-schema.json
+++ b/dist/686C-674-schema.json
@@ -121,6 +121,236 @@
         "countryName": {
           "type": "string",
           "enum": [
+            "USA",
+            "AFG",
+            "ALB",
+            "DZA",
+            "AND",
+            "AGO",
+            "AIA",
+            "ATA",
+            "ATG",
+            "ARG",
+            "ARM",
+            "ABW",
+            "AUS",
+            "AUT",
+            "AZE",
+            "BHS",
+            "BHR",
+            "BGD",
+            "BRB",
+            "BLR",
+            "BEL",
+            "BLZ",
+            "BEN",
+            "BMU",
+            "BTN",
+            "BOL",
+            "BIH",
+            "BWA",
+            "BVT",
+            "BRA",
+            "IOT",
+            "BRN",
+            "BGR",
+            "BFA",
+            "BDI",
+            "KHM",
+            "CMR",
+            "CAN",
+            "CPV",
+            "CYM",
+            "CAF",
+            "TCD",
+            "CHL",
+            "CHN",
+            "CXR",
+            "CCK",
+            "COL",
+            "COM",
+            "COG",
+            "COD",
+            "COK",
+            "CRI",
+            "CIV",
+            "HRV",
+            "CUB",
+            "CYP",
+            "CZE",
+            "DNK",
+            "DJI",
+            "DMA",
+            "DOM",
+            "ECU",
+            "EGY",
+            "SLV",
+            "GNQ",
+            "ERI",
+            "EST",
+            "ETH",
+            "FLK",
+            "FRO",
+            "FJI",
+            "FIN",
+            "FRA",
+            "GUF",
+            "PYF",
+            "ATF",
+            "GAB",
+            "GMB",
+            "GEO",
+            "DEU",
+            "GHA",
+            "GIB",
+            "GRC",
+            "GRL",
+            "GRD",
+            "GLP",
+            "GTM",
+            "GIN",
+            "GNB",
+            "GUY",
+            "HTI",
+            "HMD",
+            "HND",
+            "HKG",
+            "HUN",
+            "ISL",
+            "IND",
+            "IDN",
+            "IRN",
+            "IRQ",
+            "IRL",
+            "ISR",
+            "ITA",
+            "JAM",
+            "JPN",
+            "JOR",
+            "KAZ",
+            "KEN",
+            "KIR",
+            "PRK",
+            "KOR",
+            "KWT",
+            "KGZ",
+            "LAO",
+            "LVA",
+            "LBN",
+            "LSO",
+            "LBR",
+            "LBY",
+            "LIE",
+            "LTU",
+            "LUX",
+            "MAC",
+            "MKD",
+            "MDG",
+            "MWI",
+            "MYS",
+            "MDV",
+            "MLI",
+            "MLT",
+            "MTQ",
+            "MRT",
+            "MUS",
+            "MYT",
+            "MEX",
+            "FSM",
+            "MDA",
+            "MCO",
+            "MNG",
+            "MSR",
+            "MAR",
+            "MOZ",
+            "MMR",
+            "NAM",
+            "NRU",
+            "NPL",
+            "ANT",
+            "NLD",
+            "NCL",
+            "NZL",
+            "NIC",
+            "NER",
+            "NGA",
+            "NIU",
+            "NFK",
+            "NOR",
+            "OMN",
+            "PAK",
+            "PAN",
+            "PNG",
+            "PRY",
+            "PER",
+            "PHL",
+            "PCN",
+            "POL",
+            "PRT",
+            "QAT",
+            "REU",
+            "ROU",
+            "RUS",
+            "RWA",
+            "SHN",
+            "KNA",
+            "LCA",
+            "SPM",
+            "VCT",
+            "SMR",
+            "STP",
+            "SAU",
+            "SEN",
+            "SCG",
+            "SYC",
+            "SLE",
+            "SGP",
+            "SVK",
+            "SVN",
+            "SLB",
+            "SOM",
+            "ZAF",
+            "SGS",
+            "ESP",
+            "LKA",
+            "SDN",
+            "SUR",
+            "SWZ",
+            "SWE",
+            "CHE",
+            "SYR",
+            "TWN",
+            "TJK",
+            "TZA",
+            "THA",
+            "TLS",
+            "TGO",
+            "TKL",
+            "TON",
+            "TTO",
+            "TUN",
+            "TUR",
+            "TKM",
+            "TCA",
+            "TUV",
+            "UGA",
+            "UKR",
+            "ARE",
+            "GBR",
+            "URY",
+            "UZB",
+            "VUT",
+            "VAT",
+            "VEN",
+            "VNM",
+            "VGB",
+            "WLF",
+            "ESH",
+            "YEM",
+            "ZMB",
+            "ZWE"
+          ],
+          "enumNames": [
             "United States",
             "Afghanistan",
             "Albania",
@@ -586,7 +816,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "childFullName": {
+                  "fullName": {
                     "$ref": "#/definitions/fullName"
                   },
                   "ssn": {
@@ -609,7 +839,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "childPlaceOfBirth": {
+                  "placeOfBirth": {
                     "$ref": "#/definitions/genericLocation"
                   },
                   "childStatus": {
@@ -636,7 +866,7 @@
                     "type": "object",
                     "properties": {}
                   },
-                  "childPreviouslyMarried": {
+                  "previouslyMarried": {
                     "type": "string",
                     "enum": [
                       "Yes",
@@ -644,7 +874,7 @@
                     ],
                     "default": "No"
                   },
-                  "childPreviousMarriageDetails": {
+                  "previousMarriageDetails": {
                     "type": "object",
                     "properties": {
                       "dateMarriageEnded": {
@@ -683,7 +913,15 @@
                     "$ref": "#/definitions/genericTrueFalse"
                   },
                   "childAddressInfo": {
-                    "$ref": "#/definitions/addressSchema"
+                    "type": "object",
+                    "properties": {
+                      "personChildLivesWith": {
+                        "$ref": "#/definitions/fullName"
+                      },
+                      "address": {
+                        "$ref": "#/definitions/address"
+                      }
+                    }
                   }
                 }
               }
@@ -710,22 +948,22 @@
         "spouseNameInformation": {
           "type": "object",
           "properties": {
-            "spouseFullName": {
+            "fullName": {
               "$ref": "#/definitions/fullName"
             },
-            "spouseSSN": {
+            "ssn": {
               "$ref": "#/definitions/ssn"
             },
-            "spouseDOB": {
+            "dob": {
               "$ref": "#/definitions/date"
             },
-            "isSpouseVeteran": {
+            "isVeteran": {
               "$ref": "#/definitions/genericTrueFalse"
             },
-            "spouseVAFileNumber": {
+            "VAFileNumber": {
               "$ref": "#/definitions/genericNumberAndDashInput"
             },
-            "spouseServiceNumber": {
+            "serviceNumber": {
               "$ref": "#/definitions/genericNumberAndDashInput"
             }
           }
@@ -733,13 +971,13 @@
         "currentMarriageInformation": {
           "type": "object",
           "properties": {
-            "dateOfMarriage": {
+            "date": {
               "$ref": "#/definitions/date"
             },
-            "locationOfMarriage": {
+            "location": {
               "$ref": "#/definitions/genericLocation"
             },
-            "marriageType": {
+            "type": {
               "type": "string",
               "enum": [
                 "CEREMONIAL",
@@ -756,7 +994,7 @@
                 "Other"
               ]
             },
-            "marriageTypeOther": {
+            "typeOther": {
               "$ref": "#/definitions/genericTextInput"
             },
             "view:marriageTypeInformation": {
@@ -772,9 +1010,14 @@
               "$ref": "#/definitions/genericTrueFalse"
             },
             "currentSpouseReasonForSeparation": {
-              "$ref": "#/definitions/genericTextInput"
+              "type": "string",
+              "enum": [
+                "Death",
+                "Divorce",
+                "Other"
+              ]
             },
-            "currentSpouseAddress": {
+            "address": {
               "$ref": "#/definitions/addressSchema"
             }
           }
@@ -790,7 +1033,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "formerSpouseName": {
+                  "fullName": {
                     "$ref": "#/definitions/fullName"
                   }
                 }
@@ -806,10 +1049,10 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "marriageStartDate": {
+                  "startDate": {
                     "$ref": "#/definitions/date"
                   },
-                  "marriageStartLocation": {
+                  "startLocation": {
                     "$ref": "#/definitions/genericLocation"
                   },
                   "reasonMarriageEnded": {
@@ -830,10 +1073,10 @@
                   "reasonMarriageEndedOther": {
                     "$ref": "#/definitions/genericTextInput"
                   },
-                  "marriageEndDate": {
+                  "endDate": {
                     "$ref": "#/definitions/date"
                   },
-                  "marriageEndLocation": {
+                  "endLocation": {
                     "$ref": "#/definitions/genericLocation"
                   }
                 }
@@ -852,7 +1095,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "formerSpouseName": {
+                  "fullName": {
                     "$ref": "#/definitions/fullName"
                   }
                 }
@@ -868,10 +1111,10 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "marriageStartDate": {
+                  "startDate": {
                     "$ref": "#/definitions/date"
                   },
-                  "marriageStartLocation": {
+                  "startLocation": {
                     "$ref": "#/definitions/genericLocation"
                   },
                   "reasonMarriageEnded": {
@@ -892,10 +1135,10 @@
                   "reasonMarriageEndedOther": {
                     "$ref": "#/definitions/genericTextInput"
                   },
-                  "marriageEndDate": {
+                  "endDate": {
                     "$ref": "#/definitions/date"
                   },
-                  "marriageEndLocation": {
+                  "endLocation": {
                     "$ref": "#/definitions/genericLocation"
                   }
                 }
@@ -920,13 +1163,13 @@
     "reportDivorce": {
       "type": "object",
       "properties": {
-        "formerSpouseName": {
+        "fullName": {
           "$ref": "#/definitions/fullName"
         },
-        "dateOfDivorce": {
+        "date": {
           "$ref": "#/definitions/date"
         },
-        "locationOfDivorce": {
+        "location": {
           "$ref": "#/definitions/genericLocation"
         },
         "isMarriageAnnulledOrVoid": {
@@ -934,8 +1177,11 @@
         },
         "explanationOfAnnullmentOrVoid": {
           "type": "string",
-          "maxLength": 500,
-          "pattern": "^(?!\\s)(?!.*?\\s{2,})[^<>%$#@!^&*]+$"
+          "enum": [
+            "Death",
+            "Divorce",
+            "Other"
+          ]
         }
       }
     },
@@ -1001,10 +1247,10 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "deceasedDateOfDeath": {
+                  "date": {
                     "$ref": "#/definitions/date"
                   },
-                  "deceasedLocationOfDeath": {
+                  "location": {
                     "$ref": "#/definitions/genericLocation"
                   }
                 }
@@ -1017,10 +1263,10 @@
     "reportChildMarriage": {
       "type": "object",
       "properties": {
-        "marriedChildName": {
+        "fullName": {
           "$ref": "#/definitions/fullName"
         },
-        "dateChildMarried": {
+        "dateMarried": {
           "$ref": "#/definitions/date"
         }
       }
@@ -1048,7 +1294,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "stepchildName": {
+                  "fullName": {
                     "$ref": "#/definitions/fullName"
                   }
                 }
@@ -1065,11 +1311,11 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "stillSupportingStepchild": {
+                  "supportingStepchild": {
                     "$ref": "#/definitions/genericTrueFalse",
                     "default": false
                   },
-                  "stepchildLivingExpensesPaid": {
+                  "livingExpensesPaid": {
                     "type": "string",
                     "enum": [
                       "More than half",
@@ -1081,7 +1327,7 @@
                   "whoDoesTheStepchildLiveWith": {
                     "$ref": "#/definitions/fullName"
                   },
-                  "stepchildAddress": {
+                  "address": {
                     "$ref": "#/definitions/addressSchema"
                   }
                 }
@@ -1101,13 +1347,13 @@
               "type": "object",
               "properties": {}
             },
-            "studentFullName": {
+            "fullName": {
               "$ref": "#/definitions/fullName"
             },
-            "studentSSN": {
+            "ssn": {
               "$ref": "#/definitions/ssn"
             },
-            "studentDOB": {
+            "birthDate": {
               "$ref": "#/definitions/date"
             }
           }
@@ -1115,10 +1361,10 @@
         "studentAddressMarriageTuition": {
           "type": "object",
           "properties": {
-            "studentAddress": {
+            "address": {
               "$ref": "#/definitions/addressSchema"
             },
-            "studentWasMarried": {
+            "wasMarried": {
               "$ref": "#/definitions/genericTrueFalse"
             },
             "marriageDate": {
@@ -1141,13 +1387,13 @@
             "schoolInformation": {
               "type": "object",
               "properties": {
-                "schoolName": {
+                "name": {
                   "$ref": "#/definitions/genericTextInput"
                 },
                 "trainingProgram": {
                   "$ref": "#/definitions/genericTextInput"
                 },
-                "schoolAddress": {
+                "address": {
                   "$ref": "#/definitions/addressSchema"
                 }
               }
@@ -1157,7 +1403,7 @@
         "studentTermDates": {
           "type": "object",
           "properties": {
-            "termDates": {
+            "currentTermDates": {
               "type": "object",
               "properties": {
                 "officialSchoolStartDate": {
@@ -1199,13 +1445,13 @@
             "lastTermSchoolInformation": {
               "type": "object",
               "properties": {
-                "schoolName": {
+                "name": {
                   "$ref": "#/definitions/genericTextInput"
                 },
-                "schoolAddress": {
+                "address": {
                   "$ref": "#/definitions/addressSchema"
                 },
-                "dateTermBegan": {
+                "termBegin": {
                   "$ref": "#/definitions/date"
                 },
                 "dateTermEnded": {
@@ -1272,7 +1518,7 @@
             "studentDoesHaveNetworth": {
               "$ref": "#/definitions/genericTrueFalse"
             },
-            "networthInformation": {
+            "studentNetworthInformation": {
               "type": "object",
               "properties": {
                 "savings": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/686c-674/schema.js
+++ b/src/schemas/686c-674/schema.js
@@ -133,7 +133,7 @@ const schema = {
         veteranInformation: {
           type: 'object',
           properties: {
-            veteranFullName: {
+            fullName: {
               $ref: '#/definitions/fullName',
             },
             ssn: {
@@ -275,7 +275,7 @@ const schema = {
                         $ref: '#/definitions/fullName',
                       },
                       address: {
-                        $ref: '#/definitions/address',
+                        $ref: '#/definitions/addressSchema',
                       },
                     },
                   },
@@ -311,7 +311,7 @@ const schema = {
             ssn: {
               $ref: '#/definitions/ssn',
             },
-            dob: {
+            birthDate: {
               $ref: '#/definitions/date',
             },
             isVeteran: {
@@ -587,7 +587,7 @@ const schema = {
     reportChildStoppedAttendingSchool: {
       type: 'object',
       properties: {
-        childNoLongerAtSchoolName: {
+        fullName: {
           $ref: '#/definitions/fullName',
         },
         dateChildLeftSchool: {

--- a/src/schemas/686c-674/schema.js
+++ b/src/schemas/686c-674/schema.js
@@ -61,7 +61,8 @@ const schema = {
         },
         countryName: {
           type: 'string',
-          enum: countries.map(country => country.label),
+          enum: countries.map(country => country.value),
+          enumNames: countries.map(country => country.label),
         },
         addressLine1: {
           type: 'string',
@@ -178,7 +179,7 @@ const schema = {
               items: {
                 type: 'object',
                 properties: {
-                  childFullName: {
+                  fullName: {
                     $ref: '#/definitions/fullName',
                   },
                   ssn: {
@@ -201,7 +202,7 @@ const schema = {
               items: {
                 type: 'object',
                 properties: {
-                  childPlaceOfBirth: {
+                  placeOfBirth: {
                     $ref: '#/definitions/genericLocation',
                   },
                   childStatus: {
@@ -228,13 +229,13 @@ const schema = {
                     type: 'object',
                     properties: {},
                   },
-                  childPreviouslyMarried: {
+                  previouslyMarried: {
                     type: 'string',
                     enum: ['Yes', 'No'],
                     default: 'No',
                   },
 
-                  childPreviousMarriageDetails: {
+                  previousMarriageDetails: {
                     type: 'object',
                     properties: {
                       dateMarriageEnded: {
@@ -268,7 +269,15 @@ const schema = {
                     $ref: '#/definitions/genericTrueFalse',
                   },
                   childAddressInfo: {
-                    $ref: '#/definitions/addressSchema',
+                    type: 'object',
+                    properties: {
+                      personChildLivesWith: {
+                        $ref: '#/definitions/fullName',
+                      },
+                      address: {
+                        $ref: '#/definitions/address',
+                      },
+                    },
                   },
                 },
               },
@@ -296,22 +305,22 @@ const schema = {
         spouseNameInformation: {
           type: 'object',
           properties: {
-            spouseFullName: {
+            fullName: {
               $ref: '#/definitions/fullName',
             },
-            spouseSSN: {
+            ssn: {
               $ref: '#/definitions/ssn',
             },
-            spouseDOB: {
+            dob: {
               $ref: '#/definitions/date',
             },
-            isSpouseVeteran: {
+            isVeteran: {
               $ref: '#/definitions/genericTrueFalse',
             },
-            spouseVAFileNumber: {
+            VAFileNumber: {
               $ref: '#/definitions/genericNumberAndDashInput',
             },
-            spouseServiceNumber: {
+            serviceNumber: {
               $ref: '#/definitions/genericNumberAndDashInput',
             },
           },
@@ -319,18 +328,18 @@ const schema = {
         currentMarriageInformation: {
           type: 'object',
           properties: {
-            dateOfMarriage: {
+            date: {
               $ref: '#/definitions/date',
             },
-            locationOfMarriage: {
+            location: {
               $ref: '#/definitions/genericLocation',
             },
-            marriageType: {
+            type: {
               type: 'string',
               enum: ['CEREMONIAL', 'COMMON-LAW', 'TRIBAL', 'PROXY', 'OTHER'],
               enumNames: ['Ceremonial', 'Common-law', 'Tribal', 'Proxy', 'Other'],
             },
-            marriageTypeOther: {
+            typeOther: {
               $ref: '#/definitions/genericTextInput',
             },
             'view:marriageTypeInformation': {
@@ -346,9 +355,10 @@ const schema = {
               $ref: '#/definitions/genericTrueFalse',
             },
             currentSpouseReasonForSeparation: {
-              $ref: '#/definitions/genericTextInput',
+              type: 'string',
+              enum: ['Death', 'Divorce', 'Other'],
             },
-            currentSpouseAddress: {
+            address: {
               $ref: '#/definitions/addressSchema',
             },
           },
@@ -364,7 +374,7 @@ const schema = {
               items: {
                 type: 'object',
                 properties: {
-                  formerSpouseName: {
+                  fullName: {
                     $ref: '#/definitions/fullName',
                   },
                 },
@@ -380,10 +390,10 @@ const schema = {
               items: {
                 type: 'object',
                 properties: {
-                  marriageStartDate: {
+                  startDate: {
                     $ref: '#/definitions/date',
                   },
-                  marriageStartLocation: {
+                  startLocation: {
                     $ref: '#/definitions/genericLocation',
                   },
                   reasonMarriageEnded: {
@@ -394,10 +404,10 @@ const schema = {
                   reasonMarriageEndedOther: {
                     $ref: '#/definitions/genericTextInput',
                   },
-                  marriageEndDate: {
+                  endDate: {
                     $ref: '#/definitions/date',
                   },
-                  marriageEndLocation: {
+                  endLocation: {
                     $ref: '#/definitions/genericLocation',
                   },
                 },
@@ -416,7 +426,7 @@ const schema = {
               items: {
                 type: 'object',
                 properties: {
-                  formerSpouseName: {
+                  fullName: {
                     $ref: '#/definitions/fullName',
                   },
                 },
@@ -432,10 +442,10 @@ const schema = {
               items: {
                 type: 'object',
                 properties: {
-                  marriageStartDate: {
+                  startDate: {
                     $ref: '#/definitions/date',
                   },
-                  marriageStartLocation: {
+                  startLocation: {
                     $ref: '#/definitions/genericLocation',
                   },
                   reasonMarriageEnded: {
@@ -446,10 +456,10 @@ const schema = {
                   reasonMarriageEndedOther: {
                     $ref: '#/definitions/genericTextInput',
                   },
-                  marriageEndDate: {
+                  endDate: {
                     $ref: '#/definitions/date',
                   },
-                  marriageEndLocation: {
+                  endLocation: {
                     $ref: '#/definitions/genericLocation',
                   },
                 },
@@ -475,13 +485,13 @@ const schema = {
     reportDivorce: {
       type: 'object',
       properties: {
-        formerSpouseName: {
+        fullName: {
           $ref: '#/definitions/fullName',
         },
-        dateOfDivorce: {
+        date: {
           $ref: '#/definitions/date',
         },
-        locationOfDivorce: {
+        location: {
           $ref: '#/definitions/genericLocation',
         },
         isMarriageAnnulledOrVoid: {
@@ -489,8 +499,7 @@ const schema = {
         },
         explanationOfAnnullmentOrVoid: {
           type: 'string',
-          maxLength: 500,
-          pattern: '^(?!\\s)(?!.*?\\s{2,})[^<>%$#@!^&*]+$',
+          enum: ['Death', 'Divorce', 'Other'],
         },
       },
     },
@@ -549,10 +558,10 @@ const schema = {
               items: {
                 type: 'object',
                 properties: {
-                  deceasedDateOfDeath: {
+                  date: {
                     $ref: '#/definitions/date',
                   },
-                  deceasedLocationOfDeath: {
+                  location: {
                     $ref: '#/definitions/genericLocation',
                   },
                 },
@@ -566,10 +575,10 @@ const schema = {
     reportChildMarriage: {
       type: 'object',
       properties: {
-        marriedChildName: {
+        fullName: {
           $ref: '#/definitions/fullName',
         },
-        dateChildMarried: {
+        dateMarried: {
           $ref: '#/definitions/date',
         },
       },
@@ -599,7 +608,7 @@ const schema = {
               items: {
                 type: 'object',
                 properties: {
-                  stepchildName: {
+                  fullName: {
                     $ref: '#/definitions/fullName',
                   },
                 },
@@ -616,11 +625,11 @@ const schema = {
               items: {
                 type: 'object',
                 properties: {
-                  stillSupportingStepchild: {
+                  supportingStepchild: {
                     $ref: '#/definitions/genericTrueFalse',
                     default: false,
                   },
-                  stepchildLivingExpensesPaid: {
+                  livingExpensesPaid: {
                     type: 'string',
                     enum: ['More than half', 'Half', 'Less than half'],
                     default: 'More than half',
@@ -628,7 +637,7 @@ const schema = {
                   whoDoesTheStepchildLiveWith: {
                     $ref: '#/definitions/fullName',
                   },
-                  stepchildAddress: {
+                  address: {
                     $ref: '#/definitions/addressSchema',
                   },
                 },
@@ -649,13 +658,13 @@ const schema = {
               type: 'object',
               properties: {},
             },
-            studentFullName: {
+            fullName: {
               $ref: '#/definitions/fullName',
             },
-            studentSSN: {
+            ssn: {
               $ref: '#/definitions/ssn',
             },
-            studentDOB: {
+            birthDate: {
               $ref: '#/definitions/date',
             },
           },
@@ -664,10 +673,10 @@ const schema = {
         studentAddressMarriageTuition: {
           type: 'object',
           properties: {
-            studentAddress: {
+            address: {
               $ref: '#/definitions/addressSchema',
             },
-            studentWasMarried: {
+            wasMarried: {
               $ref: '#/definitions/genericTrueFalse',
             },
             marriageDate: {
@@ -691,13 +700,13 @@ const schema = {
             schoolInformation: {
               type: 'object',
               properties: {
-                schoolName: {
+                name: {
                   $ref: '#/definitions/genericTextInput',
                 },
                 trainingProgram: {
                   $ref: '#/definitions/genericTextInput',
                 },
-                schoolAddress: {
+                address: {
                   $ref: '#/definitions/addressSchema',
                 },
               },
@@ -708,7 +717,7 @@ const schema = {
         studentTermDates: {
           type: 'object',
           properties: {
-            termDates: {
+            currentTermDates: {
               type: 'object',
               properties: {
                 officialSchoolStartDate: {
@@ -751,13 +760,13 @@ const schema = {
             lastTermSchoolInformation: {
               type: 'object',
               properties: {
-                schoolName: {
+                name: {
                   $ref: '#/definitions/genericTextInput',
                 },
-                schoolAddress: {
+                address: {
                   $ref: '#/definitions/addressSchema',
                 },
-                dateTermBegan: {
+                termBegin: {
                   $ref: '#/definitions/date',
                 },
                 dateTermEnded: {
@@ -826,7 +835,7 @@ const schema = {
             studentDoesHaveNetworth: {
               $ref: '#/definitions/genericTrueFalse',
             },
-            networthInformation: {
+            studentNetworthInformation: {
               type: 'object',
               properties: {
                 savings: {

--- a/test/schemas/686c-674/schema.spec.js
+++ b/test/schemas/686c-674/schema.spec.js
@@ -1,7 +1,6 @@
 import SharedTests from '../../support/shared-tests';
 import SchemaTestHelper from '../../support/schema-test-helper';
 import schemas from '../../../dist/schemas';
-import fixtures from '../../support/fixtures';
 
 const schema = schemas['686C-674'];
 const schemaTestHelper = new SchemaTestHelper(schema);
@@ -40,8 +39,8 @@ const testData = {
           last: 'Doe',
         },
         dependentType: 'SPOUSE',
-        deceasedDateOfDeath: '2001-01-02',
-        deceasedLocationOfDeath: {
+        date: '2001-01-02',
+        location: {
           state: 'California',
           city: 'Los Angeles',
         },
@@ -54,17 +53,17 @@ const testData = {
       {
         stepChildren: [
           {
-            stepchildName: {
+            fullName: {
               first: 'John',
               last: 'Doe',
             },
-            stillSupportingStepchild: true,
-            stepchildLivingExpensesPaid: 'Half',
+            supportingStepchild: true,
+            livingExpensesPaid: 'Half',
             whoDoesTheStepchildLiveWith: {
               first: 'James',
               last: 'Doe',
             },
-            stepchildAddress: {
+            address: {
               countryName: 'United States',
               addressLine1: '123 At Home Dr',
               city: 'A City',
@@ -81,22 +80,22 @@ const testData = {
     valid: [
       {
         studentNameAndSSN: {
-          studentFullName: {
+          fullName: {
             first: 'John',
             last: 'Doe',
           },
-          studentSSN: '123121234',
-          studentDOB: '2010-01-04',
+          ssn: '123121234',
+          birthDate: '2010-01-04',
         },
         studentAddressMarriageTuition: {
-          studentAddress: {
-            countryName: 'United States',
+          address: {
+            countryName: 'USA',
             addressLine1: '123 At Home Dr',
             city: 'A City',
             stateCode: 'AL',
             zipCode: '91103',
           },
-          studentWasMarried: true,
+          wasMarried: true,
           marriageDate: '2012-08-08',
           tuitionIsPaidByGovAgency: true,
           agencyName: 'The Government',
@@ -104,10 +103,10 @@ const testData = {
         },
         studentSchoolAddress: {
           schoolInformation: {
-            schoolName: 'Phoenix Online',
+            name: 'Phoenix Online',
             trainingProgram: 'Marine Biology',
-            schoolAddress: {
-              countryName: 'United States',
+            address: {
+              countryName: 'USA',
               addressLine1: '123 At Home Dr',
               city: 'A City',
               stateCode: 'AL',
@@ -116,7 +115,7 @@ const testData = {
           },
         },
         studentTermDates: {
-          termDates: {
+          currentTermDates: {
             officialSchoolStartDate: '2011-01-01',
             expectedStudentStartDate: '2011-01-03',
             expectedGraduationDate: '2014-01-01',
@@ -131,15 +130,15 @@ const testData = {
         studentLastTerm: {
           studentDidAttendSchoolLastTerm: true,
           lastTermSchoolInformation: {
-            schoolName: 'Argosy',
-            schoolAddress: {
-              countryName: 'United States',
+            name: 'Argosy',
+            address: {
+              countryName: 'USA',
               addressLine1: '123 At Home Dr',
               city: 'A City',
               stateCode: 'AL',
               zipCode: '91103',
             },
-            dateTermBegan: '2010-01-01',
+            termBegin: '2010-01-01',
             dateTermEnded: '2010-09-09',
             classesPerWeek: 2,
             hoursPerWeek: 20,
@@ -163,7 +162,7 @@ const testData = {
         },
         studentNetworthInformation: {
           studentDoesHaveNetworth: true,
-          networthInformation: {
+          studentNetworthInformation: {
             savings: '0',
             securities: '0',
             realEstate: '0',
@@ -176,15 +175,15 @@ const testData = {
     invalid: [
       {
         studentNameAndSSN: {
-          studentFullName: {
+          fullName: {
             first: 'John',
             last: 'Doe',
           },
-          studentSSN: '123121234',
-          studentDOB: '2010-01-04',
+          ssn: '123121234',
+          birthDate: '2010-01-04',
         },
         studentAddressMarriageTuition: {
-          studentAddress: {
+          address: {
             countryName: 'United States',
             addressLine1: '123 At Home Dr',
             city: 'A City',
@@ -194,9 +193,9 @@ const testData = {
         },
         studentSchoolAddress: {
           schoolInformation: {
-            schoolName: 'Phoenix Online',
+            name: 'Phoenix Online',
             trainingProgram: 'Marine Biology',
-            schoolAddress: {
+            address: {
               countryName: 'United States',
               addressLine1: '123 At Home Dr',
               city: 'A City',
@@ -206,7 +205,7 @@ const testData = {
           },
         },
         studentTermDates: {
-          termDates: {
+          currentTermDates: {
             officialSchoolStartDate: '2011-01-01',
             expectedStudentStartDate: '2011-01-03',
             expectedGraduationDate: '2014-01-01',
@@ -221,15 +220,15 @@ const testData = {
         studentLastTerm: {
           studentDidAttendSchoolLastTerm: true,
           lastTermSchoolInformation: {
-            schoolName: 'Argosy',
-            schoolAddress: {
+            name: 'Argosy',
+            address: {
               countryName: 'United States',
               addressLine1: '123 At Home Dr',
               city: 'A City',
               stateCode: 'AL',
               zipCode: '91103',
             },
-            dateTermBegan: '2010-01-01',
+            termBegin: '2010-01-01',
             dateTermEnded: '2010-09-09',
             classesPerWeek: 2,
             hoursPerWeek: 20,
@@ -253,51 +252,48 @@ const testData = {
 describe('686c-674 schema', () => {
   // veteran information
   sharedTests.runTest('fullName', [
-    'veteranInformation.veteranInformation.veteranFullName',
-    'addSpouse.spouseNameInformation.spouseFullName',
-    'reportDivorce.formerSpouseName',
-    'reportChildMarriage.marriedChildName',
-    'reportChildStoppedAttendingSchool.childNoLongerAtSchoolName',
-    'report674.studentNameAndSSN.studentFullName',
+    'veteranInformation.veteranInformation.fullName',
+    'addSpouse.spouseNameInformation.fullName',
+    'reportDivorce.fullName',
+    'reportChildMarriage.fullName',
+    'reportChildStoppedAttendingSchool.fullName',
+    'report674.studentNameAndSSN.fullName',
   ]);
   sharedTests.runTest('ssn', [
     'veteranInformation.veteranInformation.ssn',
-    'addSpouse.spouseNameInformation.spouseSSN',
-    'report674.studentNameAndSSN.studentSSN',
+    'addSpouse.spouseNameInformation.ssn',
+    'report674.studentNameAndSSN.ssn',
   ]);
   sharedTests.runTest('date', [
     'veteranInformation.veteranInformation.birthDate',
-    'addSpouse.spouseNameInformation.spouseDOB',
-    'addSpouse.currentMarriageInformation.dateOfMarriage',
-    'reportDivorce.dateOfDivorce',
-    'reportChildMarriage.dateChildMarried',
+    'addSpouse.spouseNameInformation.birthDate',
+    'addSpouse.currentMarriageInformation.date',
+    'reportDivorce.date',
+    'reportChildMarriage.dateMarried',
     'reportChildStoppedAttendingSchool.dateChildLeftSchool',
-    'report674.studentNameAndSSN.studentDOB',
+    'report674.studentNameAndSSN.birthDate',
     'report674.studentAddressMarriageTuition.marriageDate',
     'report674.studentAddressMarriageTuition.datePaymentsBegan',
-    'report674.studentTermDates.termDates.officialSchoolStartDate',
-    'report674.studentTermDates.termDates.expectedStudentStartDate',
-    'report674.studentTermDates.termDates.expectedGraduationDate',
-    'report674.studentLastTerm.lastTermSchoolInformation.dateTermBegan',
+    'report674.studentTermDates.currentTermDates.officialSchoolStartDate',
+    'report674.studentTermDates.currentTermDates.expectedStudentStartDate',
+    'report674.studentTermDates.currentTermDates.expectedGraduationDate',
+    'report674.studentLastTerm.lastTermSchoolInformation.termBegin',
     'report674.studentLastTerm.lastTermSchoolInformation.dateTermEnded',
   ]);
   sharedTests.runTest('phone', ['veteranInformation.veteranAddress.phoneNumber']);
   sharedTests.runTest('email', ['veteranInformation.veteranAddress.emailAddress']);
 
   // Current Marriage
-  schemaTestHelper.testValidAndInvalid('addSpouse.spouseNameInformation.isSpouseVeteran', testData.boolean);
-  schemaTestHelper.testValidAndInvalid('addSpouse.currentMarriageInformation.marriageType', testData.marriageTypes);
+  schemaTestHelper.testValidAndInvalid('addSpouse.spouseNameInformation.isVeteran', testData.boolean);
+  schemaTestHelper.testValidAndInvalid('addSpouse.currentMarriageInformation.type', testData.marriageTypes);
   schemaTestHelper.testValidAndInvalid('addSpouse.doesLiveWithSpouse.spouseDoesLiveWithVeteran', testData.boolean);
   schemaTestHelper.testValidAndInvalid('addSpouse.spouseMarriageHistory.spouseWasMarriedBefore', testData.boolean);
   schemaTestHelper.testValidAndInvalid('addSpouse.veteranMarriageHistory.veteranWasMarriedBefore', testData.boolean);
-  schemaTestHelper.testValidAndInvalid(
-    'addSpouse.currentMarriageInformation.locationOfMarriage',
-    testData.genericLocation,
-  );
+  schemaTestHelper.testValidAndInvalid('addSpouse.currentMarriageInformation.location', testData.genericLocation);
 
   // Report Divorce
   schemaTestHelper.testValidAndInvalid('reportDivorce.isMarriageAnnulledOrVoid', testData.boolean);
-  schemaTestHelper.testValidAndInvalid('reportDivorce.locationOfDivorce', testData.genericLocation);
+  schemaTestHelper.testValidAndInvalid('reportDivorce.location', testData.genericLocation);
 
   // Deceased Dependents
   schemaTestHelper.testValidAndInvalid('deceasedDependents', testData.deceasedDependent);


### PR DESCRIPTION
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/8296)

This pull request generalizes the property names for the 686c-674 by removing some of the workflow-specific prefixes. i.e. `veteranAddress` becomes `address`. 

This pull request also updates all unit tests in `vets-json-schema` impacted by this change.