### PR TITLE
Update 26-1880-schema

### DIFF
--- a/dist/26-1880-schema.json
+++ b/dist/26-1880-schema.json
@@ -552,11 +552,6 @@
           "minLength": 1,
           "maxLength": 100
         },
-        "street3": {
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 100
-        },
         "city": {
           "type": "string",
           "minLength": 1,

--- a/dist/26-1880-schema.json
+++ b/dist/26-1880-schema.json
@@ -688,7 +688,8 @@
           ]
         },
         "postalCode": {
-          "type": "string"
+          "type": "string",
+          "pattern": "^(\\d{5})(?:[-](\\d{4}))?$"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.20.2",
+  "version": "20.20.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/26-1880/definitions.js
+++ b/src/schemas/26-1880/definitions.js
@@ -35,11 +35,6 @@ const definitions = {
         minLength: 1,
         maxLength: 100,
       },
-      street3: {
-        type: 'string',
-        minLength: 1,
-        maxLength: 100,
-      },
       city: {
         type: 'string',
         minLength: 1,

--- a/src/schemas/26-1880/definitions.js
+++ b/src/schemas/26-1880/definitions.js
@@ -52,6 +52,7 @@ const definitions = {
       },
       postalCode: {
         type: 'string',
+        pattern: '^(\\d{5})(?:[-](\\d{4}))?$',
       },
     },
   },


### PR DESCRIPTION
# Update to 26-1880-schema

This pull request handles two updates to Certificate of Eligibility:

1. our `postalCode` validation was only allowing 5 digit zip codes, but now allowing 9 digit zip codes. This updates the pattern to allow both, `12345` and `12345-6789`.

2. removes _street address line 3_ from schema

Relates to Issues:
- [#42284](https://github.com/department-of-veterans-affairs/va.gov-team/issues/42284)
- [#21347](https://github.com/department-of-veterans-affairs/vets-website/issues/21347)

## Pull Requests to update the schema in related repositories
Vets API Pull Request [#10058](https://github.com/department-of-veterans-affairs/vets-api/pull/10058)
Will draft a Pull Request for `vets-website` momentarily.