### PR TITLE
remove ssn and va file number from schema

### DIFF
--- a/dist/28-1900-schema.json
+++ b/dist/28-1900-schema.json
@@ -40,14 +40,6 @@
         "last"
       ]
     },
-    "ssn": {
-      "type": "string",
-      "pattern": "^[0-9]{9}$"
-    },
-    "vaFileNumber": {
-      "type": "string",
-      "pattern": "^[cC]{0,1}\\d{7,9}$"
-    },
     "phone": {
       "type": "string",
       "minLength": 10
@@ -565,12 +557,6 @@
       "properties": {
         "fullName": {
           "$ref": "#/definitions/fullName"
-        },
-        "ssn": {
-          "$ref": "#/definitions/ssn"
-        },
-        "vaFileNumber": {
-          "$ref": "#/definitions/vaFileNumber"
         },
         "dob": {
           "$ref": "#/definitions/date"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.6.2",
+  "version": "20.6.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.6.5",
+  "version": "20.6.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/28-1900/schema.js
+++ b/src/schemas/28-1900/schema.js
@@ -9,19 +9,13 @@ const schema = {
   title: 'DISABLED VETERANS APPLICATION FOR VOCATIONAL REHABILITATION (28-1900)',
   type: 'object',
   additionalProperties: true,
-  definitions: pick(definitions, 'date', 'fullName', 'ssn', 'vaFileNumber', 'phone', 'email', 'profileAddress'),
+  definitions: pick(definitions, 'date', 'fullName', 'phone', 'email', 'profileAddress'),
   properties: {
     veteranInformation: {
       type: 'object',
       properties: {
         fullName: {
           $ref: '#/definitions/fullName',
-        },
-        ssn: {
-          $ref: '#/definitions/ssn',
-        },
-        vaFileNumber: {
-          $ref: '#/definitions/vaFileNumber',
         },
         dob: {
           $ref: '#/definitions/date',

--- a/test/schemas/28-1900/schema.spec.js
+++ b/test/schemas/28-1900/schema.spec.js
@@ -41,8 +41,6 @@ const testData = {
 
 describe('veteran readiness and employment', () => {
   sharedTests.runTest('fullName', ['veteranInformation.fullName']);
-  sharedTests.runTest('ssn', ['veteranInformation.ssn']);
-  sharedTests.runTest('vaFileNumber', ['veteranInformation.vaFileNumber']);
   sharedTests.runTest('date', ['veteranInformation.dob']);
   sharedTests.runTest('email', ['email']);
   sharedTests.runTest('phone', ['mainPhone', 'cellPhone']);


### PR DESCRIPTION
## Description
**Draft until [this ticket is complete](https://github.com/department-of-veterans-affairs/va.gov-team/issues/26822)**
This pull request removes ssn and va file number from the chapter 31 schema. 
## Pull Requests to update the schema in related repositories
<!--
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
-->
https://github.com/department-of-veterans-affairs/vets-website/pull/17783
https://github.com/department-of-veterans-affairs/vets-api/pull/7428