### PR TITLE
Make isEssentialAcaCoverage required in 1010ez schema

### DIFF
--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -1806,6 +1806,7 @@
     "gender",
     "isSpanishHispanicLatino",
     "veteranAddress",
-    "isMedicaidEligible"
+    "isMedicaidEligible",
+    "isEssentialAcaCoverage"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.19.5",
+  "version": "20.20.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -434,6 +434,7 @@ const schema = {
     'isSpanishHispanicLatino',
     'veteranAddress',
     'isMedicaidEligible',
+    'isEssentialAcaCoverage'
   ],
 };
 


### PR DESCRIPTION
# New schema
Make isEssentialAcaCoverage required in 1010ez schema because it is required by the HCA API. This change should not break anything because the frontend is already always sending a value for this field.
<!--
Please describe the new schema that is being added and include links to any relevant
issues to help future developers understand the schema and related code.

Please ensure you have incremented the version in `package.json`.
-->
https://github.com/department-of-veterans-affairs/va.gov-team/issues/38715

## Pull Requests to update the schema in related repositories
<!--
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
-->
department-of-veterans-affairs/vets-website#0000
department-of-veterans-affairs/vets-api#0000