### PR TITLE
Updated doc type selection options and values

### DIFF
--- a/dist/686C-674-schema.json
+++ b/dist/686C-674-schema.json
@@ -1491,8 +1491,20 @@
             "childEvidenceDocumentType": {
               "type": "string",
               "enum": [
+                "13",
+                "25",
+                "58",
+                "59",
+                "663",
+                "10"
+              ],
+              "enumNames": [
                 "Adoption Decree",
-                "Birth Certificate"
+                "Birth Certificate",
+                "Medical Treatment Record - Government Facility",
+                "Medical Treatment Record - Non-Government Facility",
+                "Medical Opinion",
+                "Unknown"
               ]
             },
             "supportingDocuments": {
@@ -1715,9 +1727,16 @@
             "spouseEvidenceDocumentType": {
               "type": "string",
               "enum": [
+                "14",
+                "61",
+                "119",
+                "10"
+              ],
+              "enumNames": [
+                "Affidavit",
                 "Marriage Certificate / License",
-                "Divorce Decree",
-                "Report of Death"
+                "VA 21-4171 Supporting Statement Regarding Marriage",
+                "Unknown"
               ]
             },
             "supportingDocuments": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.3.2",
+  "version": "20.3.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/686c-674/schema.js
+++ b/src/schemas/686c-674/schema.js
@@ -286,7 +286,15 @@ const schema = {
             },
             childEvidenceDocumentType: {
               type: 'string',
-              enum: ['Adoption Decree', 'Birth Certificate'],
+              enum: ['13', '25', '58', '59', '663', '10'],
+              enumNames: [
+                'Adoption Decree',
+                'Birth Certificate',
+                'Medical Treatment Record - Government Facility',
+                'Medical Treatment Record - Non-Government Facility',
+                'Medical Opinion',
+                'Unknown',
+              ],
             },
             supportingDocuments: {
               $ref: '#/definitions/files',
@@ -482,7 +490,13 @@ const schema = {
             },
             spouseEvidenceDocumentType: {
               type: 'string',
-              enum: ['Marriage Certificate / License', 'Divorce Decree', 'Report of Death'],
+              enum: ['14', '61', '119', '10'],
+              enumNames: [
+                'Affidavit',
+                'Marriage Certificate / License',
+                'VA 21-4171 Supporting Statement Regarding Marriage',
+                'Unknown',
+              ],
             },
             supportingDocuments: {
               $ref: '#/definitions/files',


### PR DESCRIPTION
# Background

When we initially set up the additional evidence document type we used placeholder options as the stakeholders had not given us the actual options or number values that needed to be passed. Now that we have gotten those options, this PR updates those options in the code.

