### PR TITLE
9206 - Update schema properties for 686

### DIFF
--- a/dist/686C-674-schema.json
+++ b/dist/686C-674-schema.json
@@ -1042,9 +1042,9 @@
                   "reasonMarriageEnded": {
                     "type": "string",
                     "enum": [
-                      "DIVORCE",
-                      "DEATH",
-                      "OTHER"
+                      "Divorce",
+                      "Death",
+                      "Other"
                     ],
                     "enumNames": [
                       "Divorce",
@@ -1102,9 +1102,9 @@
                   "reasonMarriageEnded": {
                     "type": "string",
                     "enum": [
-                      "DIVORCE",
-                      "DEATH",
-                      "OTHER"
+                      "Divorce",
+                      "Death",
+                      "Other"
                     ],
                     "enumNames": [
                       "Divorce",
@@ -1155,8 +1155,8 @@
         "reasonMarriageEnded": {
           "type": "string",
           "enum": [
-            "DIVORCE",
-            "OTHER"
+            "Divorce",
+            "Other"
           ],
           "enumNames": [
             "Divorce",

--- a/dist/686C-674-schema.json
+++ b/dist/686C-674-schema.json
@@ -1044,14 +1044,12 @@
                     "enum": [
                       "DIVORCE",
                       "DEATH",
-                      "ANNULMENT",
                       "OTHER"
                     ],
                     "enumNames": [
                       "Divorce",
                       "Death",
-                      "Annulment",
-                      "Other"
+                      "Annulment/Other"
                     ]
                   },
                   "reasonMarriageEndedOther": {
@@ -1106,14 +1104,12 @@
                     "enum": [
                       "DIVORCE",
                       "DEATH",
-                      "ANNULMENT",
                       "OTHER"
                     ],
                     "enumNames": [
                       "Divorce",
                       "Death",
-                      "Annulment",
-                      "Other"
+                      "Annulment/Other"
                     ]
                   },
                   "reasonMarriageEndedOther": {
@@ -1156,16 +1152,19 @@
         "location": {
           "$ref": "#/definitions/genericLocation"
         },
-        "isMarriageAnnulledOrVoid": {
-          "$ref": "#/definitions/genericTrueFalse"
-        },
-        "explanationOfAnnullmentOrVoid": {
+        "reasonMarriageEnded": {
           "type": "string",
           "enum": [
-            "Death",
+            "DIVORCE",
+            "OTHER"
+          ],
+          "enumNames": [
             "Divorce",
-            "Other"
+            "Annulment/Other"
           ]
+        },
+        "explanationOfOther": {
+          "$ref": "#/definitions/genericTextInput"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/686c-674/schema.js
+++ b/src/schemas/686c-674/schema.js
@@ -382,8 +382,8 @@ const schema = {
                   },
                   reasonMarriageEnded: {
                     type: 'string',
-                    enum: ['DIVORCE', 'DEATH', 'ANNULMENT', 'OTHER'],
-                    enumNames: ['Divorce', 'Death', 'Annulment', 'Other'],
+                    enum: ['DIVORCE', 'DEATH', 'OTHER'],
+                    enumNames: ['Divorce', 'Death', 'Annulment/Other'],
                   },
                   reasonMarriageEndedOther: {
                     $ref: '#/definitions/genericTextInput',
@@ -434,8 +434,8 @@ const schema = {
                   },
                   reasonMarriageEnded: {
                     type: 'string',
-                    enum: ['DIVORCE', 'DEATH', 'ANNULMENT', 'OTHER'],
-                    enumNames: ['Divorce', 'Death', 'Annulment', 'Other'],
+                    enum: ['DIVORCE', 'DEATH', 'OTHER'],
+                    enumNames: ['Divorce', 'Death', 'Annulment/Other'],
                   },
                   reasonMarriageEndedOther: {
                     $ref: '#/definitions/genericTextInput',
@@ -478,12 +478,13 @@ const schema = {
         location: {
           $ref: '#/definitions/genericLocation',
         },
-        isMarriageAnnulledOrVoid: {
-          $ref: '#/definitions/genericTrueFalse',
-        },
-        explanationOfAnnullmentOrVoid: {
+        reasonMarriageEnded: {
           type: 'string',
-          enum: ['Death', 'Divorce', 'Other'],
+          enum: ['DIVORCE', 'OTHER'],
+          enumNames: ['Divorce', 'Annulment/Other'],
+        },
+        explanationOfOther: {
+          $ref: '#/definitions/genericTextInput',
         },
       },
     },

--- a/src/schemas/686c-674/schema.js
+++ b/src/schemas/686c-674/schema.js
@@ -382,7 +382,7 @@ const schema = {
                   },
                   reasonMarriageEnded: {
                     type: 'string',
-                    enum: ['DIVORCE', 'DEATH', 'OTHER'],
+                    enum: ['Divorce', 'Death', 'Other'],
                     enumNames: ['Divorce', 'Death', 'Annulment/Other'],
                   },
                   reasonMarriageEndedOther: {
@@ -434,7 +434,7 @@ const schema = {
                   },
                   reasonMarriageEnded: {
                     type: 'string',
-                    enum: ['DIVORCE', 'DEATH', 'OTHER'],
+                    enum: ['Divorce', 'Death', 'Other'],
                     enumNames: ['Divorce', 'Death', 'Annulment/Other'],
                   },
                   reasonMarriageEndedOther: {
@@ -480,7 +480,7 @@ const schema = {
         },
         reasonMarriageEnded: {
           type: 'string',
-          enum: ['DIVORCE', 'OTHER'],
+          enum: ['Divorce', 'Other'],
           enumNames: ['Divorce', 'Annulment/Other'],
         },
         explanationOfOther: {

--- a/test/schemas/686c-674/schema.spec.js
+++ b/test/schemas/686c-674/schema.spec.js
@@ -31,6 +31,10 @@ const testData = {
     valid: ['CEREMONIAL', 'COMMON-LAW', 'TRIBAL', 'PROXY', 'OTHER'],
     invalid: ['something', 'else', 'entirely'],
   },
+  reasonsMarriageEnded: {
+    valid: ['DIVORCE', 'OTHER'],
+    invalid: ['DEATH', 'SOME_OTHER'],
+  },
   deceasedDependent: {
     valid: [
       {
@@ -286,7 +290,7 @@ describe('686c-674 schema', () => {
   schemaTestHelper.testValidAndInvalid('addSpouse.currentMarriageInformation.location', testData.genericLocation);
 
   // Report Divorce
-  schemaTestHelper.testValidAndInvalid('reportDivorce.isMarriageAnnulledOrVoid', testData.boolean);
+  schemaTestHelper.testValidAndInvalid('reportDivorce.reasonMarriageEnded', testData.reasonsMarriageEnded);
   schemaTestHelper.testValidAndInvalid('reportDivorce.location', testData.genericLocation);
 
   // Deceased Dependents

--- a/test/schemas/686c-674/schema.spec.js
+++ b/test/schemas/686c-674/schema.spec.js
@@ -32,8 +32,8 @@ const testData = {
     invalid: ['something', 'else', 'entirely'],
   },
   reasonsMarriageEnded: {
-    valid: ['DIVORCE', 'OTHER'],
-    invalid: ['DEATH', 'SOME_OTHER'],
+    valid: ['Divorce', 'Other'],
+    invalid: ['DIVORCE', 'OTHER'],
   },
   deceasedDependent: {
     valid: [


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/9206)

This pull request updates the schema properties for some fields in the 686. This was needed to better align with accepted values in BGS. The fields for the report a divorce workflow are also being renamed to `reasonMarriageEnded` and `explanationOfOther` to provide more semantic context to their purpose.