### PR TITLE
Update 10-10EZ Medicare Claim Number max length

### DIFF
--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -1729,7 +1729,8 @@
       "$ref": "#/definitions/date"
     },
     "medicareClaimNumber": {
-      "type": "string"
+      "type": "string",
+      "maxLength": 30
     },
     "lastServiceBranch": {
       "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.20.11",
+  "version": "20.20.12",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -381,6 +381,7 @@ const schema = {
     },
     medicareClaimNumber: {
       type: 'string',
+      maxLength: 30,
     },
     lastServiceBranch: {
       type: 'string',


### PR DESCRIPTION
# New schema
We recently learned our downstream system has a maximum character length for one of the fields in our form. This PR updates the 10-10EZ schema to validate for a max character length of the Medicare Claim Number field.

## Original Issue(s)
department-of-veterans-affairs/va.gov-team#44106

## Pull Requests to update the schema in related repositories
department-of-veterans-affairs/vets-website#0000
department-of-veterans-affairs/vets-api#0000