### PR TITLE
Removed compliance agreement schema

### DIFF
--- a/dist/COVID-VACCINATION-EXPANSION-schema.json
+++ b/dist/COVID-VACCINATION-EXPANSION-schema.json
@@ -592,10 +592,6 @@
             "caregiverOfVeteran",
             "CHAMPVA"
           ]
-        },
-        "complianceAgreement": {
-          "type": "boolean",
-          "default": false
         }
       }
     },

--- a/src/schemas/COVID-VACCINATION-EXPANSION/schema.js
+++ b/src/schemas/COVID-VACCINATION-EXPANSION/schema.js
@@ -72,10 +72,6 @@ const schema = {
           type: 'string',
           enum: ['veteran', 'spouse', 'caregiverEnrolled', 'caregiverOfVeteran', 'CHAMPVA'],
         },
-        complianceAgreement: {
-          type: 'boolean',
-          default: false,
-        },
       },
     },
     militaryHistory: {


### PR DESCRIPTION
Now that we have determined that we can use the `privacyAgreementAccepted` value to tell if the user accepts the truth statement for the covid vaccine expansion form, we need to remove the `complianceAgreement` schema. This PR removes that schema.