### PR TITLE
Change order of Gender options for A11y

### DIFF
--- a/dist/COVID-VACCINE-TRIAL-schema.json
+++ b/dist/COVID-VACCINE-TRIAL-schema.json
@@ -245,10 +245,10 @@
         "GENDER::NON_BINARY": {
           "type": "boolean"
         },
-        "GENDER::SELF_IDENTIFY": {
+        "GENDER::NONE_OF_ABOVE": {
           "type": "boolean"
         },
-        "GENDER::NONE_OF_ABOVE": {
+        "GENDER::SELF_IDENTIFY": {
           "type": "boolean"
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "18.6.0",
+  "version": "18.6.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"
@@ -20,13 +20,13 @@
     "dist"
   ],
   "devDependencies": {
-    "@babel/core": "^7.11.6",
-    "@babel/preset-env": "^7.11.5",
-    "@babel/register": "^7.11.5",
+    "@babel/core": "^7.12.10",
+    "@babel/preset-env": "^7.12.11",
+    "@babel/register": "^7.12.10",
     "ajv": "^4.5.0",
     "chai": "^3.5.0",
     "chalk": "^2.4.2",
-    "danger": "^10.5.0",
+    "danger": "^10.6.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-config-prettier": "^6.12.0",
@@ -34,7 +34,7 @@
     "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-mocha": "^6.3.0",
-    "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-prettier": "^3.3.1",
     "jsonfile": "^2.3.1",
     "lodash": "^4.17.20",
     "mocha": "^3.0.2",

--- a/src/schemas/COVID-VACCINE-TRIAL/schema.js
+++ b/src/schemas/COVID-VACCINE-TRIAL/schema.js
@@ -179,10 +179,10 @@ const GENDER = {
     'GENDER::NON_BINARY': {
       type: 'boolean',
     },
-    'GENDER::SELF_IDENTIFY': {
+    'GENDER::NONE_OF_ABOVE': {
       type: 'boolean',
     },
-    'GENDER::NONE_OF_ABOVE': {
+    'GENDER::SELF_IDENTIFY': {
       type: 'boolean',
     },
   },


### PR DESCRIPTION
# Update Covid-Vaccine-Trial Schema for A11y
Reorder Select options for Gender based on Ally audit. 

department-of-veterans-affairs/va.gov-team#18272

## Pull Requests to update the schema in related repositories

department-of-veterans-affairs/vets-website#0000
department-of-veterans-affairs/vets-api#0000