### PR TITLE
Removed file type field

### DIFF
--- a/dist/26-1880-schema.json
+++ b/dist/26-1880-schema.json
@@ -1048,22 +1048,6 @@
     "documentUpload": {
       "type": "object",
       "properties": {
-        "fileType": {
-          "type": "string",
-          "enum": [
-            "Discharge or separation papers (DD214)",
-            "Statement of service",
-            "Report of Separation and Record of Service (NGB Form 22)",
-            "Retirement Points Statement (NGB Form 23)",
-            "Proof of honorable service",
-            "Annual retirement points",
-            "Closing Disclosure",
-            "HUD-1 Settlement Statement",
-            "Statement from Loan Servicer",
-            "Alta Statement",
-            "Other"
-          ]
-        },
         "files": {
           "$ref": "#/definitions/files"
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.19.4",
+  "version": "20.19.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/26-1880/schema.js
+++ b/src/schemas/26-1880/schema.js
@@ -164,22 +164,6 @@ const schema = {
     documentUpload: {
       type: 'object',
       properties: {
-        fileType: {
-          type: 'string',
-          enum: [
-            'Discharge or separation papers (DD214)',
-            'Statement of service',
-            'Report of Separation and Record of Service (NGB Form 22)',
-            'Retirement Points Statement (NGB Form 23)',
-            'Proof of honorable service',
-            'Annual retirement points',
-            'Closing Disclosure',
-            'HUD-1 Settlement Statement',
-            'Statement from Loan Servicer',
-            'Alta Statement',
-            'Other',
-          ],
-        },
         files: {
           $ref: '#/definitions/files',
         },


### PR DESCRIPTION
# Background
Since by default when a user uploads multiple documents using our form system document uploader the user cannot select a different file type, we are removing the file type altogether. This PR removes that field and bumps the version number in the package.json file