### PR TITLE
Refactors Decision Review Contestable Issues Schemas

### DIFF
--- a/dist/DECISION-REVIEW-GET-CONTESTABLE-ISSUES-RESPONSE-200_V1-example.json
+++ b/dist/DECISION-REVIEW-GET-CONTESTABLE-ISSUES-RESPONSE-200_V1-example.json
@@ -1,0 +1,77 @@
+{
+  "data": [
+    {
+      "type": "contestableIssue",
+      "attributes": {
+        "ratingIssueSubjectText": "right knee",
+        "ratingIssuePercentNumber": "10",
+        "ratingIssueReferenceId": "826209920000",
+        "ratingIssueProfileDate": "2019-02-22",
+        "ratingIssueDiagnosticCode": null,
+        "description": "Right knee",
+        "isRating": true,
+        "latestIssuesInChain": [
+          {
+            "id": null,
+            "approxDecisionDate": "2019-02-26"
+          }
+        ],
+        "decisionIssueId": null,
+        "ratingDecisionReferenceId": null,
+        "approxDecisionDate": "2019-02-26",
+        "rampClaimId": null,
+        "titleOfActiveReview": null,
+        "sourceReviewType": null,
+        "timely": true
+      }
+    },
+    {
+      "type": "contestableIssue",
+      "attributes": {
+        "ratingIssueSubjectText": "ptsd",
+        "ratingIssueReferenceId": "826209441170",
+        "ratingIssueProfileDate": "2019-02-22",
+        "ratingIssueDiagnosticCode": null,
+        "description": "PTSD",
+        "isRating": true,
+        "latestIssuesInChain": [
+          {
+            "id": null,
+            "approxDecisionDate": "2019-02-25"
+          }
+        ],
+        "decisionIssueId": null,
+        "ratingDecisionReferenceId": null,
+        "approxDecisionDate": "2019-02-25",
+        "rampClaimId": null,
+        "titleOfActiveReview": null,
+        "sourceReviewType": null,
+        "timely": true
+      }
+    },
+    {
+      "type": "contestableIssue",
+      "attributes": {
+        "ratingIssueSubjectText": "left knee",
+        "ratingIssueReferenceId": "826209597423",
+        "ratingIssueProfileDate": "2019-02-22",
+        "ratingIssueDiagnosticCode": null,
+        "description": "Left knee",
+        "isRating": true,
+        "latestIssuesInChain": [
+          {
+            "id": null,
+            "approxDecisionDate": "2019-02-24"
+          }
+        ],
+        "decisionIssueId": null,
+        "ratingDecisionReferenceId": null,
+        "approxDecisionDate": "2019-02-24",
+        "rampClaimId": null,
+        "titleOfActiveReview": null,
+        "sourceReviewType": null,
+        "timely": true
+      }
+    }
+  ]
+}

--- a/dist/DECISION-REVIEW-GET-CONTESTABLE-ISSUES-RESPONSE-200_V1-schema.json
+++ b/dist/DECISION-REVIEW-GET-CONTESTABLE-ISSUES-RESPONSE-200_V1-schema.json
@@ -1,0 +1,149 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "description": "A contestable issue (to contest this, you include it as a RequestIssue when creating a HigherLevelReview, SupplementalClaim, or Appeal)",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "contestableIssue"
+            ]
+          },
+          "id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "ratingIssueReferenceId": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "RatingIssue ID"
+              },
+              "ratingIssueProfileDate": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date",
+                "description": "(yyyy-mm-dd) RatingIssue profile date"
+              },
+              "ratingIssueDiagnosticCode": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "RatingIssue diagnostic code"
+              },
+              "ratingDecisionReferenceId": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The BGS ID for the contested rating decision. This may be populated while ratingIssueReferenceId is nil"
+              },
+              "decisionIssueId": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "DecisionIssue ID"
+              },
+              "approxDecisionDate": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date",
+                "description": "(yyyy-mm-dd) Approximate decision date"
+              },
+              "description": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Description"
+              },
+              "rampClaimId": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "RampClaim ID"
+              },
+              "titleOfActiveReview": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Title of DecisionReview that this issue is still active on"
+              },
+              "sourceReviewType": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "The type of DecisionReview (HigherLevelReview, SupplementalClaim, Appeal) the issue was last decided on (if any)"
+              },
+              "timely": {
+                "type": "boolean",
+                "description": "An issue is timely if the receipt date is within 372 dates of the decision date."
+              },
+              "latestIssuesInChain": {
+                "type": "array",
+                "description": "Shows the chain of decision and rating issues that preceded this issue. Only the most recent issue can be contested (the object itself that contains the latestIssuesInChain attribute).",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": [
+                        "string",
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "approxDecisionDate": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date"
+                    }
+                  }
+                }
+              },
+              "ratingIssueSubjectText": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Short description of RatingIssue"
+              },
+              "ratingIssuePercentNumber": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "Numerical rating for RatingIssue"
+              },
+              "isRating": {
+                "type": "boolean",
+                "description": "Whether or not this is a RatingIssue"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/dist/HLR-GET-CONTESTABLE-ISSUES-REQUEST-BENEFIT-TYPE_V1-schema.json
+++ b/dist/HLR-GET-CONTESTABLE-ISSUES-REQUEST-BENEFIT-TYPE_V1-schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "string",
+  "enum": [
+    "compensation"
+  ]
+}

