### PR TITLE
converted schema for making vet info static

### DIFF
--- a/dist/686C-674-schema.json
+++ b/dist/686C-674-schema.json
@@ -770,23 +770,7 @@
       "properties": {
         "veteranInformation": {
           "type": "object",
-          "properties": {
-            "fullName": {
-              "$ref": "#/definitions/fullName"
-            },
-            "ssn": {
-              "$ref": "#/definitions/ssn"
-            },
-            "vaFileNumber": {
-              "$ref": "#/definitions/genericNumberAndDashInput"
-            },
-            "serviceNumber": {
-              "$ref": "#/definitions/genericNumberAndDashInput"
-            },
-            "birthDate": {
-              "$ref": "#/definitions/date"
-            }
-          }
+          "properties": {}
         },
         "veteranAddress": {
           "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "5.0.2",
+  "version": "5.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/686c-674/schema.js
+++ b/src/schemas/686c-674/schema.js
@@ -132,23 +132,7 @@ const schema = {
       properties: {
         veteranInformation: {
           type: 'object',
-          properties: {
-            fullName: {
-              $ref: '#/definitions/fullName',
-            },
-            ssn: {
-              $ref: '#/definitions/ssn',
-            },
-            vaFileNumber: {
-              $ref: '#/definitions/genericNumberAndDashInput',
-            },
-            serviceNumber: {
-              $ref: '#/definitions/genericNumberAndDashInput',
-            },
-            birthDate: {
-              $ref: '#/definitions/date',
-            },
-          },
+          properties: {},
         },
         veteranAddress: {
           type: 'object',

--- a/test/schemas/686c-674/schema.spec.js
+++ b/test/schemas/686c-674/schema.spec.js
@@ -252,20 +252,14 @@ const testData = {
 describe('686c-674 schema', () => {
   // veteran information
   sharedTests.runTest('fullName', [
-    'veteranInformation.veteranInformation.fullName',
     'addSpouse.spouseNameInformation.fullName',
     'reportDivorce.fullName',
     'reportChildMarriage.fullName',
     'reportChildStoppedAttendingSchool.fullName',
     'report674.studentNameAndSSN.fullName',
   ]);
-  sharedTests.runTest('ssn', [
-    'veteranInformation.veteranInformation.ssn',
-    'addSpouse.spouseNameInformation.ssn',
-    'report674.studentNameAndSSN.ssn',
-  ]);
+  sharedTests.runTest('ssn', ['addSpouse.spouseNameInformation.ssn', 'report674.studentNameAndSSN.ssn']);
   sharedTests.runTest('date', [
-    'veteranInformation.veteranInformation.birthDate',
     'addSpouse.spouseNameInformation.birthDate',
     'addSpouse.currentMarriageInformation.date',
     'reportDivorce.date',


### PR DESCRIPTION
This is the vets-json-schema changes to coinside with the changes in [this](https://github.com/department-of-veterans-affairs/va.gov-team/issues/8829) ticket to convert the veteran information to a static display. Since we want the information left out of the review we just need to make the properties empty and we will handle the display in the uiSchema.