### PR TITLE
Remove `ratingDecisionId` from 526 submissions

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -581,9 +581,6 @@
           "ratedDisabilityId": {
             "type": "string"
           },
-          "ratingDecisionId": {
-            "type": "string"
-          },
           "diagnosticCode": {
             "type": "number"
           },
@@ -617,9 +614,6 @@
                   "$ref": "#/definitions/specialIssues"
                 },
                 "ratedDisabilityId": {
-                  "type": "string"
-                },
-                "ratingDecisionId": {
                   "type": "string"
                 },
                 "diagnosticCode": {
@@ -1035,7 +1029,7 @@
           "treatmentCenterName": {
             "type": "string",
             "maxLength": 100,
-            "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+            "pattern": "([-a-zA-Z0-9\"\\/&()'.#]([-a-zA-Z0-9()'.# ])?)+$"
           },
           "treatmentDateRange": {
             "$ref": "#/definitions/dateRangeFromRequired"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -30,9 +30,6 @@ const disabilitiesBaseDef = {
       ratedDisabilityId: {
         type: 'string',
       },
-      ratingDecisionId: {
-        type: 'string',
-      },
       diagnosticCode: {
         type: 'number',
       },


### PR DESCRIPTION
## Description

Remove `ratingDecisionid` from form 526 schema because EVSS no longer accepts this value on submission

See https://github.com/department-of-veterans-affairs/va.gov-team/issues/8350 for more details