### PR TITLE
13784: Add receiveTexts to 10203 schema

### DIFF
--- a/dist/22-10203-schema.json
+++ b/dist/22-10203-schema.json
@@ -667,6 +667,9 @@
     },
     "scoEmailSent": {
       "type": "boolean"
+    },
+    "receiveTexts": {
+      "type": "boolean"
     }
   },
   "required": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "14.1.1",
+  "version": "14.1.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/22-10203/schema.js
+++ b/src/schemas/22-10203/schema.js
@@ -51,7 +51,7 @@ const schema = {
     },
     schoolCountry: {
       type: 'string',
-      enum: constants.countries.map((country) => country.value),
+      enum: constants.countries.map(country => country.value),
     },
     schoolStudentId: {
       type: 'string',

--- a/src/schemas/22-10203/schema.js
+++ b/src/schemas/22-10203/schema.js
@@ -51,7 +51,7 @@ const schema = {
     },
     schoolCountry: {
       type: 'string',
-      enum: constants.countries.map(country => country.value),
+      enum: constants.countries.map((country) => country.value),
     },
     schoolStudentId: {
       type: 'string',
@@ -88,6 +88,9 @@ const schema = {
       type: 'boolean',
     },
     scoEmailSent: {
+      type: 'boolean',
+    },
+    receiveTexts: {
       type: 'boolean',
     },
   },


### PR DESCRIPTION
Update to 10203 Schema to add `receiveTexts` for personal information.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13784)

## Pull Requests to update the schema in related repositories
PRs for `vets-website` and `vets-api` to be added after this merge.