### PR TITLE
Update/fix profileAddress definition property order

### DIFF
--- a/dist/26-4555-schema.json
+++ b/dist/26-4555-schema.json
@@ -263,6 +263,10 @@
         "isMilitary": {
           "type": "boolean"
         },
+        "view:militaryBaseDescription": {
+          "type": "object",
+          "properties": {}
+        },
         "country": {
           "type": "string",
           "enum": [
@@ -725,10 +729,6 @@
             "Zambia",
             "Zimbabwe"
           ]
-        },
-        "view:militaryBaseDescription": {
-          "type": "object",
-          "properties": {}
         },
         "street": {
           "type": "string",

--- a/dist/28-1900-schema.json
+++ b/dist/28-1900-schema.json
@@ -55,6 +55,10 @@
         "isMilitary": {
           "type": "boolean"
         },
+        "view:militaryBaseDescription": {
+          "type": "object",
+          "properties": {}
+        },
         "country": {
           "type": "string",
           "enum": [
@@ -517,10 +521,6 @@
             "Zambia",
             "Zimbabwe"
           ]
-        },
-        "view:militaryBaseDescription": {
-          "type": "object",
-          "properties": {}
         },
         "street": {
           "type": "string",

--- a/dist/28-8832-schema.json
+++ b/dist/28-8832-schema.json
@@ -9,6 +9,10 @@
         "isMilitary": {
           "type": "boolean"
         },
+        "view:militaryBaseDescription": {
+          "type": "object",
+          "properties": {}
+        },
         "country": {
           "type": "string",
           "enum": [
@@ -471,10 +475,6 @@
             "Zambia",
             "Zimbabwe"
           ]
-        },
-        "view:militaryBaseDescription": {
-          "type": "object",
-          "properties": {}
         },
         "street": {
           "type": "string",

--- a/dist/COVID-VACCINATION-EXPANSION-schema.json
+++ b/dist/COVID-VACCINATION-EXPANSION-schema.json
@@ -31,6 +31,10 @@
         "isMilitary": {
           "type": "boolean"
         },
+        "view:militaryBaseDescription": {
+          "type": "object",
+          "properties": {}
+        },
         "country": {
           "type": "string",
           "enum": [
@@ -493,10 +497,6 @@
             "Zambia",
             "Zimbabwe"
           ]
-        },
-        "view:militaryBaseDescription": {
-          "type": "object",
-          "properties": {}
         },
         "street": {
           "type": "string",

--- a/dist/definitions.json
+++ b/dist/definitions.json
@@ -381,6 +381,10 @@
       "isMilitary": {
         "type": "boolean"
       },
+      "view:militaryBaseDescription": {
+        "type": "object",
+        "properties": {}
+      },
       "country": {
         "type": "string",
         "enum": [
@@ -843,10 +847,6 @@
           "Zambia",
           "Zimbabwe"
         ]
-      },
-      "view:militaryBaseDescription": {
-        "type": "object",
-        "properties": {}
       },
       "street": {
         "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.26.0",
+  "version": "20.26.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/common/definitions.js
+++ b/src/common/definitions.js
@@ -164,14 +164,14 @@ const profileAddress = {
     isMilitary: {
       type: 'boolean',
     },
+    'view:militaryBaseDescription': {
+      type: 'object',
+      properties: {},
+    },
     country: {
       type: 'string',
       enum: constants.countries.map(country => country.value),
       enumNames: countries.map(country => country.label),
-    },
-    'view:militaryBaseDescription': {
-      type: 'object',
-      properties: {},
     },
     street: {
       type: 'string',


### PR DESCRIPTION
## Definition update

Relevant issue: department-of-veterans-affairs/va.gov-team-forms#128

This pull request updates the `profileAddress` definition to have the properties be in their proper order. While order is not "guaranteed" from the JSON schema, the incorrect order is causing a couple forms to display incorrectly in vets-website.

![image](https://user-images.githubusercontent.com/53942725/223733002-d1a3a460-75d3-4ef2-bb74-1449ae106864.png)

Not all forms using `profileAddress` are affected by this because some are using a custom schema implementation, therefore completely overwriting the vets-json-schema definition.