### PR TITLE
Temporarily restore 526EZ v1

### DIFF
--- a/dist/21-526EZ-schema.json
+++ b/dist/21-526EZ-schema.json
@@ -1,0 +1,1886 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "SUPPLEMENTAL CLAIM FOR COMPENSATION (21-526EZ)",
+  "type": "object",
+  "definitions": {
+    "address": {
+      "type": "object",
+      "required": [
+        "country",
+        "city",
+        "addressLine1"
+      ],
+      "properties": {
+        "country": {
+          "type": "string",
+          "enum": [
+            "Afghanistan",
+            "Albania",
+            "Algeria",
+            "Angola",
+            "Anguilla",
+            "Antigua",
+            "Antigua and Barbuda",
+            "Argentina",
+            "Armenia",
+            "Australia",
+            "Austria",
+            "Azerbaijan",
+            "Azores",
+            "Bahamas",
+            "Bahrain",
+            "Bangladesh",
+            "Barbados",
+            "Barbuda",
+            "Belarus",
+            "Belgium",
+            "Belize",
+            "Benin",
+            "Bermuda",
+            "Bhutan",
+            "Bolivia",
+            "Bosnia-Herzegovina",
+            "Botswana",
+            "Brazil",
+            "Brunei",
+            "Bulgaria",
+            "Burkina Faso",
+            "Burma",
+            "Burundi",
+            "Cambodia",
+            "Cameroon",
+            "Canada",
+            "Cape Verde",
+            "Cayman Islands",
+            "Central African Republic",
+            "Chad",
+            "Chile",
+            "China",
+            "Colombia",
+            "Comoros",
+            "Congo, Democratic Republic of",
+            "Congo, People's Republic of",
+            "Costa Rica",
+            "Cote d'Ivoire",
+            "Croatia",
+            "Cuba",
+            "Cyprus",
+            "Czech Republic",
+            "Denmark",
+            "Djibouti",
+            "Dominica",
+            "Dominican Republic",
+            "Ecuador",
+            "Egypt",
+            "El Salvador",
+            "England",
+            "Equatorial Guinea",
+            "Eritrea",
+            "Estonia",
+            "Ethiopia",
+            "Fiji",
+            "Finland",
+            "France",
+            "French Guiana",
+            "Gabon",
+            "Gambia",
+            "Georgia",
+            "Germany",
+            "Ghana",
+            "Gibraltar",
+            "Great Britain",
+            "Great Britain and Gibraltar",
+            "Greece",
+            "Greenland",
+            "Grenada",
+            "Guadeloupe",
+            "Guatemala",
+            "Guinea",
+            "Guinea, Republic of Guinea",
+            "Guinea-Bissau",
+            "Guyana",
+            "Haiti",
+            "Honduras",
+            "Hong Kong",
+            "Hungary",
+            "Iceland",
+            "India",
+            "Indonesia",
+            "Iran",
+            "Iraq",
+            "Ireland",
+            "Israel (Jerusalem)",
+            "Israel (Tel Aviv)",
+            "Italy",
+            "Jamaica",
+            "Japan",
+            "Jordan",
+            "Kazakhstan",
+            "Kenya",
+            "Kosovo",
+            "Kuwait",
+            "Kyrgyzstan",
+            "Laos",
+            "Latvia",
+            "Lebanon",
+            "Leeward Islands",
+            "Lesotho",
+            "Liberia",
+            "Libya",
+            "Liechtenstein",
+            "Lithuania",
+            "Luxembourg",
+            "Macao",
+            "Macedonia",
+            "Madagascar",
+            "Malawi",
+            "Malaysia",
+            "Mali",
+            "Malta",
+            "Martinique",
+            "Mauritania",
+            "Mauritius",
+            "Mexico",
+            "Moldavia",
+            "Mongolia",
+            "Montenegro",
+            "Montserrat",
+            "Morocco",
+            "Mozambique",
+            "Namibia",
+            "Nepal",
+            "Netherlands",
+            "Netherlands Antilles",
+            "Nevis",
+            "New Caledonia",
+            "New Zealand",
+            "Nicaragua",
+            "Niger",
+            "Nigeria",
+            "North Korea",
+            "Northern Ireland",
+            "Norway",
+            "Oman",
+            "Pakistan",
+            "Panama",
+            "Papua New Guinea",
+            "Paraguay",
+            "Peru",
+            "Philippines",
+            "Philippines (restricted payments)",
+            "Poland",
+            "Portugal",
+            "Qatar",
+            "Republic of Yemen",
+            "Romania",
+            "Russia",
+            "Rwanda",
+            "Sao-Tome/Principe",
+            "Saudi Arabia",
+            "Scotland",
+            "Senegal",
+            "Serbia",
+            "Serbia/Montenegro",
+            "Seychelles",
+            "Sicily",
+            "Sierra Leone",
+            "Singapore",
+            "Slovakia",
+            "Slovenia",
+            "Somalia",
+            "South Africa",
+            "South Korea",
+            "Spain",
+            "Sri Lanka",
+            "St. Kitts",
+            "St. Lucia",
+            "St. Vincent",
+            "Sudan",
+            "Suriname",
+            "Swaziland",
+            "Sweden",
+            "Switzerland",
+            "Syria",
+            "Taiwan",
+            "Tajikistan",
+            "Tanzania",
+            "Thailand",
+            "Togo",
+            "Trinidad and Tobago",
+            "Tunisia",
+            "Turkey (Adana only)",
+            "Turkey (except Adana)",
+            "Turkmenistan",
+            "USA",
+            "Uganda",
+            "Ukraine",
+            "United Arab Emirates",
+            "United Kingdom",
+            "Uruguay",
+            "Uzbekistan",
+            "Vanuatu",
+            "Venezuela",
+            "Vietnam",
+            "Wales",
+            "Western Samoa",
+            "Yemen Arab Republic",
+            "Zambia",
+            "Zimbabwe"
+          ],
+          "default": "USA"
+        },
+        "addressLine1": {
+          "type": "string",
+          "maxLength": 20,
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+        },
+        "addressLine2": {
+          "type": "string",
+          "maxLength": 20,
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+        },
+        "addressLine3": {
+          "type": "string",
+          "maxLength": 20,
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+        },
+        "city": {
+          "type": "string",
+          "maxLength": 30,
+          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "AL",
+            "UM",
+            "AS",
+            "AZ",
+            "AR",
+            "AA",
+            "AE",
+            "AP",
+            "CA",
+            "CO",
+            "CT",
+            "DE",
+            "DC",
+            "FM",
+            "FL",
+            "GA",
+            "GU",
+            "HI",
+            "ID",
+            "IL",
+            "IN",
+            "IA",
+            "KS",
+            "KY",
+            "LA",
+            "ME",
+            "MH",
+            "MD",
+            "MA",
+            "MI",
+            "MN",
+            "MS",
+            "AK",
+            "MT",
+            "NE",
+            "NV",
+            "NH",
+            "NJ",
+            "NM",
+            "NY",
+            "NC",
+            "ND",
+            "MP",
+            "OH",
+            "OK",
+            "OR",
+            "PW",
+            "PA",
+            "PR",
+            "RI",
+            "SC",
+            "SD",
+            "TN",
+            "TX",
+            "UT",
+            "VT",
+            "VI",
+            "VA",
+            "WA",
+            "WV",
+            "WI",
+            "WY",
+            "PI",
+            "MO"
+          ],
+          "enumNames": [
+            "Alabama",
+            "U.S. Minor Outlying Islands",
+            "American Samoa",
+            "Arizona",
+            "Arkansas",
+            "Armed Forces Americas (AA)",
+            "Armed Forces Europe (AE)",
+            "Armed Forces Pacific (AP)",
+            "California",
+            "Colorado",
+            "Connecticut",
+            "Delaware",
+            "District Of Columbia",
+            "Federated States Of Micronesia",
+            "Florida",
+            "Georgia",
+            "Guam",
+            "Hawaii",
+            "Idaho",
+            "Illinois",
+            "Indiana",
+            "Iowa",
+            "Kansas",
+            "Kentucky",
+            "Louisiana",
+            "Maine",
+            "Marshall Islands",
+            "Maryland",
+            "Massachusetts",
+            "Michigan",
+            "Minnesota",
+            "Mississippi",
+            "Alaska",
+            "Montana",
+            "Nebraska",
+            "Nevada",
+            "New Hampshire",
+            "New Jersey",
+            "New Mexico",
+            "New York",
+            "North Carolina",
+            "North Dakota",
+            "Northern Mariana Islands",
+            "Ohio",
+            "Oklahoma",
+            "Oregon",
+            "Palau",
+            "Pennsylvania",
+            "Puerto Rico",
+            "Rhode Island",
+            "South Carolina",
+            "South Dakota",
+            "Tennessee",
+            "Texas",
+            "Utah",
+            "Vermont",
+            "Virgin Islands",
+            "Virginia",
+            "Washington",
+            "West Virginia",
+            "Wisconsin",
+            "Wyoming",
+            "Philippine Islands",
+            "Missouri"
+          ]
+        },
+        "zipCode": {
+          "type": "string",
+          "pattern": "^\\d{5}(?:([-\\s]?)\\d{4})?$"
+        }
+      }
+    },
+    "vaTreatmentCenterAddress": {
+      "type": "object",
+      "required": [
+        "country"
+      ],
+      "properties": {
+        "country": {
+          "type": "string",
+          "enum": [
+            "Afghanistan",
+            "Albania",
+            "Algeria",
+            "Angola",
+            "Anguilla",
+            "Antigua",
+            "Antigua and Barbuda",
+            "Argentina",
+            "Armenia",
+            "Australia",
+            "Austria",
+            "Azerbaijan",
+            "Azores",
+            "Bahamas",
+            "Bahrain",
+            "Bangladesh",
+            "Barbados",
+            "Barbuda",
+            "Belarus",
+            "Belgium",
+            "Belize",
+            "Benin",
+            "Bermuda",
+            "Bhutan",
+            "Bolivia",
+            "Bosnia-Herzegovina",
+            "Botswana",
+            "Brazil",
+            "Brunei",
+            "Bulgaria",
+            "Burkina Faso",
+            "Burma",
+            "Burundi",
+            "Cambodia",
+            "Cameroon",
+            "Canada",
+            "Cape Verde",
+            "Cayman Islands",
+            "Central African Republic",
+            "Chad",
+            "Chile",
+            "China",
+            "Colombia",
+            "Comoros",
+            "Congo, Democratic Republic of",
+            "Congo, People's Republic of",
+            "Costa Rica",
+            "Cote d'Ivoire",
+            "Croatia",
+            "Cuba",
+            "Cyprus",
+            "Czech Republic",
+            "Denmark",
+            "Djibouti",
+            "Dominica",
+            "Dominican Republic",
+            "Ecuador",
+            "Egypt",
+            "El Salvador",
+            "England",
+            "Equatorial Guinea",
+            "Eritrea",
+            "Estonia",
+            "Ethiopia",
+            "Fiji",
+            "Finland",
+            "France",
+            "French Guiana",
+            "Gabon",
+            "Gambia",
+            "Georgia",
+            "Germany",
+            "Ghana",
+            "Gibraltar",
+            "Great Britain",
+            "Great Britain and Gibraltar",
+            "Greece",
+            "Greenland",
+            "Grenada",
+            "Guadeloupe",
+            "Guatemala",
+            "Guinea",
+            "Guinea, Republic of Guinea",
+            "Guinea-Bissau",
+            "Guyana",
+            "Haiti",
+            "Honduras",
+            "Hong Kong",
+            "Hungary",
+            "Iceland",
+            "India",
+            "Indonesia",
+            "Iran",
+            "Iraq",
+            "Ireland",
+            "Israel (Jerusalem)",
+            "Israel (Tel Aviv)",
+            "Italy",
+            "Jamaica",
+            "Japan",
+            "Jordan",
+            "Kazakhstan",
+            "Kenya",
+            "Kosovo",
+            "Kuwait",
+            "Kyrgyzstan",
+            "Laos",
+            "Latvia",
+            "Lebanon",
+            "Leeward Islands",
+            "Lesotho",
+            "Liberia",
+            "Libya",
+            "Liechtenstein",
+            "Lithuania",
+            "Luxembourg",
+            "Macao",
+            "Macedonia",
+            "Madagascar",
+            "Malawi",
+            "Malaysia",
+            "Mali",
+            "Malta",
+            "Martinique",
+            "Mauritania",
+            "Mauritius",
+            "Mexico",
+            "Moldavia",
+            "Mongolia",
+            "Montenegro",
+            "Montserrat",
+            "Morocco",
+            "Mozambique",
+            "Namibia",
+            "Nepal",
+            "Netherlands",
+            "Netherlands Antilles",
+            "Nevis",
+            "New Caledonia",
+            "New Zealand",
+            "Nicaragua",
+            "Niger",
+            "Nigeria",
+            "North Korea",
+            "Northern Ireland",
+            "Norway",
+            "Oman",
+            "Pakistan",
+            "Panama",
+            "Papua New Guinea",
+            "Paraguay",
+            "Peru",
+            "Philippines",
+            "Philippines (restricted payments)",
+            "Poland",
+            "Portugal",
+            "Qatar",
+            "Republic of Yemen",
+            "Romania",
+            "Russia",
+            "Rwanda",
+            "Sao-Tome/Principe",
+            "Saudi Arabia",
+            "Scotland",
+            "Senegal",
+            "Serbia",
+            "Serbia/Montenegro",
+            "Seychelles",
+            "Sicily",
+            "Sierra Leone",
+            "Singapore",
+            "Slovakia",
+            "Slovenia",
+            "Somalia",
+            "South Africa",
+            "South Korea",
+            "Spain",
+            "Sri Lanka",
+            "St. Kitts",
+            "St. Lucia",
+            "St. Vincent",
+            "Sudan",
+            "Suriname",
+            "Swaziland",
+            "Sweden",
+            "Switzerland",
+            "Syria",
+            "Taiwan",
+            "Tajikistan",
+            "Tanzania",
+            "Thailand",
+            "Togo",
+            "Trinidad and Tobago",
+            "Tunisia",
+            "Turkey (Adana only)",
+            "Turkey (except Adana)",
+            "Turkmenistan",
+            "USA",
+            "Uganda",
+            "Ukraine",
+            "United Arab Emirates",
+            "United Kingdom",
+            "Uruguay",
+            "Uzbekistan",
+            "Vanuatu",
+            "Venezuela",
+            "Vietnam",
+            "Wales",
+            "Western Samoa",
+            "Yemen Arab Republic",
+            "Zambia",
+            "Zimbabwe"
+          ],
+          "default": "USA"
+        },
+        "city": {
+          "type": "string",
+          "maxLength": 30,
+          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "AL",
+            "UM",
+            "AS",
+            "AZ",
+            "AR",
+            "AA",
+            "AE",
+            "AP",
+            "CA",
+            "CO",
+            "CT",
+            "DE",
+            "DC",
+            "FM",
+            "FL",
+            "GA",
+            "GU",
+            "HI",
+            "ID",
+            "IL",
+            "IN",
+            "IA",
+            "KS",
+            "KY",
+            "LA",
+            "ME",
+            "MH",
+            "MD",
+            "MA",
+            "MI",
+            "MN",
+            "MS",
+            "AK",
+            "MT",
+            "NE",
+            "NV",
+            "NH",
+            "NJ",
+            "NM",
+            "NY",
+            "NC",
+            "ND",
+            "MP",
+            "OH",
+            "OK",
+            "OR",
+            "PW",
+            "PA",
+            "PR",
+            "RI",
+            "SC",
+            "SD",
+            "TN",
+            "TX",
+            "UT",
+            "VT",
+            "VI",
+            "VA",
+            "WA",
+            "WV",
+            "WI",
+            "WY",
+            "PI",
+            "MO"
+          ],
+          "enumNames": [
+            "Alabama",
+            "U.S. Minor Outlying Islands",
+            "American Samoa",
+            "Arizona",
+            "Arkansas",
+            "Armed Forces Americas (AA)",
+            "Armed Forces Europe (AE)",
+            "Armed Forces Pacific (AP)",
+            "California",
+            "Colorado",
+            "Connecticut",
+            "Delaware",
+            "District Of Columbia",
+            "Federated States Of Micronesia",
+            "Florida",
+            "Georgia",
+            "Guam",
+            "Hawaii",
+            "Idaho",
+            "Illinois",
+            "Indiana",
+            "Iowa",
+            "Kansas",
+            "Kentucky",
+            "Louisiana",
+            "Maine",
+            "Marshall Islands",
+            "Maryland",
+            "Massachusetts",
+            "Michigan",
+            "Minnesota",
+            "Mississippi",
+            "Alaska",
+            "Montana",
+            "Nebraska",
+            "Nevada",
+            "New Hampshire",
+            "New Jersey",
+            "New Mexico",
+            "New York",
+            "North Carolina",
+            "North Dakota",
+            "Northern Mariana Islands",
+            "Ohio",
+            "Oklahoma",
+            "Oregon",
+            "Palau",
+            "Pennsylvania",
+            "Puerto Rico",
+            "Rhode Island",
+            "South Carolina",
+            "South Dakota",
+            "Tennessee",
+            "Texas",
+            "Utah",
+            "Vermont",
+            "Virgin Islands",
+            "Virginia",
+            "Washington",
+            "West Virginia",
+            "Wisconsin",
+            "Wyoming",
+            "Philippine Islands",
+            "Missouri"
+          ]
+        }
+      }
+    },
+    "date": {
+      "pattern": "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$",
+      "type": "string"
+    },
+    "dateRange": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "$ref": "#/definitions/date"
+        },
+        "to": {
+          "$ref": "#/definitions/date"
+        }
+      }
+    },
+    "dateRangeFromRequired": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "$ref": "#/definitions/date"
+        },
+        "to": {
+          "$ref": "#/definitions/date"
+        }
+      },
+      "required": [
+        "from"
+      ]
+    },
+    "dateRangeAllRequired": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "$ref": "#/definitions/date"
+        },
+        "to": {
+          "$ref": "#/definitions/date"
+        }
+      },
+      "required": [
+        "from",
+        "to"
+      ]
+    },
+    "disabilities": {
+      "type": "array",
+      "maxItems": 100,
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "disabilityActionType"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "disabilityActionType": {
+            "type": "string",
+            "enum": [
+              "NONE",
+              "NEW",
+              "SECONDARY",
+              "INCREASE",
+              "REOPEN"
+            ]
+          },
+          "ratedDisabilityId": {
+            "type": "string"
+          },
+          "ratingDecisionId": {
+            "type": "string"
+          },
+          "diagnosticCode": {
+            "type": "number"
+          },
+          "classificationCode": {
+            "type": "string"
+          },
+          "secondaryDisabilities": {
+            "type": "array",
+            "maxItems": 100,
+            "items": {
+              "type": "object",
+              "required": [
+                "name",
+                "disabilityActionType"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "disabilityActionType": {
+                  "type": "string",
+                  "enum": [
+                    "NONE",
+                    "NEW",
+                    "SECONDARY",
+                    "INCREASE",
+                    "REOPEN"
+                  ]
+                },
+                "ratedDisabilityId": {
+                  "type": "string"
+                },
+                "ratingDecisionId": {
+                  "type": "string"
+                },
+                "diagnosticCode": {
+                  "type": "number"
+                },
+                "classificationCode": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "minItems": 1
+    },
+    "fullName": {
+      "type": "object",
+      "properties": {
+        "first": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 30,
+          "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+        },
+        "middle": {
+          "type": "string",
+          "pattern": "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
+        },
+        "last": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 30,
+          "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+        }
+      },
+      "required": [
+        "first",
+        "last"
+      ]
+    },
+    "phone": {
+      "type": "string",
+      "pattern": "^\\d{10}$"
+    },
+    "form4142": {
+      "type": "object",
+      "properties": {
+        "limitedConsent": {
+          "type": "string"
+        },
+        "providerFacility": {
+          "type": "array",
+          "required": [
+            "providerFacilityName",
+            "treatmentDateRange",
+            "providerFacilityAddress"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "providerFacilityName": {
+                "type": "string"
+              },
+              "treatmentDateRange": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/dateRange"
+                }
+              },
+              "providerFacilityAddress": {
+                "$ref": "#/definitions/centralMailAddress"
+              }
+            }
+          }
+        },
+        "privacyAgreementAccepted": {
+          "$ref": "#/definitions/privacyAgreementAccepted"
+        }
+      }
+    },
+    "centralMailAddress": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "country": {
+              "type": "string",
+              "enum": [
+                "CAN"
+              ]
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "AB",
+                "BC",
+                "MB",
+                "NB",
+                "NF",
+                "NT",
+                "NV",
+                "NU",
+                "ON",
+                "PE",
+                "QC",
+                "SK",
+                "YT"
+              ]
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "country": {
+              "type": "string",
+              "enum": [
+                "MEX"
+              ]
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "aguascalientes",
+                "baja-california-norte",
+                "baja-california-sur",
+                "campeche",
+                "chiapas",
+                "chihuahua",
+                "coahuila",
+                "colima",
+                "distrito-federal",
+                "durango",
+                "guanajuato",
+                "guerrero",
+                "hidalgo",
+                "jalisco",
+                "mexico",
+                "michoacan",
+                "morelos",
+                "nayarit",
+                "nuevo-leon",
+                "oaxaca",
+                "puebla",
+                "queretaro",
+                "quintana-roo",
+                "san-luis-potosi",
+                "sinaloa",
+                "sonora",
+                "tabasco",
+                "tamaulipas",
+                "tlaxcala",
+                "veracruz",
+                "yucatan",
+                "zacatecas"
+              ]
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "country": {
+              "type": "string",
+              "enum": [
+                "USA"
+              ]
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "AL",
+                "AK",
+                "AS",
+                "AZ",
+                "AR",
+                "AA",
+                "AE",
+                "AP",
+                "CA",
+                "CO",
+                "CT",
+                "DE",
+                "DC",
+                "FM",
+                "FL",
+                "GA",
+                "GU",
+                "HI",
+                "ID",
+                "IL",
+                "IN",
+                "IA",
+                "KS",
+                "KY",
+                "LA",
+                "ME",
+                "MH",
+                "MD",
+                "MA",
+                "MI",
+                "MN",
+                "MS",
+                "MO",
+                "MT",
+                "NE",
+                "NV",
+                "NH",
+                "NJ",
+                "NM",
+                "NY",
+                "NC",
+                "ND",
+                "MP",
+                "OH",
+                "OK",
+                "OR",
+                "PW",
+                "PA",
+                "PR",
+                "RI",
+                "SC",
+                "SD",
+                "TN",
+                "TX",
+                "UT",
+                "VT",
+                "VI",
+                "VA",
+                "WA",
+                "WV",
+                "WI",
+                "WY"
+              ]
+            },
+            "postalCode": {
+              "type": "string",
+              "pattern": "^(\\d{5})(?:[-](\\d{4}))?$"
+            }
+          }
+        },
+        {
+          "properties": {
+            "country": {
+              "not": {
+                "type": "string",
+                "enum": [
+                  "CAN",
+                  "MEX",
+                  "USA"
+                ]
+              }
+            },
+            "state": {
+              "type": "string",
+              "maxLength": 51
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 51
+            }
+          }
+        }
+      ],
+      "properties": {
+        "street": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50
+        },
+        "street2": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50
+        },
+        "city": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 51
+        }
+      },
+      "required": [
+        "postalCode"
+      ]
+    }
+  },
+  "required": [
+    "veteran",
+    "serviceInformation",
+    "disabilities",
+    "standardClaim"
+  ],
+  "properties": {
+    "veteran": {
+      "type": "object",
+      "required": [
+        "emailAddress",
+        "mailingAddress",
+        "primaryPhone"
+      ],
+      "properties": {
+        "emailAddress": {
+          "type": "string",
+          "minLength": 6,
+          "maxLength": 80,
+          "pattern": "^[_A-Za-z0-9-]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$"
+        },
+        "alternateEmailAddress": {
+          "type": "string",
+          "format": "email",
+          "maxLength": 80,
+          "pattern": "^[_A-Za-z0-9-]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$"
+        },
+        "mailingAddress": {
+          "$ref": "#/definitions/address"
+        },
+        "primaryPhone": {
+          "$ref": "#/definitions/phone"
+        },
+        "forwardingAddress": {
+          "type": "object",
+          "properties": {
+            "country": {
+              "type": "string",
+              "enum": [
+                "Afghanistan",
+                "Albania",
+                "Algeria",
+                "Angola",
+                "Anguilla",
+                "Antigua",
+                "Antigua and Barbuda",
+                "Argentina",
+                "Armenia",
+                "Australia",
+                "Austria",
+                "Azerbaijan",
+                "Azores",
+                "Bahamas",
+                "Bahrain",
+                "Bangladesh",
+                "Barbados",
+                "Barbuda",
+                "Belarus",
+                "Belgium",
+                "Belize",
+                "Benin",
+                "Bermuda",
+                "Bhutan",
+                "Bolivia",
+                "Bosnia-Herzegovina",
+                "Botswana",
+                "Brazil",
+                "Brunei",
+                "Bulgaria",
+                "Burkina Faso",
+                "Burma",
+                "Burundi",
+                "Cambodia",
+                "Cameroon",
+                "Canada",
+                "Cape Verde",
+                "Cayman Islands",
+                "Central African Republic",
+                "Chad",
+                "Chile",
+                "China",
+                "Colombia",
+                "Comoros",
+                "Congo, Democratic Republic of",
+                "Congo, People's Republic of",
+                "Costa Rica",
+                "Cote d'Ivoire",
+                "Croatia",
+                "Cuba",
+                "Cyprus",
+                "Czech Republic",
+                "Denmark",
+                "Djibouti",
+                "Dominica",
+                "Dominican Republic",
+                "Ecuador",
+                "Egypt",
+                "El Salvador",
+                "England",
+                "Equatorial Guinea",
+                "Eritrea",
+                "Estonia",
+                "Ethiopia",
+                "Fiji",
+                "Finland",
+                "France",
+                "French Guiana",
+                "Gabon",
+                "Gambia",
+                "Georgia",
+                "Germany",
+                "Ghana",
+                "Gibraltar",
+                "Great Britain",
+                "Great Britain and Gibraltar",
+                "Greece",
+                "Greenland",
+                "Grenada",
+                "Guadeloupe",
+                "Guatemala",
+                "Guinea",
+                "Guinea, Republic of Guinea",
+                "Guinea-Bissau",
+                "Guyana",
+                "Haiti",
+                "Honduras",
+                "Hong Kong",
+                "Hungary",
+                "Iceland",
+                "India",
+                "Indonesia",
+                "Iran",
+                "Iraq",
+                "Ireland",
+                "Israel (Jerusalem)",
+                "Israel (Tel Aviv)",
+                "Italy",
+                "Jamaica",
+                "Japan",
+                "Jordan",
+                "Kazakhstan",
+                "Kenya",
+                "Kosovo",
+                "Kuwait",
+                "Kyrgyzstan",
+                "Laos",
+                "Latvia",
+                "Lebanon",
+                "Leeward Islands",
+                "Lesotho",
+                "Liberia",
+                "Libya",
+                "Liechtenstein",
+                "Lithuania",
+                "Luxembourg",
+                "Macao",
+                "Macedonia",
+                "Madagascar",
+                "Malawi",
+                "Malaysia",
+                "Mali",
+                "Malta",
+                "Martinique",
+                "Mauritania",
+                "Mauritius",
+                "Mexico",
+                "Moldavia",
+                "Mongolia",
+                "Montenegro",
+                "Montserrat",
+                "Morocco",
+                "Mozambique",
+                "Namibia",
+                "Nepal",
+                "Netherlands",
+                "Netherlands Antilles",
+                "Nevis",
+                "New Caledonia",
+                "New Zealand",
+                "Nicaragua",
+                "Niger",
+                "Nigeria",
+                "North Korea",
+                "Northern Ireland",
+                "Norway",
+                "Oman",
+                "Pakistan",
+                "Panama",
+                "Papua New Guinea",
+                "Paraguay",
+                "Peru",
+                "Philippines",
+                "Philippines (restricted payments)",
+                "Poland",
+                "Portugal",
+                "Qatar",
+                "Republic of Yemen",
+                "Romania",
+                "Russia",
+                "Rwanda",
+                "Sao-Tome/Principe",
+                "Saudi Arabia",
+                "Scotland",
+                "Senegal",
+                "Serbia",
+                "Serbia/Montenegro",
+                "Seychelles",
+                "Sicily",
+                "Sierra Leone",
+                "Singapore",
+                "Slovakia",
+                "Slovenia",
+                "Somalia",
+                "South Africa",
+                "South Korea",
+                "Spain",
+                "Sri Lanka",
+                "St. Kitts",
+                "St. Lucia",
+                "St. Vincent",
+                "Sudan",
+                "Suriname",
+                "Swaziland",
+                "Sweden",
+                "Switzerland",
+                "Syria",
+                "Taiwan",
+                "Tajikistan",
+                "Tanzania",
+                "Thailand",
+                "Togo",
+                "Trinidad and Tobago",
+                "Tunisia",
+                "Turkey (Adana only)",
+                "Turkey (except Adana)",
+                "Turkmenistan",
+                "USA",
+                "Uganda",
+                "Ukraine",
+                "United Arab Emirates",
+                "United Kingdom",
+                "Uruguay",
+                "Uzbekistan",
+                "Vanuatu",
+                "Venezuela",
+                "Vietnam",
+                "Wales",
+                "Western Samoa",
+                "Yemen Arab Republic",
+                "Zambia",
+                "Zimbabwe"
+              ],
+              "default": "USA"
+            },
+            "addressLine1": {
+              "type": "string",
+              "maxLength": 35,
+              "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+            },
+            "addressLine2": {
+              "type": "string",
+              "maxLength": 35,
+              "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+            },
+            "addressLine3": {
+              "type": "string",
+              "maxLength": 35,
+              "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+            },
+            "city": {
+              "type": "string",
+              "maxLength": 30,
+              "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "AL",
+                "UM",
+                "AS",
+                "AZ",
+                "AR",
+                "AA",
+                "AE",
+                "AP",
+                "CA",
+                "CO",
+                "CT",
+                "DE",
+                "DC",
+                "FM",
+                "FL",
+                "GA",
+                "GU",
+                "HI",
+                "ID",
+                "IL",
+                "IN",
+                "IA",
+                "KS",
+                "KY",
+                "LA",
+                "ME",
+                "MH",
+                "MD",
+                "MA",
+                "MI",
+                "MN",
+                "MS",
+                "AK",
+                "MT",
+                "NE",
+                "NV",
+                "NH",
+                "NJ",
+                "NM",
+                "NY",
+                "NC",
+                "ND",
+                "MP",
+                "OH",
+                "OK",
+                "OR",
+                "PW",
+                "PA",
+                "PR",
+                "RI",
+                "SC",
+                "SD",
+                "TN",
+                "TX",
+                "UT",
+                "VT",
+                "VI",
+                "VA",
+                "WA",
+                "WV",
+                "WI",
+                "WY",
+                "PI",
+                "MO"
+              ],
+              "enumNames": [
+                "Alabama",
+                "U.S. Minor Outlying Islands",
+                "American Samoa",
+                "Arizona",
+                "Arkansas",
+                "Armed Forces Americas (AA)",
+                "Armed Forces Europe (AE)",
+                "Armed Forces Pacific (AP)",
+                "California",
+                "Colorado",
+                "Connecticut",
+                "Delaware",
+                "District Of Columbia",
+                "Federated States Of Micronesia",
+                "Florida",
+                "Georgia",
+                "Guam",
+                "Hawaii",
+                "Idaho",
+                "Illinois",
+                "Indiana",
+                "Iowa",
+                "Kansas",
+                "Kentucky",
+                "Louisiana",
+                "Maine",
+                "Marshall Islands",
+                "Maryland",
+                "Massachusetts",
+                "Michigan",
+                "Minnesota",
+                "Mississippi",
+                "Alaska",
+                "Montana",
+                "Nebraska",
+                "Nevada",
+                "New Hampshire",
+                "New Jersey",
+                "New Mexico",
+                "New York",
+                "North Carolina",
+                "North Dakota",
+                "Northern Mariana Islands",
+                "Ohio",
+                "Oklahoma",
+                "Oregon",
+                "Palau",
+                "Pennsylvania",
+                "Puerto Rico",
+                "Rhode Island",
+                "South Carolina",
+                "South Dakota",
+                "Tennessee",
+                "Texas",
+                "Utah",
+                "Vermont",
+                "Virgin Islands",
+                "Virginia",
+                "Washington",
+                "West Virginia",
+                "Wisconsin",
+                "Wyoming",
+                "Philippine Islands",
+                "Missouri"
+              ]
+            },
+            "zipCode": {
+              "type": "string",
+              "pattern": "^\\d{5}(?:([-\\s]?)\\d{4})?$"
+            },
+            "effectiveDate": {
+              "$ref": "#/definitions/date"
+            }
+          }
+        },
+        "homelessness": {
+          "type": "object",
+          "required": [
+            "isHomeless"
+          ],
+          "properties": {
+            "isHomeless": {
+              "type": "boolean"
+            },
+            "pointOfContact": {
+              "type": "object",
+              "properties": {
+                "pointOfContactName": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 100,
+                  "pattern": "^([-a-zA-Z0-9/']+( ?))*$"
+                },
+                "primaryPhone": {
+                  "$ref": "#/definitions/phone"
+                }
+              }
+            }
+          }
+        },
+        "serviceNumber": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9]{1,9}$"
+        }
+      }
+    },
+    "attachments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name",
+          "attachmentId"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "confirmationCode": {
+            "type": "string"
+          },
+          "attachmentId": {
+            "type": "string",
+            "enum": [
+              "L015",
+              "L018",
+              "L029",
+              "L702",
+              "L703",
+              "L034",
+              "L478",
+              "L048",
+              "L049",
+              "L023",
+              "L070",
+              "L450",
+              "L451",
+              "L222",
+              "L228",
+              "L229",
+              "L102",
+              "L107",
+              "L827",
+              "L115",
+              "L117",
+              "L159",
+              "L133",
+              "L139",
+              "L149"
+            ],
+            "enumNames": [
+              "Buddy/Lay Statement",
+              "Civilian Police Reports",
+              "Copy of a DD214",
+              "Disability Benefits Questionnaire (DBQ)",
+              "Goldmann Perimetry Chart/Field Of Vision Chart",
+              "Military Personnel Record",
+              "Medical Treatment Records - Furnished by SSA",
+              "Medical Treatment Record - Government Facility",
+              "Medical Treatment Record - Non-Government Facility",
+              "Other Correspondence",
+              "Photographs",
+              "STR - Dental - Photocopy",
+              "STR - Medical - Photocopy",
+              "VA Form 21-0779 - Request for Nursing Home Information in Connection with Claim for Aid & Attendance",
+              "VA Form 21-0781 - Statement in Support of Claim for PTSD",
+              "VA Form 21-0781a - Statement in Support of Claim for PTSD Secondary to Personal Assault",
+              "VA Form 21-2680 - Examination for Housebound Status or Permanent Need for Regular Aid & Attendance",
+              "VA Form 21-4142 - Authorization To Disclose Information",
+              "VA Form 21-4142a - General Release for Medical Provider Information",
+              "VA Form 21-4192 - Request for Employment Information in Connection with Claim for Disability",
+              "VA Form 21-4502 - Application for Automobile or Other Conveyance and Adaptive Equipment Under 38 U.S.C. 3901-3904",
+              "VA Form 26-4555 - Application in Acquiring Specially Adapted Housing or Special Home Adaptation Grant",
+              "VA Form 21-674 - Request for Approval of School Attendance",
+              "VA Form 21-686c - Declaration of Status of Dependents",
+              "VA Form 21-8940 - Veterans Application for Increased Compensation Based on Un-employability"
+            ]
+          }
+        }
+      }
+    },
+    "militaryPayments": {
+      "type": "object",
+      "required": [
+        "payments",
+        "receiveCompensationInLieuOfRetired"
+      ],
+      "properties": {
+        "payments": {
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "type": "object",
+            "required": [
+              "payType",
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "type": "number"
+              },
+              "payType": {
+                "type": "string",
+                "enum": [
+                  "LONGEVITY",
+                  "TEMPORARY_DISABILITY_RETIRED_LIST",
+                  "PERMANENT_DISABILITY_RETIRED_LIST",
+                  "SEPARATION",
+                  "SEVERANCE"
+                ]
+              }
+            }
+          }
+        },
+        "receiveCompensationInLieuOfRetired": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "serviceInformation": {
+      "type": "object",
+      "required": [
+        "servicePeriods"
+      ],
+      "properties": {
+        "servicePeriods": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 100,
+          "items": {
+            "type": "object",
+            "required": [
+              "serviceBranch",
+              "dateRange"
+            ],
+            "properties": {
+              "serviceBranch": {
+                "type": "string",
+                "enum": [
+                  "Air Force",
+                  "Air Force Reserve",
+                  "Air National Guard",
+                  "Army",
+                  "Army National Guard",
+                  "Army Reserve",
+                  "Coast Guard",
+                  "Coast Guard Reserve",
+                  "Marine Corps",
+                  "Marine Corps Reserve",
+                  "NOAA",
+                  "Navy",
+                  "Navy Reserve",
+                  "Public Health Service"
+                ]
+              },
+              "dateRange": {
+                "$ref": "#/definitions/dateRangeAllRequired"
+              }
+            }
+          }
+        },
+        "reservesNationalGuardService": {
+          "type": "object",
+          "required": [
+            "unitName",
+            "obligationTermOfServiceDateRange",
+            "waiveVABenefitsToRetainTrainingPay"
+          ],
+          "properties": {
+            "unitName": {
+              "type": "string",
+              "maxLength": 256,
+              "pattern": "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
+            },
+            "obligationTermOfServiceDateRange": {
+              "$ref": "#/definitions/dateRangeAllRequired"
+            },
+            "waiveVABenefitsToRetainTrainingPay": {
+              "type": "boolean"
+            },
+            "title10Activation": {
+              "type": "object",
+              "properties": {
+                "title10ActivationDate": {
+                  "$ref": "#/definitions/date"
+                },
+                "anticipatedSeparationDate": {
+                  "$ref": "#/definitions/date"
+                }
+              }
+            }
+          }
+        },
+        "separationLocationName": {
+          "type": "string",
+          "maxLength": 256,
+          "pattern": "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
+        },
+        "separationLocationCode": {
+          "type": "string"
+        },
+        "alternateNames": {
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/fullName"
+          }
+        },
+        "confinements": {
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "type": "object",
+            "properties": {
+              "confinementDateRange": {
+                "$ref": "#/definitions/dateRangeAllRequired"
+              },
+              "verifiedIndicator": {
+                "type": "boolean",
+                "default": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "disabilities": {
+      "$ref": "#/definitions/disabilities"
+    },
+    "treatments": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 100,
+      "items": {
+        "type": "object",
+        "required": [
+          "treatmentCenterName"
+        ],
+        "properties": {
+          "treatmentCenterName": {
+            "type": "string",
+            "maxLength": 100,
+            "pattern": "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$"
+          },
+          "treatmentDateRange": {
+            "$ref": "#/definitions/dateRangeFromRequired"
+          },
+          "treatmentCenterAddress": {
+            "$ref": "#/definitions/vaTreatmentCenterAddress"
+          }
+        }
+      }
+    },
+    "specialCircumstances": {
+      "type": "array",
+      "maxItems": 100,
+      "required": [
+        "name",
+        "code",
+        "needed"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "needed": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      }
+    },
+    "standardClaim": {
+      "type": "boolean",
+      "default": false
+    },
+    "form4142": {
+      "$ref": "#/definitions/form4142"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ/schema.js
+++ b/src/schemas/21-526EZ/schema.js
@@ -1,0 +1,441 @@
+import _ from 'lodash/fp';
+import definitions from '../../common/definitions';
+import { pciuCountries, pciuStates, documentTypes526 } from '../../common/constants';
+
+const disabilitiesBaseDef = {
+  type: 'array',
+  maxItems: 100,
+  items: {
+    type: 'object',
+    required: ['name', 'disabilityActionType'],
+    properties: {
+      name: {
+        type: 'string',
+      },
+      disabilityActionType: {
+        type: 'string',
+        enum: ['NONE', 'NEW', 'SECONDARY', 'INCREASE', 'REOPEN'],
+      },
+      ratedDisabilityId: {
+        type: 'string',
+      },
+      ratingDecisionId: {
+        type: 'string',
+      },
+      diagnosticCode: {
+        type: 'number',
+      },
+      classificationCode: {
+        type: 'string',
+      },
+    },
+  },
+};
+
+const addressBaseDef = {
+  type: 'object',
+  required: ['country', 'city', 'addressLine1'],
+  properties: {
+    country: {
+      type: 'string',
+      enum: pciuCountries,
+      default: 'USA',
+    },
+    addressLine1: {
+      type: 'string',
+      maxLength: 20,
+      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+    },
+    addressLine2: {
+      type: 'string',
+      maxLength: 20,
+      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+    },
+    addressLine3: {
+      type: 'string',
+      maxLength: 20,
+      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+    },
+    city: {
+      type: 'string',
+      maxLength: 30,
+      pattern: "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+    },
+    state: {
+      type: 'string',
+      enum: pciuStates.map(state => state.value),
+      enumNames: pciuStates.map(state => state.label),
+    },
+    zipCode: {
+      type: 'string',
+      pattern: '^\\d{5}(?:([-\\s]?)\\d{4})?$',
+    },
+  },
+};
+
+// Some date ranges require both 'from' and 'to' dates
+const dateRangeAllRequired = _.set('required', ['from', 'to'], definitions.dateRange);
+
+// Other date ranges don't
+const dateRangeFromRequired = _.set('required', ['from'], definitions.dateRange);
+
+/**
+ * Transforms common fullName definition by adding regex validations and
+ * removing suffix property.
+ * @typedef {object} definitions
+ * @property {object} fullName
+ * @param {definitions} definitions the common schema definitions file
+ * @returns {object} the servicePeriods schema object
+ */
+
+// eslint-disable-next-line no-shadow
+const fullNameDef = (definitions => {
+  const fullNameClone = _.cloneDeep(definitions.fullName);
+  delete fullNameClone.properties.suffix;
+
+  // These patterns are taken straight from Swagger
+  const firstLastPattern = "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$";
+  fullNameClone.properties.first.pattern = firstLastPattern;
+  fullNameClone.properties.last.pattern = firstLastPattern;
+  fullNameClone.properties.middle.pattern = "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$";
+
+  return fullNameClone;
+})(definitions);
+
+/**
+ * Modifies address schema for use with treatments schema
+ * @property {object} addressSchema
+ * @returns {object} the treatmentCenterAddress schema object
+ */
+const vaTreatmentCenterAddressDef = (addressSchema => {
+  const { type, properties } = addressSchema;
+  return {
+    type,
+    required: ['country'],
+    properties: _.pick(['country', 'city', 'state'], properties),
+  };
+})(addressBaseDef);
+
+const schema = {
+  $schema: 'http://json-schema.org/draft-04/schema#',
+  title: 'SUPPLEMENTAL CLAIM FOR COMPENSATION (21-526EZ)',
+  type: 'object',
+  definitions: {
+    address: addressBaseDef,
+    vaTreatmentCenterAddress: vaTreatmentCenterAddressDef,
+    date: definitions.date,
+    dateRange: definitions.dateRange,
+    dateRangeFromRequired,
+    dateRangeAllRequired,
+    disabilities: _.merge(disabilitiesBaseDef, {
+      minItems: 1,
+      items: {
+        properties: {
+          secondaryDisabilities: disabilitiesBaseDef,
+        },
+      },
+    }),
+    fullName: fullNameDef,
+    phone: definitions.usaPhone,
+    form4142: definitions.form4142,
+    // Private Provider Facility Address for forms 4142/4142A
+    // uses Central Mail Address Schema properties as the
+    // document is submitted to Central Mail (ICMHS)
+    // Refer to definitions.js $ref: '#/definitions/centralMailAddress'
+    centralMailAddress: definitions.centralMailAddress,
+  },
+  required: ['veteran', 'serviceInformation', 'disabilities', 'standardClaim'],
+  properties: {
+    veteran: {
+      type: 'object',
+      required: ['emailAddress', 'mailingAddress', 'primaryPhone'],
+      properties: {
+        emailAddress: {
+          type: 'string',
+          minLength: 6,
+          maxLength: 80,
+          pattern: '^[_A-Za-z0-9-]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$',
+        },
+        alternateEmailAddress: {
+          type: 'string',
+          format: 'email',
+          maxLength: 80,
+          pattern: '^[_A-Za-z0-9-]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$',
+        },
+        mailingAddress: {
+          $ref: '#/definitions/address',
+        },
+        primaryPhone: {
+          $ref: '#/definitions/phone',
+        },
+        // Forwarding address differs from mailing address in a few key ways:
+        // 1. Address lines 1-3 are max 20 chars instead of 35
+        // 2. The UI is such that requiring fields must be done in the UI schema
+        // 3. There is an effectiveDate property that specifies the date at which
+        //    the forwarding address should start to be used
+        forwardingAddress: _.set(
+          'properties.effectiveDate',
+          {
+            $ref: '#/definitions/date',
+          },
+          _.omit(
+            'required',
+            _.merge(addressBaseDef, {
+              properties: {
+                addressLine1: {
+                  maxLength: 35,
+                },
+                addressLine2: {
+                  maxLength: 35,
+                },
+                addressLine3: {
+                  maxLength: 35,
+                },
+              },
+            }),
+          ),
+        ),
+        homelessness: {
+          type: 'object',
+          required: ['isHomeless'],
+          properties: {
+            isHomeless: {
+              type: 'boolean',
+            },
+            pointOfContact: {
+              type: 'object',
+              properties: {
+                pointOfContactName: {
+                  type: 'string',
+                  minLength: 1,
+                  maxLength: 100,
+                  pattern: "^([-a-zA-Z0-9/']+( ?))*$",
+                },
+                primaryPhone: {
+                  $ref: '#/definitions/phone',
+                },
+              },
+            },
+          },
+        },
+        serviceNumber: {
+          type: 'string',
+          pattern: '^[a-zA-Z0-9]{1,9}$',
+        },
+      },
+    },
+    attachments: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['name', 'attachmentId'],
+        properties: {
+          // This is the document name schema - FileField requires this specific name be used
+          name: {
+            type: 'string',
+          },
+          confirmationCode: {
+            type: 'string',
+          },
+          // This is the document type schema - FileField requires this specific name be used
+          attachmentId: {
+            type: 'string',
+            enum: documentTypes526.map(doc => doc.value),
+            enumNames: documentTypes526.map(doc => doc.label),
+          },
+        },
+      },
+    },
+    militaryPayments: {
+      type: 'object',
+      required: ['payments', 'receiveCompensationInLieuOfRetired'],
+      properties: {
+        payments: {
+          type: 'array',
+          maxItems: 100,
+          items: {
+            type: 'object',
+            required: ['payType', 'amount'],
+            properties: {
+              amount: {
+                type: 'number',
+              },
+              payType: {
+                type: 'string',
+                enum: [
+                  'LONGEVITY',
+                  'TEMPORARY_DISABILITY_RETIRED_LIST',
+                  'PERMANENT_DISABILITY_RETIRED_LIST',
+                  'SEPARATION',
+                  'SEVERANCE',
+                ],
+              },
+            },
+          },
+        },
+        receiveCompensationInLieuOfRetired: {
+          // I want military retired pay instead of VA compensation
+          type: 'boolean',
+          default: false,
+        },
+      },
+    },
+    serviceInformation: {
+      type: 'object',
+      required: ['servicePeriods'],
+      properties: {
+        servicePeriods: {
+          type: 'array',
+          minItems: 1,
+          maxItems: 100,
+          items: {
+            type: 'object',
+            required: ['serviceBranch', 'dateRange'],
+            properties: {
+              serviceBranch: {
+                type: 'string',
+                enum: [
+                  'Air Force',
+                  'Air Force Reserve',
+                  'Air National Guard',
+                  'Army',
+                  'Army National Guard',
+                  'Army Reserve',
+                  'Coast Guard',
+                  'Coast Guard Reserve',
+                  'Marine Corps',
+                  'Marine Corps Reserve',
+                  'NOAA',
+                  'Navy',
+                  'Navy Reserve',
+                  'Public Health Service',
+                ],
+              },
+              dateRange: {
+                $ref: '#/definitions/dateRangeAllRequired',
+              },
+            },
+          },
+        },
+        reservesNationalGuardService: {
+          type: 'object',
+          required: ['unitName', 'obligationTermOfServiceDateRange', 'waiveVABenefitsToRetainTrainingPay'],
+          properties: {
+            unitName: {
+              type: 'string',
+              maxLength: 256,
+              pattern: "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$",
+            },
+            obligationTermOfServiceDateRange: {
+              $ref: '#/definitions/dateRangeAllRequired',
+            },
+            waiveVABenefitsToRetainTrainingPay: {
+              // I elect to waive VA benefits for the days I accrued
+              // inactive duty training pay in order to retain my inactive
+              // duty training pay.
+              type: 'boolean',
+            },
+            title10Activation: {
+              type: 'object',
+              properties: {
+                title10ActivationDate: {
+                  $ref: '#/definitions/date',
+                },
+                anticipatedSeparationDate: {
+                  $ref: '#/definitions/date',
+                },
+              },
+            },
+          },
+        },
+        separationLocationName: {
+          type: 'string',
+          maxLength: 256,
+          pattern: "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$",
+        },
+        separationLocationCode: {
+          type: 'string',
+        },
+        alternateNames: {
+          type: 'array',
+          maxItems: 100,
+          items: {
+            $ref: '#/definitions/fullName',
+          },
+        },
+        confinements: {
+          type: 'array',
+          maxItems: 100,
+          items: {
+            type: 'object',
+            properties: {
+              confinementDateRange: {
+                $ref: '#/definitions/dateRangeAllRequired',
+              },
+              verifiedIndicator: {
+                type: 'boolean',
+                default: false,
+              },
+            },
+          },
+        },
+      },
+    },
+    disabilities: {
+      $ref: '#/definitions/disabilities',
+    },
+    treatments: {
+      type: 'array',
+      minItems: 1,
+      maxItems: 100,
+      items: {
+        type: 'object',
+        required: ['treatmentCenterName'],
+        properties: {
+          treatmentCenterName: {
+            type: 'string',
+            maxLength: 100,
+            pattern: "^([a-zA-Z0-9\\-'.#]([a-zA-Z0-9\\-'.# ])?)+$",
+          },
+          treatmentDateRange: {
+            $ref: '#/definitions/dateRangeFromRequired',
+          },
+          treatmentCenterAddress: {
+            $ref: '#/definitions/vaTreatmentCenterAddress',
+          },
+        },
+      },
+    },
+    specialCircumstances: {
+      type: 'array',
+      maxItems: 100,
+      required: ['name', 'code', 'needed'],
+      items: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+          code: {
+            type: 'string',
+          },
+          needed: {
+            type: 'boolean',
+            default: false,
+          },
+        },
+      },
+    },
+    standardClaim: {
+      // I DO NOT want my claim considered for rapid processing under the FDC
+      // program because I plan to submit further evidence in support of my claim
+      type: 'boolean',
+      default: false,
+    },
+    form4142: {
+      $ref: '#/definitions/form4142',
+    },
+  },
+};
+
+export default schema;


### PR DESCRIPTION
# Restore schema

Temporarily restore form 526 v1 to unblock work. This will be resolved in the future when `vets-api` tests for this form are changed over to work on 526 all-claims schema (v2).

Related: https://github.com/department-of-veterans-affairs/vets-api/pull/4538
