### PR TITLE
Restore missing privacyAgreementAccepted definition in 26-4555 schema

### DIFF
--- a/dist/26-4555-schema.json
+++ b/dist/26-4555-schema.json
@@ -864,11 +864,14 @@
         }
       }
     },
-    "required": [
-      "privacyAgreementAccepted"
-    ],
     "remarks": {
       "type": "string"
+    },
+    "privacyAgreementAccepted": {
+      "$ref": "#/definitions/privacyAgreementAccepted"
     }
-  }
+  },
+  "required": [
+    "privacyAgreementAccepted"
+  ]
 }

--- a/dist/26-4555-schema.json
+++ b/dist/26-4555-schema.json
@@ -765,6 +765,12 @@
     "vaFileNumber": {
       "type": "string",
       "pattern": "^[cC]{0,1}\\d{7,9}$"
+    },
+    "privacyAgreementAccepted": {
+      "type": "boolean",
+      "enum": [
+        true
+      ]
     }
   },
   "properties": {
@@ -858,6 +864,9 @@
         }
       }
     },
+    "required": [
+      "privacyAgreementAccepted"
+    ],
     "remarks": {
       "type": "string"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.25.1",
+  "version": "20.25.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/26-4555/schema.js
+++ b/src/schemas/26-4555/schema.js
@@ -19,6 +19,7 @@ const schema = {
     'profileAddress',
     'ssn',
     'vaFileNumber',
+    'privacyAgreementAccepted',
   ]),
   properties: {
     veteran: {
@@ -76,6 +77,7 @@ const schema = {
         careFacilityAddress: { $ref: '#/definitions/address' },
       },
     },
+    required: ['privacyAgreementAccepted'],
     remarks: {
       type: 'string',
     },

--- a/src/schemas/26-4555/schema.js
+++ b/src/schemas/26-4555/schema.js
@@ -77,11 +77,14 @@ const schema = {
         careFacilityAddress: { $ref: '#/definitions/address' },
       },
     },
-    required: ['privacyAgreementAccepted'],
     remarks: {
       type: 'string',
     },
+    privacyAgreementAccepted: {
+      $ref: '#/definitions/privacyAgreementAccepted',
+    },
   },
+  required: ['privacyAgreementAccepted'],
 };
 
 export default schema;

--- a/test/schemas/26-4555/schema.spec.js
+++ b/test/schemas/26-4555/schema.spec.js
@@ -21,6 +21,7 @@ const schemaDefaults = {
     address: usAddressFixture,
     homePhone: fixtures.phone,
   },
+  privacyAgreementAccepted: true,
 };
 
 const testData = {


### PR DESCRIPTION
# Fixed schema
<!--
Please describe the new schema that is being added and include links to any relevant
issues to help future developers understand the schema and related code.

Please ensure you have incremented the version in `package.json`.
-->
Just adding back the missing privacyAgreementAccepted definition to my schema.  That's it.
[This PR bumps version to v2.25.2]

## Pull Requests to update the schema in related repositories
<!--
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
-->
No f/e or b/e PRs for just this change &mdash; development's still in-progress.