### PR TITLE
[Development] Make 526 bank routing schema

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -1150,7 +1150,7 @@
     },
     "bankRoutingNumber": {
       "type": "string",
-      "pattern": "^\\d{9}$"
+      "pattern": "^[\\d*]{9}$"
     },
     "bankName": {
       "type": "string",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "6.0.3",
+  "version": "6.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "6.4.0",
+  "version": "6.4.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -539,7 +539,7 @@ const schema = {
     },
     bankRoutingNumber: {
       type: 'string',
-      pattern: '^\\d{9}$',
+      pattern: '^[\\d*]{9}$',
     },
     bankName: {
       type: 'string',

--- a/test/schemas/21-526EZ/schema.spec.js
+++ b/test/schemas/21-526EZ/schema.spec.js
@@ -347,7 +347,7 @@ const data = {
     invalid: ['', '123', makeString(20)],
   },
   bankRoutingNumber: {
-    valid: ['123456789', '987654321'],
+    valid: ['123456789', '987654321', '*****1234'],
     invalid: [null, '', '123', 'abcdefghi', 123456789],
   },
   bankName: {


### PR DESCRIPTION
# Update schema

In form 526, the bank routing number regular expression is very restrictive and does not allow the masking of the number (e.g. `*****1234`), which is provided by the save-in-progress endpoint.

The regular expression will be updated to allow a combination of numbers and asterisks.

Related issues:
- issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/11731
- vets-website: pending
- vets-api: pending
