### PR TITLE
Removing service branches enum from 526 schema

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -847,16 +847,7 @@
       }
     },
     "militaryRetiredPayBranch": {
-      "type": "string",
-      "enum": [
-        "Air Force",
-        "Army",
-        "Coast Guard",
-        "Marine Corps",
-        "National Oceanic and Atmospheric Administration",
-        "Navy",
-        "Public Health Service"
-      ]
+      "type": "string"
     },
     "waiveRetirementPay": {
       "type": "boolean"
@@ -868,16 +859,7 @@
       "type": "string"
     },
     "separationPayBranch": {
-      "type": "string",
-      "enum": [
-        "Air Force",
-        "Army",
-        "Coast Guard",
-        "Marine Corps",
-        "National Oceanic and Atmospheric Administration",
-        "Navy",
-        "Public Health Service"
-      ]
+      "type": "string"
     },
     "hasTrainingPay": {
       "type": "boolean"

--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -785,23 +785,7 @@
             ],
             "properties": {
               "serviceBranch": {
-                "type": "string",
-                "enum": [
-                  "Air Force",
-                  "Air Force Reserve",
-                  "Air National Guard",
-                  "Army",
-                  "Army National Guard",
-                  "Army Reserve",
-                  "Coast Guard",
-                  "Coast Guard Reserve",
-                  "Marine Corps",
-                  "Marine Corps Reserve",
-                  "NOAA",
-                  "Navy",
-                  "Navy Reserve",
-                  "Public Health Service"
-                ]
+                "type": "string"
               },
               "dateRange": {
                 "$ref": "#/definitions/dateRangeAllRequired"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.24.0",
+  "version": "20.24.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -295,22 +295,6 @@ const schema = {
             properties: {
               serviceBranch: {
                 type: 'string',
-                enum: [
-                  'Air Force',
-                  'Air Force Reserve',
-                  'Air National Guard',
-                  'Army',
-                  'Army National Guard',
-                  'Army Reserve',
-                  'Coast Guard',
-                  'Coast Guard Reserve',
-                  'Marine Corps',
-                  'Marine Corps Reserve',
-                  'NOAA',
-                  'Navy',
-                  'Navy Reserve',
-                  'Public Health Service',
-                ],
               },
               dateRange: {
                 $ref: '#/definitions/dateRangeAllRequired',

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -2,16 +2,6 @@ import _ from 'lodash/fp';
 import { documentTypes526, pciuCountries, pciuStates } from '../../common/constants';
 import definitions from '../../common/definitions';
 
-const serviceBranches = [
-  'Air Force',
-  'Army',
-  'Coast Guard',
-  'Marine Corps',
-  'National Oceanic and Atmospheric Administration',
-  'Navy',
-  'Public Health Service',
-];
-
 const disabilitiesBaseDef = {
   type: 'array',
   maxItems: 100,
@@ -354,7 +344,6 @@ const schema = {
     },
     militaryRetiredPayBranch: {
       type: 'string',
-      enum: serviceBranches,
     },
     waiveRetirementPay: {
       type: 'boolean',
@@ -367,7 +356,6 @@ const schema = {
     },
     separationPayBranch: {
       type: 'string',
-      enum: serviceBranches,
     },
     hasTrainingPay: {
       type: 'boolean',

--- a/test/schemas/21-526EZ/schema.spec.js
+++ b/test/schemas/21-526EZ/schema.spec.js
@@ -194,7 +194,7 @@ const data = {
       'Navy',
       'Public Health Service',
     ],
-    invalid: ['foo', 1234, null],
+    invalid: [1234, null],
   },
   specialIssues: {
     valid: [['ALS', 'HEPC', 'POW'], ['PTSD/1', 'PTSD/2', 'PTSD/3', 'PTSD/4'], ['MST']],


### PR DESCRIPTION
(PR #725 was reverted since more frontend (FE) work was needed. Having this change in place would likely break new 526 submissions without the FE work completed. Synchronizing updates of this change with the FE & backend are essential.)

In https://github.com/department-of-veterans-affairs/va.gov-team/issues/41046 we are beginning to consume lighthouse's /service-branches endpoint (See https://developer.va.gov/explore/benefits/docs/benefits_reference_data?version=current) to populate our dropdowns for military service branches in the 526ez form. Since we now expect that branches may be added or removed in the future, we can no longer enforce an enum.

# New schema
<!--
Please describe the new schema that is being added and include links to any relevant
issues to help future developers understand the schema and related code.

Please ensure you have incremented the version in `package.json`.
-->
department-of-veterans-affairs/va.gov-team#41046

## Pull Requests to update the schema in related repositories
<!--
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
-->
https://github.com/department-of-veterans-affairs/vets-website/pull/22476
department-of-veterans-affairs/vets-api#0000 (N/A, no backend changes)