### PR TITLE
40856 update loanhistory schema

### DIFF
--- a/dist/26-1880-schema.json
+++ b/dist/26-1880-schema.json
@@ -8,6 +8,20 @@
       "pattern": "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$",
       "type": "string"
     },
+    "dateRange": {
+      "type": "object",
+      "properties": {
+        "from": {
+          "$ref": "#/definitions/date"
+        },
+        "to": {
+          "$ref": "#/definitions/date"
+        }
+      },
+      "required": [
+        "from"
+      ]
+    },
     "files": {
       "type": "array",
       "items": {
@@ -842,34 +856,6 @@
       "type": "string",
       "maxLength": 256,
       "format": "email"
-    },
-    "serviceDateRange": {
-      "type": "object",
-      "properties": {
-        "from": {
-          "$ref": "#/definitions/date"
-        },
-        "to": {
-          "$ref": "#/definitions/date"
-        }
-      },
-      "required": [
-        "from"
-      ]
-    },
-    "loanDateRange": {
-      "type": "object",
-      "properties": {
-        "startDate": {
-          "$ref": "#/definitions/date"
-        },
-        "paidOffDate": {
-          "$ref": "#/definitions/date"
-        }
-      },
-      "required": [
-        "startDate"
-      ]
     }
   },
   "properties": {
@@ -880,9 +866,7 @@
           "$ref": "#/definitions/fullName"
         },
         "dateOfBirth": {
-          "type": "string",
-          "title": "Date of birth",
-          "pattern": "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$"
+          "$ref": "#/definitions/date"
         }
       },
       "required": [
@@ -966,7 +950,7 @@
                 ]
               },
               "dateRange": {
-                "$ref": "#/definitions/serviceDateRange"
+                "$ref": "#/definitions/dateRange"
               }
             },
             "required": [
@@ -1014,17 +998,15 @@
           "minItems": 1,
           "items": {
             "type": "object",
-            "title": "Existing VA loan",
             "properties": {
               "dateRange": {
-                "$ref": "#/definitions/loanDateRange"
+                "$ref": "#/definitions/dateRange"
               },
               "propertyAddress": {
                 "$ref": "#/definitions/loanAddress"
               },
               "vaLoanNumber": {
-                "type": "number",
-                "title": "VA loan number"
+                "type": "number"
               },
               "propertyOwned": {
                 "type": "boolean"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.19.5",
+  "version": "20.19.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/26-1880/definitions.js
+++ b/src/schemas/26-1880/definitions.js
@@ -1,69 +1,15 @@
 import { countries, states } from '../../common/constants';
+import definitions from '../../common/definitions';
 
 // filter out military states
 const militaryStates = ['AA', 'AE', 'AP'];
 const filteredStates = states.USA.filter(state => !militaryStates.includes(state.value));
 
-const dateRange = (from = 'from', to = 'to') => {
-  return {
-    type: 'object',
-    properties: {
-      [from]: {
-        $ref: '#/definitions/date',
-      },
-      [to]: {
-        $ref: '#/definitions/date',
-      },
-    },
-    required: [from],
-  };
-};
-
-const definitions = {
-  date: {
-    pattern: '^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$',
-    type: 'string',
-  },
-  files: {
-    type: 'array',
-    items: {
-      type: 'object',
-      properties: {
-        name: {
-          type: 'string',
-        },
-        size: {
-          type: 'integer',
-        },
-        confirmationCode: {
-          type: 'string',
-        },
-      },
-    },
-  },
-  fullName: {
-    type: 'object',
-    properties: {
-      first: {
-        type: 'string',
-        minLength: 1,
-        maxLength: 30,
-      },
-      middle: {
-        type: 'string',
-      },
-      last: {
-        type: 'string',
-        minLength: 1,
-        maxLength: 30,
-      },
-      suffix: {
-        type: 'string',
-        enum: ['Jr.', 'Sr.', 'II', 'III', 'IV'],
-      },
-    },
-    required: ['first', 'last'],
-  },
+const defs = {
+  date: definitions.date,
+  dateRange: { ...definitions.dateRange, required: ['from'] },
+  files: definitions.files,
+  fullName: definitions.fullName,
   profileAddress: {
     type: 'object',
     properties: {
@@ -149,8 +95,6 @@ const definitions = {
     maxLength: 256,
     format: 'email',
   },
-  serviceDateRange: dateRange(),
-  loanDateRange: dateRange('startDate', 'paidOffDate'),
 };
 
-export default definitions;
+export default defs;

--- a/src/schemas/26-1880/definitions.js
+++ b/src/schemas/26-1880/definitions.js
@@ -1,15 +1,15 @@
 import { countries, states } from '../../common/constants';
-import definitions from '../../common/definitions';
+import commonDefinitions from '../../common/definitions';
 
 // filter out military states
 const militaryStates = ['AA', 'AE', 'AP'];
 const filteredStates = states.USA.filter(state => !militaryStates.includes(state.value));
 
-const defs = {
-  date: definitions.date,
-  dateRange: { ...definitions.dateRange, required: ['from'] },
-  files: definitions.files,
-  fullName: definitions.fullName,
+const definitions = {
+  date: commonDefinitions.date,
+  dateRange: { ...commonDefinitions.dateRange, required: ['from'] },
+  files: commonDefinitions.files,
+  fullName: commonDefinitions.fullName,
   profileAddress: {
     type: 'object',
     properties: {
@@ -97,4 +97,4 @@ const defs = {
   },
 };
 
-export default defs;
+export default definitions;

--- a/src/schemas/26-1880/schema.js
+++ b/src/schemas/26-1880/schema.js
@@ -14,9 +14,7 @@ const schema = {
           $ref: '#/definitions/fullName',
         },
         dateOfBirth: {
-          type: 'string',
-          title: 'Date of birth',
-          pattern: '^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$',
+          $ref: '#/definitions/date',
         },
       },
       required: ['dateOfBirth'],
@@ -91,7 +89,7 @@ const schema = {
                 ],
               },
               dateRange: {
-                $ref: '#/definitions/serviceDateRange',
+                $ref: '#/definitions/dateRange',
               },
             },
             required: ['serviceBranch', 'dateRange'],
@@ -130,17 +128,15 @@ const schema = {
           minItems: 1,
           items: {
             type: 'object',
-            title: 'Existing VA loan',
             properties: {
               dateRange: {
-                $ref: '#/definitions/loanDateRange',
+                $ref: '#/definitions/dateRange',
               },
               propertyAddress: {
                 $ref: '#/definitions/loanAddress',
               },
               vaLoanNumber: {
                 type: 'number',
-                title: 'VA loan number',
               },
               propertyOwned: {
                 type: 'boolean',


### PR DESCRIPTION
## Update schema
<!--
Please describe the new schema that is being added and include links to any relevant
issues to help future developers understand the schema and related code.

Please ensure you have incremented the version in `package.json`.
-->
Using `dateRange` common definition in favor of `loanDateRange` and `serviceDateRange` definitions. Also replaced some definitions that already had common definitions in `src/common/definitions`.

## Original Issue(s)
department-of-veterans-affairs/va.gov-team#40856

## Pull Requests to update the schema in related repositories
<!--
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
-->
department-of-veterans-affairs/vets-website#0000
department-of-veterans-affairs/vets-api#0000