### PR TITLE
21-526EZ: Require isVaEmployee and standardClaim

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -1787,5 +1787,9 @@
         }
       }
     }
-  }
+  },
+  "required": [
+    "isVaEmployee",
+    "standardClaim"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -1068,6 +1068,10 @@ const schema = {
       },
     },
   },
+  required: [
+    isVaEmployee,
+    standardClaim
+  ]
 };
 
 export default schema;

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -1069,8 +1069,8 @@ const schema = {
     },
   },
   required: [
-    isVaEmployee,
-    standardClaim
+    'isVaEmployee',
+    'standardClaim'
   ]
 };
 


### PR DESCRIPTION
## New schema
<!--
Please describe the new schema that is being added and include links to any relevant
issues to help future developers understand the schema and related code.

Please ensure you have incremented the version in `package.json`.
-->

EVSS's xsd for the 526 claim form shows the fields `isVaEmployee` and `standardClaim` as optional/not required. However, we noticed upon submission of BDD 526 claims, EVSS was returning errors telling us that both these fields are conditionally required under some circumstances for the BDD form. To communicate this need between the FE and BE both fields should be "required".

closes department-of-veterans-affairs/va.gov-team#10861

## Pull Requests to update the schema in related repositories
<!--
This PR will be reviewed by someone from a group in CODEOWNERS to ensure that there is a
related front-end and back-end PR where the gem was updated. Please include those links
-->
In progress:
department-of-veterans-affairs/vets-website#0000
department-of-veterans-affairs/vets-api#0000

<!-- The reviewer should just check that the related PRs exist and version is incremented. -->
