### PR TITLE
Bumped version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.6.0",
+  "version": "20.6.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"


### PR DESCRIPTION
On a [previous PR](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/602) I forgot to bump the version number in package.json, this PR bumps it.