### PR TITLE
Add all SIGI genders to HCA Schema

### DIFF
--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -1595,6 +1595,27 @@
     "wantsInitialVaContact": {
       "type": "boolean"
     },
+    "isGenderMan": {
+      "type": "boolean"
+    },
+    "isGenderWoman": {
+      "type": "boolean"
+    },
+    "isGenderTransMan": {
+      "type": "boolean"
+    },
+    "isGenderTransWoman": {
+      "type": "boolean"
+    },
+    "isGenderNonBinary": {
+      "type": "boolean"
+    },
+    "isGenderNotListed": {
+      "type": "boolean"
+    },
+    "isGenderPreferNoAnswer": {
+      "type": "boolean"
+    },
     "isSpanishHispanicLatino": {
       "type": "boolean"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.15.4",
+  "version": "20.16.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -252,6 +252,27 @@ const schema = {
     wantsInitialVaContact: {
       type: 'boolean',
     },
+    isGenderMan: {
+      type: 'boolean',
+    },
+    isGenderWoman: {
+      type: 'boolean',
+    },
+    isGenderTransMan: {
+      type: 'boolean',
+    },
+    isGenderTransWoman: {
+      type: 'boolean',
+    },
+    isGenderNonBinary: {
+      type: 'boolean',
+    },
+    isGenderNotListed: {
+      type: 'boolean',
+    },
+    isGenderPreferNoAnswer: {
+      type: 'boolean',
+    },
     isSpanishHispanicLatino: {
       type: 'boolean',
     },

--- a/test/schemas/10-10EZ/schema.spec.js
+++ b/test/schemas/10-10EZ/schema.spec.js
@@ -150,7 +150,21 @@ describe('healthcare-application json schema', () => {
   });
 
   schemaTestHelper.testValidAndInvalid('lastServiceBranch', {
-    valid: ['air force', 'army', 'coast guard', 'marine corps', 'merchant seaman', 'navy', 'noaa', 'space force', 'usphs', 'f.commonwealth', 'f.guerilla', 'f.scouts new', 'f.scouts old'],
+    valid: [
+      'air force',
+      'army',
+      'coast guard',
+      'marine corps',
+      'merchant seaman',
+      'navy',
+      'noaa',
+      'space force',
+      'usphs',
+      'f.commonwealth',
+      'f.guerilla',
+      'f.scouts new',
+      'f.scouts old',
+    ],
     invalid: [null, 3, 'random-string'],
   });
 });


### PR DESCRIPTION
# New schema
<!--
Please describe the new schema that is being added and include links to any relevant
issues to help future developers understand the schema and related code.

Please ensure you have incremented the version in `package.json`.
-->
As per [Ticket #25411](https://app.zenhub.com/workspaces/vsa---caregiver-5fff0cfd1462b6000e320fc7/issues/department-of-veterans-affairs/va.gov-team/25411) added all SIGI genders to HCA schema so we can build new SIGI self identifying gender page as per [designs](https://github.com/department-of-veterans-affairs/va.gov-team/issues/25412)

department-of-veterans-affairs/va.gov-team#25411

## Pull Requests to update the schema in related repositories
<!--
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
-->
department-of-veterans-affairs/vets-website#19337
department-of-veterans-affairs/vets-api#0000