### PR TITLE
Changed names of document upload

### DIFF
--- a/dist/686C-674-schema.json
+++ b/dist/686C-674-schema.json
@@ -1507,7 +1507,7 @@
                 "Unknown"
               ]
             },
-            "supportingDocuments": {
+            "childSupportingDocuments": {
               "$ref": "#/definitions/files"
             }
           }
@@ -1739,7 +1739,7 @@
                 "Unknown"
               ]
             },
-            "supportingDocuments": {
+            "spouseSupportingDocuments": {
               "$ref": "#/definitions/files"
             }
           }

--- a/src/schemas/686c-674/schema.js
+++ b/src/schemas/686c-674/schema.js
@@ -296,7 +296,7 @@ const schema = {
                 'Unknown',
               ],
             },
-            supportingDocuments: {
+            childSupportingDocuments: {
               $ref: '#/definitions/files',
             },
           },
@@ -498,7 +498,7 @@ const schema = {
                 'Unknown',
               ],
             },
-            supportingDocuments: {
+            spouseSupportingDocuments: {
               $ref: '#/definitions/files',
             },
           },


### PR DESCRIPTION
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/25791)

During testing of the 686c form it was discovered that if a user went through two separate workflows and uploaded different documents for each workflow they were only allowed to upload one type of document instead of two separate ones. This turned out to be caused by both document uploaders using the same array so this PR separates the arrays that are used for the document uploads on the 686c.