--- a/dist/NOD-SHOW-RESPONSE-200_V1-example.json
+++ b/dist/NOD-SHOW-RESPONSE-200_V1-example.json
@@ -1,0 +1,61 @@
+{
+  "data": {
+    "id": "00000000-1111-2222-3333-444444444444",
+    "type": "noticeOfDisagreement",
+    "attributes": {
+      "status": "pending",
+      "updatedAt": "2020-01-02T03:04:05.067Z",
+      "createdAt": "2020-01-02T03:04:05.067Z",
+      "formData": {
+        "data": {
+          "type": "noticeOfDisagreement",
+          "attributes": {
+            "veteran": {
+              "homeless": false,
+              "address": {
+                "addressLine1": "123 Main St",
+                "city": "North Pole",
+                "countryCodeISO2": "CA",
+                "zipCode5": "00000"
+              },
+              "phone": {
+                "areaCode": "555",
+                "phoneNumber": "8001111"
+              },
+              "email": "clause@north.com",
+              "timezone": "America/Chicago"
+            },
+            "representative": {
+              "name": "Tony Danza"
+            },
+            "boardReviewOption": "evidence_submission",
+            "requestingExtension": false,
+            "appealingVhaDenial": false
+          }
+        },
+        "included": [
+          {
+            "type": "contestableIssue",
+            "attributes": {
+              "issue": "tinnitus",
+              "decisionDate": "1900-01-01",
+              "decisionIssueId": 1,
+              "ratingIssueReferenceId": "2",
+              "ratingDecisionReferenceId": "3",
+              "disagreementArea": "Effective Date"
+            }
+          },
+          {
+            "type": "contestableIssue",
+            "attributes": {
+              "issue": "left knee",
+              "decisionDate": "1900-01-02",
+              "decisionIssueId": 4,
+              "ratingIssueReferenceId": "5"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/dist/SC-CREATE-REQUEST-BODY_V1-example.json
+++ b/dist/SC-CREATE-REQUEST-BODY_V1-example.json
@@ -1,226 +1,36 @@
 {
   "data": {
-    "id": "00000000-1111-2222-3333-444444444444",
     "type": "supplementalClaim",
     "attributes": {
-      "status": "pending",
-      "updatedAt": "2020-01-02T03:04:05.067Z",
-      "createdAt": "2020-01-02T03:04:05.067Z",
-      "formData": {
-        "data": {
-          "type": "supplementalClaim",
-          "attributes": {
-            "benefitType": "compensation",
-            "claimantType": "other",
-            "claimantTypeOtherValue": "Veteran Attorney",
-            "veteran": {
-              "address": {
-                "addressLine1": "123 Main St",
-                "addressLine2": "Suite #1200",
-                "addressLine3": "Box 4",
-                "city": "New York",
-                "countryCodeISO2": "US",
-                "stateCode": "NY",
-                "zipCode5": "30012"
-              },
-              "phone": {
-                "countryCode": "03",
-                "areaCode": "555",
-                "phoneNumber": "8001111"
-              },
-              "email": "bobsemail@bobbytablesemail.com",
-              "timezone": "America/Chicago"
-            },
-            "claimant": {
-              "address": {
-                "addressLine1": "456 First St",
-                "addressLine2": "Apt 5",
-                "addressLine3": "Box 1",
-                "city": "Montreal",
-                "countryCodeISO2": "CA",
-                "zipCode5": "00000",
-                "internationalPostalCode": "A9999AAA"
-              },
-              "phone": {
-                "countryCode": "1",
-                "areaCode": "555",
-                "phoneNumber": "8111100",
-                "phoneNumberExt": "4"
-              },
-              "email": "joe@email.com",
-              "timezone": "America/Detroit"
-            },
-            "socOptIn": true,
-            "form5103Acknowledged": true,
-            "evidenceSubmission": {
-              "evidenceType": [
-                "upload",
-                "retrieval"
-              ],
-              "retrieveFrom": [
-                {
-                  "type": "retrievalEvidence",
-                  "attributes": {
-                    "locationAndName": "X-Ray VAMC",
-                    "evidenceDates": [
-                      {
-                        "startDate": "2020-04-10",
-                        "endDate": "2020-04-10"
-                      },
-                      {
-                        "startDate": "2020-01-02",
-                        "endDate": "2020-02-01"
-                      },
-                      {
-                        "startDate": "2020-02-20",
-                        "endDate": "2020-02-22"
-                      },
-                      {
-                        "startDate": "2019-02-02",
-                        "endDate": "2020-02-03"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "retrievalEvidence",
-                  "attributes": {
-                    "locationAndName": "Blood Lab VA Facility",
-                    "evidenceDates": [
-                      {
-                        "startDate": "2020-02-20",
-                        "endDate": "2020-02-22"
-                      },
-                      {
-                        "startDate": "2020-02-02",
-                        "endDate": "2020-02-07"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "retrievalEvidence",
-                  "attributes": {
-                    "locationAndName": "Doctor's Notes VAMC",
-                    "evidenceDates": [
-                      {
-                        "startDate": "2020-04-10",
-                        "endDate": "2020-04-10"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "retrievalEvidence",
-                  "attributes": {
-                    "locationAndName": "CT scan VA Medical Facility",
-                    "evidenceDates": [
-                      {
-                        "startDate": "2020-07-19",
-                        "endDate": "2020-07-19"
-                      },
-                      {
-                        "startDate": "2018-03-06",
-                        "endDate": "2019-02-12"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "retrievalEvidence",
-                  "attributes": {
-                    "locationAndName": "Lab work VAMC",
-                    "evidenceDates": [
-                      {
-                        "startDate": "2018-03-06",
-                        "endDate": "2018-03-06"
-                      },
-                      {
-                        "startDate": "2018-01-15",
-                        "endDate": "2018-01-15"
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          }
+      "benefitType": "fiduciary",
+      "claimantType": "veteran",
+      "veteran": {
+        "address": {
+          "addressLine1": "123 Main St",
+          "city": "New York",
+          "countryCodeISO2": "US",
+          "zipCode5": "30012"
         },
-        "included": [
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "right shoulder",
-              "decisionDate": "2000-01-08",
-              "socDate": "2020-04-30"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "lower back",
-              "decisionDate": "1900-01-06",
-              "socDate": "2021-02-24"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "torn rotator cuff",
-              "decisionDate": "1989-03-07",
-              "socDate": "2020-04-30"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "hearing loss",
-              "decisionDate": "1930-10-20",
-              "socDate": "2016-05-30"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "sciatica",
-              "decisionDate": "2007-01-19",
-              "socDate": "2012-01-02"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "bowel obstruction",
-              "decisionDate": "1999-12-29",
-              "socDate": "2019-08-13"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "right eye",
-              "decisionDate": "1920-04-02",
-              "socDate": "2019-11-19"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "left index finger",
-              "decisionDate": "2018-08-17",
-              "socDate": "2021-03-20"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "spinal compression",
-              "decisionDate": "2013-09-11",
-              "socDate": "2020-08-24"
-            }
-          }
-        ]
+        "phone": {
+          "areaCode": "555",
+          "phoneNumber": "8001111"
+        },
+        "email": "josie@example.com",
+        "timezone": "America/Chicago"
+      },
+      "socOptIn": false,
+      "evidenceSubmission": {
+        "evidenceType": ["upload"]
       }
     }
-  }
+  },
+  "included": [
+    {
+      "type": "contestableIssue",
+      "attributes": {
+        "issue": "right shoulder",
+        "decisionDate": "1900-01-06"
+      }
+    }
+  ]
 }

--- a/dist/SC-CREATE-REQUEST-BODY_V1-example.json
+++ b/dist/SC-CREATE-REQUEST-BODY_V1-example.json
@@ -20,7 +20,9 @@
       },
       "socOptIn": false,
       "evidenceSubmission": {
-        "evidenceType": ["upload"]
+        "evidenceType": [
+          "upload"
+        ]
       }
     }
   },

--- a/dist/SC-GET-CONTESTABLE-ISSUES-REQUEST-BENEFIT-TYPE_V1-schema.json
+++ b/dist/SC-GET-CONTESTABLE-ISSUES-REQUEST-BENEFIT-TYPE_V1-schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "string",
+  "description": "If the contested issue is a Disability Compensation issue, acknowledgement of form 5103 is required - see form5103Acknowledged.",
+  "enum": [
+    "compensation",
+    "pensionSurvivorsBenefits",
+    "fiduciary",
+    "lifeInsurance",
+    "veteransHealthAdministration",
+    "veteranReadinessAndEmployment",
+    "loanGuaranty",
+    "education",
+    "nationalCemeteryAdministration"
+  ]
+}

--- a/dist/SC-SHOW-RESPONSE-200_V1-example.json
+++ b/dist/SC-SHOW-RESPONSE-200_V1-example.json
@@ -1,0 +1,49 @@
+{
+  "data": {
+    "id": "00000000-1111-2222-3333-444444444444",
+    "type": "supplementalClaim",
+    "attributes": {
+      "status": "pending",
+      "updatedAt": "2020-01-02T03:04:05.067Z",
+      "createdAt": "2020-01-02T03:04:05.067Z",
+      "formData": {
+        "data": {
+          "type": "supplementalClaim",
+          "attributes": {
+            "benefitType": "fiduciary",
+            "claimantType": "veteran",
+            "veteran": {
+              "address": {
+                "addressLine1": "123 Main St",
+                "city": "New York",
+                "countryCodeISO2": "US",
+                "zipCode5": "30012"
+              },
+              "phone": {
+                "areaCode": "555",
+                "phoneNumber": "8001111"
+              },
+              "email": "josie@example.com",
+              "timezone": "America/Chicago"
+            },
+            "socOptIn": false,
+            "evidenceSubmission": {
+              "evidenceType": [
+                "upload"
+              ]
+            }
+          }
+        },
+        "included": [
+          {
+            "type": "contestableIssue",
+            "attributes": {
+              "issue": "right shoulder",
+              "decisionDate": "1900-01-06"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.20.7",
+  "version": "20.20.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/examples/DECISION-REVIEW-get-contestable-issues-response-200_v1/example.js
+++ b/src/examples/DECISION-REVIEW-get-contestable-issues-response-200_v1/example.js
@@ -1,0 +1,1 @@
+export default require('../../schemas/DECISION-REVIEW-get-contestable-issues-response-200_v1/example.json');

--- a/src/examples/NOD-show-response-200_v1/example.js
+++ b/src/examples/NOD-show-response-200_v1/example.js
@@ -1,0 +1,1 @@
+export default require('../../schemas/NOD-show-response-200_v1/example.json');

--- a/src/examples/SC-show-response-200_v1/example.js
+++ b/src/examples/SC-show-response-200_v1/example.js
@@ -1,0 +1,1 @@
+export default require('../../schemas/SC-show-response-200_v1/example.json');

--- a/src/schemas/DECISION-REVIEW-get-contestable-issues-response-200_v1/README.md
+++ b/src/schemas/DECISION-REVIEW-get-contestable-issues-response-200_v1/README.md
@@ -1,0 +1,1 @@
+Example pulled directly from Lighthouse https://developer.va.gov/explore/appeals/docs/decision_reviews?version=current

--- a/src/schemas/DECISION-REVIEW-get-contestable-issues-response-200_v1/example.json
+++ b/src/schemas/DECISION-REVIEW-get-contestable-issues-response-200_v1/example.json
@@ -1,0 +1,77 @@
+{
+  "data": [
+    {
+      "type": "contestableIssue",
+      "attributes": {
+        "ratingIssueSubjectText": "right knee",
+        "ratingIssuePercentNumber": "10",
+        "ratingIssueReferenceId": "826209920000",
+        "ratingIssueProfileDate": "2019-02-22",
+        "ratingIssueDiagnosticCode": null,
+        "description": "Right knee",
+        "isRating": true,
+        "latestIssuesInChain": [
+          {
+            "id": null,
+            "approxDecisionDate": "2019-02-26"
+          }
+        ],
+        "decisionIssueId": null,
+        "ratingDecisionReferenceId": null,
+        "approxDecisionDate": "2019-02-26",
+        "rampClaimId": null,
+        "titleOfActiveReview": null,
+        "sourceReviewType": null,
+        "timely": true
+      }
+    },
+    {
+      "type": "contestableIssue",
+      "attributes": {
+        "ratingIssueSubjectText": "ptsd",
+        "ratingIssueReferenceId": "826209441170",
+        "ratingIssueProfileDate": "2019-02-22",
+        "ratingIssueDiagnosticCode": null,
+        "description": "PTSD",
+        "isRating": true,
+        "latestIssuesInChain": [
+          {
+            "id": null,
+            "approxDecisionDate": "2019-02-25"
+          }
+        ],
+        "decisionIssueId": null,
+        "ratingDecisionReferenceId": null,
+        "approxDecisionDate": "2019-02-25",
+        "rampClaimId": null,
+        "titleOfActiveReview": null,
+        "sourceReviewType": null,
+        "timely": true
+      }
+    },
+    {
+      "type": "contestableIssue",
+      "attributes": {
+        "ratingIssueSubjectText": "left knee",
+        "ratingIssueReferenceId": "826209597423",
+        "ratingIssueProfileDate": "2019-02-22",
+        "ratingIssueDiagnosticCode": null,
+        "description": "Left knee",
+        "isRating": true,
+        "latestIssuesInChain": [
+          {
+            "id": null,
+            "approxDecisionDate": "2019-02-24"
+          }
+        ],
+        "decisionIssueId": null,
+        "ratingDecisionReferenceId": null,
+        "approxDecisionDate": "2019-02-24",
+        "rampClaimId": null,
+        "titleOfActiveReview": null,
+        "sourceReviewType": null,
+        "timely": true
+      }
+    }
+  ]
+}

--- a/src/schemas/DECISION-REVIEW-get-contestable-issues-response-200_v1/schema.js
+++ b/src/schemas/DECISION-REVIEW-get-contestable-issues-response-200_v1/schema.js
@@ -1,0 +1,5 @@
+// This schema is pulled directly from the OpenAPI documentation provided by Lighthouse https://api.va.gov/services/appeals/docs/v1/decision_reviews
+
+import schema from './schema.json';
+schema.$schema = 'http://json-schema.org/draft-04/schema#';
+export default schema;

--- a/src/schemas/DECISION-REVIEW-get-contestable-issues-response-200_v1/schema.json
+++ b/src/schemas/DECISION-REVIEW-get-contestable-issues-response-200_v1/schema.json
@@ -1,0 +1,100 @@
+{
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "description": "A contestable issue (to contest this, you include it as a RequestIssue when creating a HigherLevelReview, SupplementalClaim, or Appeal)",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["contestableIssue"]
+          },
+          "id": {
+            "type": ["string", "null"]
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "ratingIssueReferenceId": {
+                "type": ["string", "null"],
+                "description": "RatingIssue ID"
+              },
+              "ratingIssueProfileDate": {
+                "type": ["string", "null"],
+                "format": "date",
+                "description": "(yyyy-mm-dd) RatingIssue profile date"
+              },
+              "ratingIssueDiagnosticCode": {
+                "type": ["string", "null"],
+                "description": "RatingIssue diagnostic code"
+              },
+              "ratingDecisionReferenceId": {
+                "type": ["string", "null"],
+                "description": "The BGS ID for the contested rating decision. This may be populated while ratingIssueReferenceId is nil"
+              },
+              "decisionIssueId": {
+                "type": ["integer", "null"],
+                "description": "DecisionIssue ID"
+              },
+              "approxDecisionDate": {
+                "type": ["string", "null"],
+                "format": "date",
+                "description": "(yyyy-mm-dd) Approximate decision date"
+              },
+              "description": {
+                "type": ["string", "null"],
+                "description": "Description"
+              },
+              "rampClaimId": {
+                "type": ["string", "null"],
+                "description": "RampClaim ID"
+              },
+              "titleOfActiveReview": {
+                "type": ["string", "null"],
+                "description": "Title of DecisionReview that this issue is still active on"
+              },
+              "sourceReviewType": {
+                "type": ["string", "null"],
+                "description": "The type of DecisionReview (HigherLevelReview, SupplementalClaim, Appeal) the issue was last decided on (if any)"
+              },
+              "timely": {
+                "type": "boolean",
+                "description": "An issue is timely if the receipt date is within 372 dates of the decision date."
+              },
+              "latestIssuesInChain": {
+                "type": "array",
+                "description": "Shows the chain of decision and rating issues that preceded this issue. Only the most recent issue can be contested (the object itself that contains the latestIssuesInChain attribute).",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": ["string", "null", "integer"]
+                    },
+                    "approxDecisionDate": {
+                      "type": ["string", "null"],
+                      "format": "date"
+                    }
+                  }
+                }
+              },
+              "ratingIssueSubjectText": {
+                "type": ["string", "null"],
+                "description": "Short description of RatingIssue"
+              },
+              "ratingIssuePercentNumber": {
+                "type": ["string", "null"],
+                "description": "Numerical rating for RatingIssue"
+              },
+              "isRating": {
+                "type": "boolean",
+                "description": "Whether or not this is a RatingIssue"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/schemas/HLR-get-contestable-issues-request-benefit-type_v1/schema.js
+++ b/src/schemas/HLR-get-contestable-issues-request-benefit-type_v1/schema.js
@@ -1,0 +1,10 @@
+import schema from '../HLR-create-request-body_v1/schema';
+
+const benefitTypeSchema = schema.definitions.hlrCreate.properties.data.properties.attributes.properties.benefitType;
+
+if (!benefitTypeSchema) throw 'benefit_type_schema missing';
+
+export default {
+  $schema: 'http://json-schema.org/draft-04/schema#',
+  ...benefitTypeSchema,
+};

--- a/src/schemas/NOD-show-response-200_v1/example.json
+++ b/src/schemas/NOD-show-response-200_v1/example.json
@@ -1,0 +1,61 @@
+{
+  "data": {
+    "id": "00000000-1111-2222-3333-444444444444",
+    "type": "noticeOfDisagreement",
+    "attributes": {
+      "status": "pending",
+      "updatedAt": "2020-01-02T03:04:05.067Z",
+      "createdAt": "2020-01-02T03:04:05.067Z",
+      "formData": {
+        "data": {
+          "type": "noticeOfDisagreement",
+          "attributes": {
+            "veteran": {
+              "homeless": false,
+              "address": {
+                "addressLine1": "123 Main St",
+                "city": "North Pole",
+                "countryCodeISO2": "CA",
+                "zipCode5": "00000"
+              },
+              "phone": {
+                "areaCode": "555",
+                "phoneNumber": "8001111"
+              },
+              "email": "clause@north.com",
+              "timezone": "America/Chicago"
+            },
+            "representative": {
+              "name": "Tony Danza"
+            },
+            "boardReviewOption": "evidence_submission",
+            "requestingExtension": false,
+            "appealingVhaDenial": false
+          }
+        },
+        "included": [
+          {
+            "type": "contestableIssue",
+            "attributes": {
+              "issue": "tinnitus",
+              "decisionDate": "1900-01-01",
+              "decisionIssueId": 1,
+              "ratingIssueReferenceId": "2",
+              "ratingDecisionReferenceId": "3",
+              "disagreementArea": "Effective Date"
+            }
+          },
+          {
+            "type": "contestableIssue",
+            "attributes": {
+              "issue": "left knee",
+              "decisionDate": "1900-01-02",
+              "decisionIssueId": 4,
+              "ratingIssueReferenceId": "5"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/schemas/SC-create-request-body_v1/example.json
+++ b/src/schemas/SC-create-request-body_v1/example.json
@@ -1,223 +1,36 @@
 {
   "data": {
-    "id": "00000000-1111-2222-3333-444444444444",
     "type": "supplementalClaim",
     "attributes": {
-      "status": "pending",
-      "updatedAt": "2020-01-02T03:04:05.067Z",
-      "createdAt": "2020-01-02T03:04:05.067Z",
-      "formData": {
-        "data": {
-          "type": "supplementalClaim",
-          "attributes": {
-            "benefitType": "compensation",
-            "claimantType": "other",
-            "claimantTypeOtherValue": "Veteran Attorney",
-            "veteran": {
-              "address": {
-                "addressLine1": "123 Main St",
-                "addressLine2": "Suite #1200",
-                "addressLine3": "Box 4",
-                "city": "New York",
-                "countryCodeISO2": "US",
-                "stateCode": "NY",
-                "zipCode5": "30012"
-              },
-              "phone": {
-                "countryCode": "03",
-                "areaCode": "555",
-                "phoneNumber": "8001111"
-              },
-              "email": "bobsemail@bobbytablesemail.com",
-              "timezone": "America/Chicago"
-            },
-            "claimant": {
-              "address": {
-                "addressLine1": "456 First St",
-                "addressLine2": "Apt 5",
-                "addressLine3": "Box 1",
-                "city": "Montreal",
-                "countryCodeISO2": "CA",
-                "zipCode5": "00000",
-                "internationalPostalCode": "A9999AAA"
-              },
-              "phone": {
-                "countryCode": "1",
-                "areaCode": "555",
-                "phoneNumber": "8111100",
-                "phoneNumberExt": "4"
-              },
-              "email": "joe@email.com",
-              "timezone": "America/Detroit"
-            },
-            "socOptIn": true,
-            "form5103Acknowledged": true,
-            "evidenceSubmission": {
-              "evidenceType": ["upload", "retrieval"],
-              "retrieveFrom": [
-                {
-                  "type": "retrievalEvidence",
-                  "attributes": {
-                    "locationAndName": "X-Ray VAMC",
-                    "evidenceDates": [
-                      {
-                        "startDate": "2020-04-10",
-                        "endDate": "2020-04-10"
-                      },
-                      {
-                        "startDate": "2020-01-02",
-                        "endDate": "2020-02-01"
-                      },
-                      {
-                        "startDate": "2020-02-20",
-                        "endDate": "2020-02-22"
-                      },
-                      {
-                        "startDate": "2019-02-02",
-                        "endDate": "2020-02-03"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "retrievalEvidence",
-                  "attributes": {
-                    "locationAndName": "Blood Lab VA Facility",
-                    "evidenceDates": [
-                      {
-                        "startDate": "2020-02-20",
-                        "endDate": "2020-02-22"
-                      },
-                      {
-                        "startDate": "2020-02-02",
-                        "endDate": "2020-02-07"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "retrievalEvidence",
-                  "attributes": {
-                    "locationAndName": "Doctor's Notes VAMC",
-                    "evidenceDates": [
-                      {
-                        "startDate": "2020-04-10",
-                        "endDate": "2020-04-10"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "retrievalEvidence",
-                  "attributes": {
-                    "locationAndName": "CT scan VA Medical Facility",
-                    "evidenceDates": [
-                      {
-                        "startDate": "2020-07-19",
-                        "endDate": "2020-07-19"
-                      },
-                      {
-                        "startDate": "2018-03-06",
-                        "endDate": "2019-02-12"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "retrievalEvidence",
-                  "attributes": {
-                    "locationAndName": "Lab work VAMC",
-                    "evidenceDates": [
-                      {
-                        "startDate": "2018-03-06",
-                        "endDate": "2018-03-06"
-                      },
-                      {
-                        "startDate": "2018-01-15",
-                        "endDate": "2018-01-15"
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          }
+      "benefitType": "fiduciary",
+      "claimantType": "veteran",
+      "veteran": {
+        "address": {
+          "addressLine1": "123 Main St",
+          "city": "New York",
+          "countryCodeISO2": "US",
+          "zipCode5": "30012"
         },
-        "included": [
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "right shoulder",
-              "decisionDate": "2000-01-08",
-              "socDate": "2020-04-30"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "lower back",
-              "decisionDate": "1900-01-06",
-              "socDate": "2021-02-24"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "torn rotator cuff",
-              "decisionDate": "1989-03-07",
-              "socDate": "2020-04-30"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "hearing loss",
-              "decisionDate": "1930-10-20",
-              "socDate": "2016-05-30"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "sciatica",
-              "decisionDate": "2007-01-19",
-              "socDate": "2012-01-02"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "bowel obstruction",
-              "decisionDate": "1999-12-29",
-              "socDate": "2019-08-13"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "right eye",
-              "decisionDate": "1920-04-02",
-              "socDate": "2019-11-19"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "left index finger",
-              "decisionDate": "2018-08-17",
-              "socDate": "2021-03-20"
-            }
-          },
-          {
-            "type": "contestableIssue",
-            "attributes": {
-              "issue": "spinal compression",
-              "decisionDate": "2013-09-11",
-              "socDate": "2020-08-24"
-            }
-          }
-        ]
+        "phone": {
+          "areaCode": "555",
+          "phoneNumber": "8001111"
+        },
+        "email": "josie@example.com",
+        "timezone": "America/Chicago"
+      },
+      "socOptIn": false,
+      "evidenceSubmission": {
+        "evidenceType": ["upload"]
       }
     }
-  }
+  },
+  "included": [
+    {
+      "type": "contestableIssue",
+      "attributes": {
+        "issue": "right shoulder",
+        "decisionDate": "1900-01-06"
+      }
+    }
+  ]
 }

--- a/src/schemas/SC-get-contestable-issues-request-benefit-type_v1/schema.js
+++ b/src/schemas/SC-get-contestable-issues-request-benefit-type_v1/schema.js
@@ -1,0 +1,10 @@
+import schema from '../SC-create-request-body_v1/schema';
+
+const benefitTypeSchema = schema.definitions.scCreate.properties.data.properties.attributes.properties.benefitType;
+
+if (!benefitTypeSchema) throw 'benefit_type_schema missing';
+
+export default {
+  $schema: 'http://json-schema.org/draft-04/schema#',
+  ...benefitTypeSchema,
+};

--- a/src/schemas/SC-show-response-200_v1/example.json
+++ b/src/schemas/SC-show-response-200_v1/example.json
@@ -1,0 +1,47 @@
+{
+  "data": {
+    "id": "00000000-1111-2222-3333-444444444444",
+    "type": "supplementalClaim",
+    "attributes": {
+      "status": "pending",
+      "updatedAt": "2020-01-02T03:04:05.067Z",
+      "createdAt": "2020-01-02T03:04:05.067Z",
+      "formData": {
+        "data": {
+          "type": "supplementalClaim",
+          "attributes": {
+            "benefitType": "fiduciary",
+            "claimantType": "veteran",
+            "veteran": {
+              "address": {
+                "addressLine1": "123 Main St",
+                "city": "New York",
+                "countryCodeISO2": "US",
+                "zipCode5": "30012"
+              },
+              "phone": {
+                "areaCode": "555",
+                "phoneNumber": "8001111"
+              },
+              "email": "josie@example.com",
+              "timezone": "America/Chicago"
+            },
+            "socOptIn": false,
+            "evidenceSubmission": {
+              "evidenceType": ["upload"]
+            }
+          }
+        },
+        "included": [
+          {
+            "type": "contestableIssue",
+            "attributes": {
+              "issue": "right shoulder",
+              "decisionDate": "1900-01-06"
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Decision Review Schema Updates
This adjusts and creates new schemas/examples relating to Decision Review Contestable Issues. Instead of Supplemental Claims sharing schemas with Higher Level Review, we're adding its own schema as it looks like there are `benefit_type`'s unique to it.

Additionally, there was schema example placed directly in the spec folder on `vets-api`, which we've migrated here to have everything in a single location.

Related to [Issues #44262](https://github.com/department-of-veterans-affairs/va.gov-team/issues/44262)

## Pull Requests to update the schema in related repositories
https://github.com/department-of-veterans-affairs/vets-api/pull/10307