### PR TITLE
Removing enum from military service options in 526ez

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.23.0",
+  "version": "20.24.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -295,22 +295,6 @@ const schema = {
             properties: {
               serviceBranch: {
                 type: 'string',
-                enum: [
-                  'Air Force',
-                  'Air Force Reserve',
-                  'Air National Guard',
-                  'Army',
-                  'Army National Guard',
-                  'Army Reserve',
-                  'Coast Guard',
-                  'Coast Guard Reserve',
-                  'Marine Corps',
-                  'Marine Corps Reserve',
-                  'NOAA',
-                  'Navy',
-                  'Navy Reserve',
-                  'Public Health Service',
-                ],
               },
               dateRange: {
                 $ref: '#/definitions/dateRangeAllRequired',

--- a/test/schemas/21-526EZ/schema.spec.js
+++ b/test/schemas/21-526EZ/schema.spec.js
@@ -145,7 +145,7 @@ const data = {
       ],
     ],
     invalid: [
-      [{ serviceBranch: 'test', dateRange: fixtures.dateRange }],
+      [{ serviceBranch: 123456, dateRange: fixtures.dateRange }],
       [{ serviceBranch: 'Air Force' }],
       [{ serviceBranch: 'Air Force', dateRange: { from: '2015-01-01' } }],
       [{ dateRange: {} }],


### PR DESCRIPTION
In https://github.com/department-of-veterans-affairs/va.gov-team/issues/41046 we are beginning to consume lighthouse's /service-branches endpoint (See https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) to populate our dropdown for military service branches in the 526ez form. Since we now expect that branches may be added or removed in the future, we can no longer enforce an enum.

# New schema
<!--
Please describe the new schema that is being added and include links to any relevant
issues to help future developers understand the schema and related code.

Please ensure you have incremented the version in `package.json`.
-->
https://github.com/department-of-veterans-affairs/va.gov-team/issues/41046

## Pull Requests to update the schema in related repositories
<!--
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
-->
department-of-veterans-affairs/vets-website#0000
department-of-veterans-affairs/vets-api#0000

(I will add these links shortly after this PR is merged)