### PR TITLE
removing pst-flt from code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 
-*       @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/platform-release-tools @department-of-veterans-affairs/pst-forms-library
+*       @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/platform-release-tools 


### PR DESCRIPTION
# Update code owner

This PR is just to remove the `Platform Spike Team - Forms Library Team` from the CODEOWNERS file.

[department-of-veterans-affairs/va.gov-team#571](https://app.zenhub.com/workspaces/forms-library---platform-spike-team-61b0ae1f2cd3c30014e8a5b0/issues/department-of-veterans-affairs/va-forms-system-core/571)