### PR TITLE
added additional evidence document types

### DIFF
--- a/dist/686C-674-schema.json
+++ b/dist/686C-674-schema.json
@@ -1488,15 +1488,15 @@
               "type": "object",
               "properties": {}
             },
-            "supportingDocuments": {
-              "$ref": "#/definitions/files"
-            },
             "childEvidenceDocumentType": {
               "type": "string",
               "enum": [
                 "Adoption Decree",
                 "Birth Certificate"
               ]
+            },
+            "supportingDocuments": {
+              "$ref": "#/definitions/files"
             }
           }
         }
@@ -1712,9 +1712,6 @@
               "type": "object",
               "properties": {}
             },
-            "supportingDocuments": {
-              "$ref": "#/definitions/files"
-            },
             "spouseEvidenceDocumentType": {
               "type": "string",
               "enum": [
@@ -1722,6 +1719,9 @@
                 "Divorce Decree",
                 "Report of Death"
               ]
+            },
+            "supportingDocuments": {
+              "$ref": "#/definitions/files"
             }
           }
         }

--- a/dist/686C-674-schema.json
+++ b/dist/686C-674-schema.json
@@ -1495,6 +1495,10 @@
                 "Birth Certificate"
               ]
             },
+            "view:additionalEvidenceFileTypes": {
+              "type": "object",
+              "properties": {}
+            },
             "supportingDocuments": {
               "$ref": "#/definitions/files"
             }
@@ -1719,6 +1723,10 @@
                 "Divorce Decree",
                 "Report of Death"
               ]
+            },
+            "view:additionalEvidenceFileTypes": {
+              "type": "object",
+              "properties": {}
             },
             "supportingDocuments": {
               "$ref": "#/definitions/files"

--- a/dist/686C-674-schema.json
+++ b/dist/686C-674-schema.json
@@ -1490,6 +1490,13 @@
             },
             "supportingDocuments": {
               "$ref": "#/definitions/files"
+            },
+            "childEvidenceDocumentType": {
+              "type": "string",
+              "enum": [
+                "Adoption Decree",
+                "Birth Certificate"
+              ]
             }
           }
         }
@@ -1707,6 +1714,14 @@
             },
             "supportingDocuments": {
               "$ref": "#/definitions/files"
+            },
+            "spouseEvidenceDocumentType": {
+              "type": "string",
+              "enum": [
+                "Marriage Certificate / License",
+                "Divorce Decree",
+                "Report of Death"
+              ]
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.0.1",
+  "version": "20.0.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/686c-674/schema.js
+++ b/src/schemas/686c-674/schema.js
@@ -287,6 +287,10 @@ const schema = {
             supportingDocuments: {
               $ref: '#/definitions/files',
             },
+            childEvidenceDocumentType: {
+              type: 'string',
+              enum: ['Adoption Decree', 'Birth Certificate']
+            },
           },
         },
       },
@@ -478,6 +482,10 @@ const schema = {
             },
             supportingDocuments: {
               $ref: '#/definitions/files',
+            },
+            spouseEvidenceDocumentType: {
+              type: 'string',
+              enum: ['Marriage Certificate / License', 'Divorce Decree', 'Report of Death']
             },
           },
         },

--- a/src/schemas/686c-674/schema.js
+++ b/src/schemas/686c-674/schema.js
@@ -288,6 +288,10 @@ const schema = {
               type: 'string',
               enum: ['Adoption Decree', 'Birth Certificate']
             },
+            'view:additionalEvidenceFileTypes': {
+              type: 'object',
+              properties: {},
+            }, 
             supportingDocuments: {
               $ref: '#/definitions/files',
             },
@@ -483,6 +487,10 @@ const schema = {
             spouseEvidenceDocumentType: {
               type: 'string',
               enum: ['Marriage Certificate / License', 'Divorce Decree', 'Report of Death']
+            },
+            'view:additionalEvidenceFileTypes': {
+              type: 'object',
+              properties: {},
             },
             supportingDocuments: {
               $ref: '#/definitions/files',

--- a/src/schemas/686c-674/schema.js
+++ b/src/schemas/686c-674/schema.js
@@ -284,12 +284,12 @@ const schema = {
               type: 'object',
               properties: {},
             },
-            supportingDocuments: {
-              $ref: '#/definitions/files',
-            },
             childEvidenceDocumentType: {
               type: 'string',
               enum: ['Adoption Decree', 'Birth Certificate']
+            },
+            supportingDocuments: {
+              $ref: '#/definitions/files',
             },
           },
         },
@@ -480,13 +480,13 @@ const schema = {
               type: 'object',
               properties: {},
             },
-            supportingDocuments: {
-              $ref: '#/definitions/files',
-            },
             spouseEvidenceDocumentType: {
               type: 'string',
               enum: ['Marriage Certificate / License', 'Divorce Decree', 'Report of Death']
             },
+            supportingDocuments: {
+              $ref: '#/definitions/files',
+            }, 
           },
         },
       },


### PR DESCRIPTION
# Background
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/22573)

It was found in testing that we need to send a document type along with the additional evidence uploads in the 686c so that VBMS knows what is being sent. This PR adds drop-downs for the user to choose what type of document they are sending.