### PR TITLE
Add sponsorStatus to 5490

### DIFF
--- a/dist/22-10203-schema.json
+++ b/dist/22-10203-schema.json
@@ -373,7 +373,7 @@
     "isPursuingTeachingCert": {
       "type": "boolean"
     },
-    "isPursuingClinicalTraining":{
+    "isPursuingClinicalTraining": {
       "type": "boolean"
     },
     "benefitLeft": {

--- a/dist/22-5490-schema.json
+++ b/dist/22-5490-schema.json
@@ -720,6 +720,14 @@
     "eduBenefitsPamphlet": {
       "type": "boolean"
     },
+    "sponsorStatus": {
+      "type": "string",
+      "enum": [
+        "diedOnDuty",
+        "diedFromDisabilityOrOnReserve",
+        "powOrMia"
+      ]
+    },
     "privacyAgreementAccepted": {
       "$ref": "#/definitions/privacyAgreementAccepted"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.4.0",
+  "version": "20.5.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.3.5",
+  "version": "21.3.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/22-5490/schema.js
+++ b/src/schemas/22-5490/schema.js
@@ -111,6 +111,10 @@ const schema = {
     eduBenefitsPamphlet: {
       type: 'boolean',
     },
+    sponsorStatus: {
+      type: 'string',
+      enum: ['diedOnDuty', 'diedFromDisabilityOrOnReserve', 'powOrMia'],
+    },
   },
   required: ['privacyAgreementAccepted', 'relativeFullName'],
 };


### PR DESCRIPTION
# Description of changes
Add `sponsorStatus` to 5490 schema.

department-of-veterans-affairs/va.gov-team#25122

## Pull Requests to update the schema in related repositories
<!--
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
-->
department-of-veterans-affairs/vets-website#0000
department-of-veterans-affairs/vets-api#0000