### PR TITLE
Removed description field and bumped version

### DIFF
--- a/dist/26-1880-schema.json
+++ b/dist/26-1880-schema.json
@@ -1064,9 +1064,6 @@
             "Other"
           ]
         },
-        "fileDescription": {
-          "type": "string"
-        },
         "files": {
           "$ref": "#/definitions/files"
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.19.3",
+  "version": "20.19.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/26-1880/schema.js
+++ b/src/schemas/26-1880/schema.js
@@ -180,9 +180,6 @@ const schema = {
             'Other',
           ],
         },
-        fileDescription: {
-          type: 'string',
-        },
         files: {
           $ref: '#/definitions/files',
         },


### PR DESCRIPTION
# background
Since by default when a user uploads multiple documents using our form system document uploader the user cannot select a different description, we are removing the description altogether. This PR removes that field and bumps the version number in the `package.json` file