### PR TITLE
28-1900 schema: update appointmentTimePreferences from object to array

### DIFF
--- a/dist/28-1900-schema.json
+++ b/dist/28-1900-schema.json
@@ -608,18 +608,21 @@
     },
     "appointmentTimePreferences": {
       "type": "array",
-      "properties": {
-        "morning": {
-          "type": "boolean",
-          "default": false
-        },
-        "midDay": {
-          "type": "boolean",
-          "default": false
-        },
-        "afternoon": {
-          "type": "boolean",
-          "default": false
+      "items": {
+        "type": "object",
+        "properties": {
+          "morning": {
+            "type": "boolean",
+            "default": false
+          },
+          "midDay": {
+            "type": "boolean",
+            "default": false
+          },
+          "afternoon": {
+            "type": "boolean",
+            "default": false
+          }
         }
       }
     }

--- a/dist/28-1900-schema.json
+++ b/dist/28-1900-schema.json
@@ -607,7 +607,7 @@
       "type": "boolean"
     },
     "appointmentTimePreferences": {
-      "type": "object",
+      "type": "array",
       "properties": {
         "morning": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.19.4",
+  "version": "21.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.19.3",
+  "version": "20.19.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/28-1900/schema.js
+++ b/src/schemas/28-1900/schema.js
@@ -59,7 +59,7 @@ const schema = {
       type: 'boolean',
     },
     appointmentTimePreferences: {
-      type: 'object',
+      type: 'array',
       properties: {
         morning: {
           type: 'boolean',

--- a/src/schemas/28-1900/schema.js
+++ b/src/schemas/28-1900/schema.js
@@ -60,18 +60,21 @@ const schema = {
     },
     appointmentTimePreferences: {
       type: 'array',
-      properties: {
-        morning: {
-          type: 'boolean',
-          default: false,
-        },
-        midDay: {
-          type: 'boolean',
-          default: false,
-        },
-        afternoon: {
-          type: 'boolean',
-          default: false,
+      items: {
+        type: 'object',
+        properties: {
+          morning: {
+            type: 'boolean',
+            default: false,
+          },
+          midDay: {
+            type: 'boolean',
+            default: false,
+          },
+          afternoon: {
+            type: 'boolean',
+            default: false,
+          },
         },
       },
     },

--- a/test/schemas/28-1900/schema.spec.js
+++ b/test/schemas/28-1900/schema.spec.js
@@ -37,6 +37,22 @@ const testData = {
       },
     ],
   },
+  appointmentTimes: {
+    valid: [
+      [
+        {
+          morning: true,
+        },
+        {
+          midDay: false,
+        },
+        {
+          afternoon: true,
+        },
+      ],
+    ],
+    invalid: [],
+  },
 };
 
 describe('veteran readiness and employment', () => {
@@ -47,9 +63,7 @@ describe('veteran readiness and employment', () => {
   schemaTestHelper.testValidAndInvalid('isMoving', testData.boolean);
   schemaTestHelper.testValidAndInvalid('useEva', testData.boolean);
   schemaTestHelper.testValidAndInvalid('useTelecounseling', testData.boolean);
-  schemaTestHelper.testValidAndInvalid('appointmentTimePreferences.morning', testData.boolean);
-  schemaTestHelper.testValidAndInvalid('appointmentTimePreferences.midDay', testData.boolean);
-  schemaTestHelper.testValidAndInvalid('appointmentTimePreferences.afternoon', testData.boolean);
+  schemaTestHelper.testValidAndInvalid('appointmentTimePreferences', testData.appointmentTimes);
   schemaTestHelper.testValidAndInvalid('veteranAddress', testData.address);
   schemaTestHelper.testValidAndInvalid('newAddress', testData.address);
 });


### PR DESCRIPTION
# New schema
<!--
Please describe the new schema that is being added and include links to any relevant
issues to help future developers understand the schema and related code.

Please ensure you have incremented the version in `package.json`.
-->

This PR is to modify the schema for the Veteran Readiness and Employment VA Form 28-1900 (Chapter 31). In production we are currently running into database update errors because we are passing in an array, and the schema expects an object.

`app/models/saved_claim/veteran_readiness_employment_claim.rb`

```
(byebug) update!(form: form_copy.to_json)
*** ActiveRecord::RecordInvalid Exception: Validation failed: Form The property '#/appointmentTimePreferences' of type array did not match the following type: object in schema 725bb504-ad14-510a-8dd6-6782b26e7cf5
```

## Related tickets

- http://sentry.vfs.va.gov/organizations/vsp/issues/49373/?environment=production&project=3&statsPeriod=90d#exception
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/36744

## Pull Requests to update the schema in related repositories
<!--
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
-->
department-of-veterans-affairs/vets-website#0000
department-of-veterans-affairs/vets-api#0000