### PR TITLE
Corrects degree misspelling

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -1586,7 +1586,7 @@
                 "Associate's degree",
                 "Bachelor’s degree",
                 "Master’s degree",
-                "Doctoral degre",
+                "Doctoral degree",
                 "Other"
               ]
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.20.1",
+  "version": "20.20.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -918,7 +918,7 @@ const schema = {
                 "Associate's degree",
                 'Bachelor’s degree',
                 'Master’s degree',
-                'Doctoral degre',
+                'Doctoral degree',
                 'Other',
               ],
             },

--- a/test/schemas/21-526EZ/schema.spec.js
+++ b/test/schemas/21-526EZ/schema.spec.js
@@ -363,7 +363,7 @@ const data = {
       "Associate's degree",
       'Bachelor’s degree',
       'Master’s degree',
-      'Doctoral degre',
+      'Doctoral degree',
       'Other',
     ],
     invalid: [null, 123, 'foo', {}],


### PR DESCRIPTION
This corrects a typo which was discovered in both this repository and the `vets-api` repository. This simply updates that misspelling, from _"Doctoral degre"_ to _"Doctoral degree"_, and ensures that any existing tests continue to pass.

## Original Issue
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29394

## Pull Requests to update the schema in related repositories
https://github.com/department-of-veterans-affairs/vets-api/pull/9878