### PR TITLE
Fix COE loan number pattern

### DIFF
--- a/dist/26-1880-schema.json
+++ b/dist/26-1880-schema.json
@@ -846,7 +846,7 @@
     },
     "loanNumber": {
       "type": "string",
-      "pattern": "^\\d[- \\d]+$"
+      "pattern": "^\\d[- \\d]*$"
     },
     "usaPhone": {
       "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.20.13",
+  "version": "20.20.14",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/generate-schemas.js
+++ b/src/generate-schemas.js
@@ -11,16 +11,21 @@ import { dist_examples as distExamples } from './examples.js';
 const files = { definitions, constants, vaMedicalFacilities, caregiverProgramFacilities, form1010cgCertifications };
 
 fs.readdirSync('src/schemas').forEach(schema => {
-  jsonfile.writeFileSync(`dist/${schema.toUpperCase()}-schema.json`, require(`./schemas/${schema}/schema`).default, {
-    spaces: 2,
-  });
+  console.log('schema = ', schema);
+  if (schema !== '.DS_Store') {
+    jsonfile.writeFileSync(`dist/${schema.toUpperCase()}-schema.json`, require(`./schemas/${schema}/schema`).default, {
+      spaces: 2,
+    });
+  }
 });
 
 fs.readdirSync('src/schemas').forEach(schema => {
-  const examples = distExamples(path.resolve(__dirname, '..'), schema);
-  Object.keys(examples).forEach(key => {
-    jsonfile.writeFileSync(`dist/${key}`, examples[key], { spaces: 2 });
-  });
+  if (schema !== '.DS_Store') {
+    const examples = distExamples(path.resolve(__dirname, '..'), schema);
+    Object.keys(examples).forEach(key => {
+      jsonfile.writeFileSync(`dist/${key}`, examples[key], { spaces: 2 });
+    });
+  }
 });
 
 // eslint-disable-next-line guard-for-in,no-restricted-syntax

--- a/src/generate-schemas.js
+++ b/src/generate-schemas.js
@@ -11,7 +11,6 @@ import { dist_examples as distExamples } from './examples.js';
 const files = { definitions, constants, vaMedicalFacilities, caregiverProgramFacilities, form1010cgCertifications };
 
 fs.readdirSync('src/schemas').forEach(schema => {
-  console.log('schema = ', schema);
   if (schema !== '.DS_Store') {
     jsonfile.writeFileSync(`dist/${schema.toUpperCase()}-schema.json`, require(`./schemas/${schema}/schema`).default, {
       spaces: 2,

--- a/src/schemas/26-1880/definitions.js
+++ b/src/schemas/26-1880/definitions.js
@@ -84,7 +84,7 @@ const definitions = {
   },
   loanNumber: {
     type: 'string',
-    pattern: '^\\d[- \\d]+$',
+    pattern: '^\\d[- \\d]*$',
   },
   usaPhone: {
     type: 'string',


### PR DESCRIPTION
# New schema

Updated the Certificate of Eligibility loan number regexp pattern to not show an error when only 1 digit is entered

[#45026](https://github.com/department-of-veterans-affairs/va.gov-team/issues/45026)

**NOTE** Additional fix to `generate-schema` function to ignore `.DS_Store` as this error message started showing up:

> Error: Cannot find module './schemas/.DS_Store/schema'

## Pull Requests to update the schema in related repositories

Pending (COE is not in production)