### PR TITLE
Removed unneeded view field

### DIFF
--- a/dist/686C-674-schema.json
+++ b/dist/686C-674-schema.json
@@ -1495,10 +1495,6 @@
                 "Birth Certificate"
               ]
             },
-            "view:additionalEvidenceFileTypes": {
-              "type": "object",
-              "properties": {}
-            },
             "supportingDocuments": {
               "$ref": "#/definitions/files"
             }
@@ -1723,10 +1719,6 @@
                 "Divorce Decree",
                 "Report of Death"
               ]
-            },
-            "view:additionalEvidenceFileTypes": {
-              "type": "object",
-              "properties": {}
             },
             "supportingDocuments": {
               "$ref": "#/definitions/files"

--- a/src/schemas/686c-674/schema.js
+++ b/src/schemas/686c-674/schema.js
@@ -288,10 +288,6 @@ const schema = {
               type: 'string',
               enum: ['Adoption Decree', 'Birth Certificate']
             },
-            'view:additionalEvidenceFileTypes': {
-              type: 'object',
-              properties: {},
-            }, 
             supportingDocuments: {
               $ref: '#/definitions/files',
             },
@@ -487,10 +483,6 @@ const schema = {
             spouseEvidenceDocumentType: {
               type: 'string',
               enum: ['Marriage Certificate / License', 'Divorce Decree', 'Report of Death']
-            },
-            'view:additionalEvidenceFileTypes': {
-              type: 'object',
-              properties: {},
             },
             supportingDocuments: {
               $ref: '#/definitions/files',


### PR DESCRIPTION
# Background
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/22573)

It was found in testing that we need to send a document type along with the additional evidence uploads in the 686c so that VBMS knows what is being sent. In a [previous PR](https://github.com/department-of-veterans-affairs/vets-json-schema/commit/64508eda29cad1f4fdfd548c58c5f0229ddc7386) we added the new document type field as well as a view field requested by design however after further review it has been requested that the additional view field gets removed. This PR removes that field.