### PR TITLE
Updating service branch options for COE schema

### DIFF
--- a/src/schemas/26-1880/schema.js
+++ b/src/schemas/26-1880/schema.js
@@ -72,7 +72,7 @@ const schema = {
             type: 'object',
             title: 'service period',
             properties: {
-              militaryBranch: {
+              serviceBranch: {
                 type: 'string',
                 enum: [
                   'Air Force',
@@ -85,17 +85,16 @@ const schema = {
                   'Coast Guard Reserve',
                   'Marine Corps',
                   'Marine Corps Reserve',
-                  'NOAA',
                   'Navy',
                   'Navy Reserve',
-                  'Public Health Service',
+                  'Other',
                 ],
               },
               dateRange: {
                 $ref: '#/definitions/serviceDateRange',
               },
             },
-            required: ['militaryBranch', 'dateRange'],
+            required: ['serviceBranch', 'dateRange'],
           },
         },
       },


### PR DESCRIPTION
# Schema Changes
This PR removes the enum values of `NOAA` and `Public Health Service` from the `serviceBranch` property in favor of `Other`. I also changed the name of `militaryBranch` back to `serviceBranch` because it caused issues with the `ServicePeriodView` component provided by the form system on the frontend.
Also incremented the version from `20.19.2` -> `20.19.3`.

department-of-veterans-affairs/va.gov-team#37508

## Pull Requests to update the schema in related repositories
<!--
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
-->
department-of-veterans-affairs/vets-website#0000
department-of-veterans-affairs/vets-api#0000