### PR TITLE
Add json schema + tests for 21-4142

### DIFF
--- a/dist/21-4142-schema.json
+++ b/dist/21-4142-schema.json
@@ -1,0 +1,909 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Authorize the release of medical information to the VA",
+  "type": "object",
+  "definitions": {
+    "address": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "country": {
+              "type": "string",
+              "enum": [
+                "CAN"
+              ]
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "AB",
+                "BC",
+                "MB",
+                "NB",
+                "NF",
+                "NT",
+                "NV",
+                "NU",
+                "ON",
+                "PE",
+                "QC",
+                "SK",
+                "YT"
+              ]
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "country": {
+              "type": "string",
+              "enum": [
+                "MEX"
+              ]
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "aguascalientes",
+                "baja-california-norte",
+                "baja-california-sur",
+                "campeche",
+                "chiapas",
+                "chihuahua",
+                "coahuila",
+                "colima",
+                "distrito-federal",
+                "durango",
+                "guanajuato",
+                "guerrero",
+                "hidalgo",
+                "jalisco",
+                "mexico",
+                "michoacan",
+                "morelos",
+                "nayarit",
+                "nuevo-leon",
+                "oaxaca",
+                "puebla",
+                "queretaro",
+                "quintana-roo",
+                "san-luis-potosi",
+                "sinaloa",
+                "sonora",
+                "tabasco",
+                "tamaulipas",
+                "tlaxcala",
+                "veracruz",
+                "yucatan",
+                "zacatecas"
+              ]
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "country": {
+              "type": "string",
+              "enum": [
+                "USA"
+              ]
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "AL",
+                "AK",
+                "AS",
+                "AZ",
+                "AR",
+                "AA",
+                "AE",
+                "AP",
+                "CA",
+                "CO",
+                "CT",
+                "DE",
+                "DC",
+                "FM",
+                "FL",
+                "GA",
+                "GU",
+                "HI",
+                "ID",
+                "IL",
+                "IN",
+                "IA",
+                "KS",
+                "KY",
+                "LA",
+                "ME",
+                "MH",
+                "MD",
+                "MA",
+                "MI",
+                "MN",
+                "MS",
+                "MO",
+                "MT",
+                "NE",
+                "NV",
+                "NH",
+                "NJ",
+                "NM",
+                "NY",
+                "NC",
+                "ND",
+                "MP",
+                "OH",
+                "OK",
+                "OR",
+                "PW",
+                "PA",
+                "PR",
+                "RI",
+                "SC",
+                "SD",
+                "TN",
+                "TX",
+                "UT",
+                "VT",
+                "VI",
+                "VA",
+                "WA",
+                "WV",
+                "WI",
+                "WY"
+              ]
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "country": {
+              "not": {
+                "type": "string",
+                "enum": [
+                  "CAN",
+                  "MEX",
+                  "USA"
+                ]
+              }
+            },
+            "state": {
+              "type": "string",
+              "maxLength": 51
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 51
+            }
+          }
+        }
+      ],
+      "properties": {
+        "street": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50
+        },
+        "street2": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50
+        },
+        "city": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 51
+        }
+      }
+    },
+    "date": {
+      "pattern": "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$",
+      "type": "string"
+    },
+    "email": {
+      "type": "string",
+      "maxLength": 256,
+      "format": "email"
+    },
+    "fullName": {
+      "type": "object",
+      "properties": {
+        "first": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 30
+        },
+        "middle": {
+          "type": "string"
+        },
+        "last": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 30
+        },
+        "suffix": {
+          "type": "string",
+          "enum": [
+            "Jr.",
+            "Sr.",
+            "II",
+            "III",
+            "IV"
+          ]
+        }
+      },
+      "required": [
+        "first",
+        "last"
+      ]
+    },
+    "fullNameNoSuffix": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "first",
+        "last"
+      ],
+      "properties": {
+        "first": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 30
+        },
+        "middle": {
+          "type": "string"
+        },
+        "last": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 30
+        }
+      }
+    },
+    "phone": {
+      "type": "string",
+      "minLength": 10
+    },
+    "privacyAgreementAccepted": {
+      "type": "boolean",
+      "enum": [
+        true
+      ]
+    },
+    "profileAddress": {
+      "type": "object",
+      "properties": {
+        "isMilitary": {
+          "type": "boolean"
+        },
+        "country": {
+          "type": "string",
+          "enum": [
+            "USA",
+            "AFG",
+            "ALB",
+            "DZA",
+            "AND",
+            "AGO",
+            "AIA",
+            "ATA",
+            "ATG",
+            "ARG",
+            "ARM",
+            "ABW",
+            "AUS",
+            "AUT",
+            "AZE",
+            "BHS",
+            "BHR",
+            "BGD",
+            "BRB",
+            "BLR",
+            "BEL",
+            "BLZ",
+            "BEN",
+            "BMU",
+            "BTN",
+            "BOL",
+            "BIH",
+            "BWA",
+            "BVT",
+            "BRA",
+            "IOT",
+            "BRN",
+            "BGR",
+            "BFA",
+            "BDI",
+            "KHM",
+            "CMR",
+            "CAN",
+            "CPV",
+            "CYM",
+            "CAF",
+            "TCD",
+            "CHL",
+            "CHN",
+            "CXR",
+            "CCK",
+            "COL",
+            "COM",
+            "COG",
+            "COD",
+            "COK",
+            "CRI",
+            "CIV",
+            "HRV",
+            "CUB",
+            "CYP",
+            "CZE",
+            "DNK",
+            "DJI",
+            "DMA",
+            "DOM",
+            "ECU",
+            "EGY",
+            "SLV",
+            "GNQ",
+            "ERI",
+            "EST",
+            "ETH",
+            "FLK",
+            "FRO",
+            "FJI",
+            "FIN",
+            "FRA",
+            "GUF",
+            "PYF",
+            "ATF",
+            "GAB",
+            "GMB",
+            "GEO",
+            "DEU",
+            "GHA",
+            "GIB",
+            "GRC",
+            "GRL",
+            "GRD",
+            "GLP",
+            "GTM",
+            "GIN",
+            "GNB",
+            "GUY",
+            "HTI",
+            "HMD",
+            "HND",
+            "HKG",
+            "HUN",
+            "ISL",
+            "IND",
+            "IDN",
+            "IRN",
+            "IRQ",
+            "IRL",
+            "ISR",
+            "ITA",
+            "JAM",
+            "JPN",
+            "JOR",
+            "KAZ",
+            "KEN",
+            "KIR",
+            "PRK",
+            "KOR",
+            "KWT",
+            "KGZ",
+            "LAO",
+            "LVA",
+            "LBN",
+            "LSO",
+            "LBR",
+            "LBY",
+            "LIE",
+            "LTU",
+            "LUX",
+            "MAC",
+            "MKD",
+            "MDG",
+            "MWI",
+            "MYS",
+            "MDV",
+            "MLI",
+            "MLT",
+            "MTQ",
+            "MRT",
+            "MUS",
+            "MYT",
+            "MEX",
+            "FSM",
+            "MDA",
+            "MCO",
+            "MNG",
+            "MSR",
+            "MAR",
+            "MOZ",
+            "MMR",
+            "NAM",
+            "NRU",
+            "NPL",
+            "ANT",
+            "NLD",
+            "NCL",
+            "NZL",
+            "NIC",
+            "NER",
+            "NGA",
+            "NIU",
+            "NFK",
+            "NOR",
+            "OMN",
+            "PAK",
+            "PAN",
+            "PNG",
+            "PRY",
+            "PER",
+            "PHL",
+            "PCN",
+            "POL",
+            "PRT",
+            "QAT",
+            "REU",
+            "ROU",
+            "RUS",
+            "RWA",
+            "SHN",
+            "KNA",
+            "LCA",
+            "SPM",
+            "VCT",
+            "SMR",
+            "STP",
+            "SAU",
+            "SEN",
+            "SCG",
+            "SYC",
+            "SLE",
+            "SGP",
+            "SVK",
+            "SVN",
+            "SLB",
+            "SOM",
+            "ZAF",
+            "SGS",
+            "ESP",
+            "LKA",
+            "SDN",
+            "SUR",
+            "SWZ",
+            "SWE",
+            "CHE",
+            "SYR",
+            "TWN",
+            "TJK",
+            "TZA",
+            "THA",
+            "TLS",
+            "TGO",
+            "TKL",
+            "TON",
+            "TTO",
+            "TUN",
+            "TUR",
+            "TKM",
+            "TCA",
+            "TUV",
+            "UGA",
+            "UKR",
+            "ARE",
+            "GBR",
+            "URY",
+            "UZB",
+            "VUT",
+            "VAT",
+            "VEN",
+            "VNM",
+            "VGB",
+            "WLF",
+            "ESH",
+            "YEM",
+            "ZMB",
+            "ZWE"
+          ],
+          "enumNames": [
+            "United States",
+            "Afghanistan",
+            "Albania",
+            "Algeria",
+            "Andorra",
+            "Angola",
+            "Anguilla",
+            "Antarctica",
+            "Antigua",
+            "Argentina",
+            "Armenia",
+            "Aruba",
+            "Australia",
+            "Austria",
+            "Azerbaijan",
+            "Bahamas",
+            "Bahrain",
+            "Bangladesh",
+            "Barbados",
+            "Belarus",
+            "Belgium",
+            "Belize",
+            "Benin",
+            "Bermuda",
+            "Bhutan",
+            "Bolivia",
+            "Bosnia",
+            "Botswana",
+            "Bouvet Island",
+            "Brazil",
+            "British Indian Ocean Territories",
+            "Brunei Darussalam",
+            "Bulgaria",
+            "Burkina Faso",
+            "Burundi",
+            "Cambodia",
+            "Cameroon",
+            "Canada",
+            "Cape Verde",
+            "Cayman",
+            "Central African Republic",
+            "Chad",
+            "Chile",
+            "China",
+            "Christmas Island",
+            "Cocos Islands",
+            "Colombia",
+            "Comoros",
+            "Congo",
+            "Democratic Republic of the Congo",
+            "Cook Islands",
+            "Costa Rica",
+            "Ivory Coast",
+            "Croatia",
+            "Cuba",
+            "Cyprus",
+            "Czech Republic",
+            "Denmark",
+            "Djibouti",
+            "Dominica",
+            "Dominican Republic",
+            "Ecuador",
+            "Egypt",
+            "El Salvador",
+            "Equatorial Guinea",
+            "Eritrea",
+            "Estonia",
+            "Ethiopia",
+            "Falkland Islands",
+            "Faroe Islands",
+            "Fiji",
+            "Finland",
+            "France",
+            "French Guiana",
+            "French Polynesia",
+            "French Southern Territories",
+            "Gabon",
+            "Gambia",
+            "Georgia",
+            "Germany",
+            "Ghana",
+            "Gibraltar",
+            "Greece",
+            "Greenland",
+            "Grenada",
+            "Guadeloupe",
+            "Guatemala",
+            "Guinea",
+            "Guinea-Bissau",
+            "Guyana",
+            "Haiti",
+            "Heard Island",
+            "Honduras",
+            "Hong Kong",
+            "Hungary",
+            "Iceland",
+            "India",
+            "Indonesia",
+            "Iran",
+            "Iraq",
+            "Ireland",
+            "Israel",
+            "Italy",
+            "Jamaica",
+            "Japan",
+            "Jordan",
+            "Kazakhstan",
+            "Kenya",
+            "Kiribati",
+            "North Korea",
+            "South Korea",
+            "Kuwait",
+            "Kyrgyzstan",
+            "Laos",
+            "Latvia",
+            "Lebanon",
+            "Lesotho",
+            "Liberia",
+            "Libya",
+            "Liechtenstein",
+            "Lithuania",
+            "Luxembourg",
+            "Macao",
+            "Macedonia",
+            "Madagascar",
+            "Malawi",
+            "Malaysia",
+            "Maldives",
+            "Mali",
+            "Malta",
+            "Martinique",
+            "Mauritania",
+            "Mauritius",
+            "Mayotte",
+            "Mexico",
+            "Micronesia",
+            "Moldova",
+            "Monaco",
+            "Mongolia",
+            "Montserrat",
+            "Morocco",
+            "Mozambique",
+            "Myanmar",
+            "Namibia",
+            "Nauru",
+            "Nepal",
+            "Netherlands Antilles",
+            "Netherlands",
+            "New Caledonia",
+            "New Zealand",
+            "Nicaragua",
+            "Niger",
+            "Nigeria",
+            "Niue",
+            "Norfolk",
+            "Norway",
+            "Oman",
+            "Pakistan",
+            "Panama",
+            "Papua New Guinea",
+            "Paraguay",
+            "Peru",
+            "Philippines",
+            "Pitcairn",
+            "Poland",
+            "Portugal",
+            "Qatar",
+            "Reunion",
+            "Romania",
+            "Russia",
+            "Rwanda",
+            "Saint Helena",
+            "Saint Kitts and Nevis",
+            "Saint Lucia",
+            "Saint Pierre and Miquelon",
+            "Saint Vincent and the Grenadines",
+            "San Marino",
+            "Sao Tome and Principe",
+            "Saudi Arabia",
+            "Senegal",
+            "Serbia",
+            "Seychelles",
+            "Sierra Leone",
+            "Singapore",
+            "Slovakia",
+            "Slovenia",
+            "Solomon Islands",
+            "Somalia",
+            "South Africa",
+            "South Georgia and the South Sandwich Islands",
+            "Spain",
+            "Sri Lanka",
+            "Sudan",
+            "Suriname",
+            "Swaziland",
+            "Sweden",
+            "Switzerland",
+            "Syrian Arab Republic",
+            "Taiwan",
+            "Tajikistan",
+            "Tanzania",
+            "Thailand",
+            "Timor-Leste",
+            "Togo",
+            "Tokelau",
+            "Tonga",
+            "Trinidad and Tobago",
+            "Tunisia",
+            "Turkey",
+            "Turkmenistan",
+            "Turks and Caicos Islands",
+            "Tuvalu",
+            "Uganda",
+            "Ukraine",
+            "United Arab Emirates",
+            "United Kingdom",
+            "Uruguay",
+            "Uzbekistan",
+            "Vanuatu",
+            "Vatican",
+            "Venezuela",
+            "Vietnam",
+            "British Virgin Islands",
+            "Wallis and Futuna",
+            "Western Sahara",
+            "Yemen",
+            "Zambia",
+            "Zimbabwe"
+          ]
+        },
+        "view:militaryBaseDescription": {
+          "type": "object",
+          "properties": {}
+        },
+        "street": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "street2": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "street3": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "city": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "state": {
+          "type": "string"
+        },
+        "postalCode": {
+          "type": "string"
+        }
+      }
+    },
+    "ssn": {
+      "type": "string",
+      "pattern": "^[0-9]{9}$"
+    },
+    "vaFileNumber": {
+      "type": "string",
+      "pattern": "^[cC]{0,1}\\d{7,9}$"
+    }
+  },
+  "properties": {
+    "veteran": {
+      "type": "object",
+      "properties": {
+        "fullName": {
+          "$ref": "#/definitions/fullName"
+        },
+        "dateOfBirth": {
+          "$ref": "#/definitions/date"
+        },
+        "ssn": {
+          "$ref": "#/definitions/ssn"
+        },
+        "vaFileNumber": {
+          "$ref": "#/definitions/vaFileNumber"
+        },
+        "address": {
+          "$ref": "#/definitions/profileAddress"
+        },
+        "homePhone": {
+          "$ref": "#/definitions/phone"
+        },
+        "internationalPhone": {
+          "$ref": "#/definitions/phone"
+        },
+        "email": {
+          "$ref": "#/definitions/email"
+        }
+      },
+      "required": [
+        "fullName",
+        "address",
+        "homePhone"
+      ]
+    },
+    "patientIdentification": {
+      "type": "object",
+      "properties": {
+        "isRequestingOwnMedicalRecords": {
+          "type": "boolean"
+        },
+        "patientFullName": {
+          "$ref": "#/definitions/fullNameNoSuffix"
+        },
+        "patientSsn": {
+          "$ref": "#/definitions/ssn"
+        },
+        "patientVaFileNumber": {
+          "$ref": "#/definitions/vaFileNumber"
+        }
+      },
+      "required": [
+        "isRequestingOwnMedicalRecords"
+      ]
+    },
+    "providerFacility": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "providerFacilityName": {
+            "type": "string"
+          },
+          "conditionsTreated": {
+            "type": "string"
+          },
+          "treatmentDateRange": {
+            "type": "object",
+            "properties": {
+              "from": {
+                "$ref": "#/definitions/date"
+              },
+              "to": {
+                "$ref": "#/definitions/date"
+              }
+            },
+            "required": [
+              "from",
+              "to"
+            ]
+          },
+          "providerFacilityAddress": {
+            "$ref": "#/definitions/address"
+          }
+        }
+      },
+      "required": [
+        "conditionsTreated",
+        "providerFacilityName",
+        "treatmentDateRange",
+        "providerFacilityAddress"
+      ]
+    },
+    "acknowledgeToReleaseInformation": {
+      "$ref": "#/definitions/privacyAgreementAccepted"
+    },
+    "limitedConsent": {
+      "type": "string"
+    },
+    "privacyAgreementAccepted": {
+      "$ref": "#/definitions/privacyAgreementAccepted"
+    }
+  },
+  "required": [
+    "veteran",
+    "patientIdentification",
+    "acknowledgeToReleaseInformation",
+    "providerFacility",
+    "privacyAgreementAccepted"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.26.1",
+  "version": "20.26.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-4142/schema.js
+++ b/src/schemas/21-4142/schema.js
@@ -1,0 +1,118 @@
+import pick from 'lodash/pick';
+import definitions from '../../common/definitions';
+
+const schema = {
+  $schema: 'http://json-schema.org/draft-04/schema#',
+  title: 'Authorize the release of medical information to the VA',
+  type: 'object',
+  definitions: pick(
+    definitions,
+    'address',
+    'date',
+    'email',
+    'fullName',
+    'fullNameNoSuffix',
+    'phone',
+    'privacyAgreementAccepted',
+    'profileAddress',
+    'ssn',
+    'vaFileNumber',
+  ),
+  properties: {
+    veteran: {
+      type: 'object',
+      properties: {
+        fullName: {
+          $ref: '#/definitions/fullName',
+        },
+        dateOfBirth: {
+          $ref: '#/definitions/date',
+        },
+        ssn: {
+          $ref: '#/definitions/ssn',
+        },
+        vaFileNumber: {
+          $ref: '#/definitions/vaFileNumber',
+        },
+        address: { $ref: '#/definitions/profileAddress' },
+        homePhone: {
+          $ref: '#/definitions/phone',
+        },
+        internationalPhone: {
+          $ref: '#/definitions/phone',
+        },
+        email: {
+          $ref: '#/definitions/email',
+        },
+      },
+      required: ['fullName', 'address', 'homePhone'],
+    },
+    patientIdentification: {
+      type: 'object',
+      properties: {
+        isRequestingOwnMedicalRecords: {
+          type: 'boolean',
+        },
+        patientFullName: {
+          $ref: '#/definitions/fullNameNoSuffix',
+        },
+        patientSsn: {
+          $ref: '#/definitions/ssn',
+        },
+        patientVaFileNumber: {
+          $ref: '#/definitions/vaFileNumber',
+        },
+      },
+      required: ['isRequestingOwnMedicalRecords'],
+    },
+    providerFacility: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          providerFacilityName: {
+            type: 'string',
+          },
+          conditionsTreated: {
+            type: 'string',
+          },
+          treatmentDateRange: {
+            type: 'object',
+            properties: {
+              from: {
+                $ref: '#/definitions/date',
+              },
+              to: {
+                $ref: '#/definitions/date',
+              },
+            },
+            required: ['from', 'to'],
+          },
+          providerFacilityAddress: {
+            $ref: '#/definitions/address',
+          },
+        },
+      },
+      required: ['conditionsTreated', 'providerFacilityName', 'treatmentDateRange', 'providerFacilityAddress'],
+    },
+    acknowledgeToReleaseInformation: {
+      $ref: '#/definitions/privacyAgreementAccepted',
+    },
+    limitedConsent: {
+      type: 'string',
+    },
+    privacyAgreementAccepted: {
+      $ref: '#/definitions/privacyAgreementAccepted',
+    },
+  },
+  required: [
+    'veteran',
+    'patientIdentification',
+    'acknowledgeToReleaseInformation',
+    'providerFacility',
+    'privacyAgreementAccepted',
+  ],
+};
+
+export default schema;

--- a/test/schemas/21-4142/schema.spec.js
+++ b/test/schemas/21-4142/schema.spec.js
@@ -1,0 +1,136 @@
+import _ from 'lodash';
+import SchemaTestHelper from '../../support/schema-test-helper';
+import schemas from '../../../dist/schemas';
+import SharedTests from '../../support/shared-tests';
+import fixtures from '../../support/fixtures';
+
+const schema = schemas['21-4142'];
+const usAddressFixture = {
+  ...fixtures.address,
+  state: 'AL',
+  postalCode: '54321',
+};
+
+const schemaDefaults = {
+  veteran: {
+    fullName: {
+      first: 'Test',
+      last: 'Name',
+    },
+    ssn: fixtures.ssn,
+    address: usAddressFixture,
+    homePhone: fixtures.phone,
+  },
+  patientIdentification: {
+    isRequestingOwnMedicalRecords: false,
+  },
+  acknowledgeToReleaseInformation: true,
+  privacyAgreementAccepted: true,
+};
+
+const veteranData = {
+  address: {
+    valid: [
+      {
+        country: 'USA',
+        street: '123 at home dr',
+        street2: 'apt 1',
+        city: 'a city',
+        state: 'AL',
+        postalCode: '12345',
+      },
+    ],
+    invalid: [
+      {
+        country: 'ABC',
+        street: true,
+        city: null,
+        state: false,
+        postalCode: 12345,
+      },
+    ],
+  },
+};
+
+// need to remove any required props from schema first,
+// in order for sharedTests.runTest to work.
+const schemaTestHelper = new SchemaTestHelper(
+  _.omit(schema, 'required', 'properties.veteran.required', 'properties.patientIdentification.required'),
+  schemaDefaults,
+);
+const sharedTests = new SharedTests(schemaTestHelper);
+
+describe('21-4142 Adapted Housing json-schema', () => {
+  [
+    ['date', ['veteran.dateOfBirth']],
+    ['email', ['veteran.email']],
+    ['fullName', ['veteran.fullName']],
+    ['phone', ['veteran.homePhone']],
+    ['ssn', ['veteran.ssn', 'patientIdentification.patientSsn']],
+    ['vaFileNumber', ['veteran.vaFileNumber', 'patientIdentification.patientVaFileNumber']],
+  ].forEach(test => {
+    sharedTests.runTest(...test);
+  });
+
+  schemaTestHelper.testValidAndInvalid('veteran.address', veteranData.address);
+
+  schemaTestHelper.testValidAndInvalid('patientIdentification', {
+    valid: [
+      {
+        isRequestingOwnMedicalRecords: false,
+        patientFullName: fixtures.fullName,
+        patientSsn: '123456789',
+        patientVaFileNumber: 'c123456789',
+      },
+      {
+        isRequestingOwnMedicalRecords: true,
+      },
+    ],
+    invalid: [
+      {
+        isRequestingOwnMedicalRecords: false,
+        patientFullName: 23456,
+        patientSsn: 1234,
+        patientVaFileNumber: 23423,
+      },
+    ],
+  });
+
+  schemaTestHelper.testValidAndInvalid('providerFacility', {
+    valid: [
+      [
+        {
+          providerFacilityName: 'Test',
+          providerFacilityAddress: usAddressFixture,
+          treatmentDateRange: fixtures.dateRange,
+          conditionsTreated: 'Test',
+        },
+      ],
+    ],
+    invalid: [
+      [
+        {
+          providerFacilityName: 3456,
+          providerFacilityAddress: usAddressFixture,
+          treatmentDateRange: fixtures.dateRange,
+          conditionsTreated: ['Test', 'Test 2'],
+        },
+      ],
+    ],
+  });
+
+  schemaTestHelper.testValidAndInvalid('patientIdentification.isRequestingOwnMedicalRecords', {
+    valid: [true, false],
+    invalid: ['yes', 'no', '0', '1'],
+  });
+
+  schemaTestHelper.testValidAndInvalid('acknowledgeToReleaseInformation', {
+    valid: [true],
+    invalid: [false, 'yes', 'no', '0', '1'],
+  });
+
+  schemaTestHelper.testValidAndInvalid('privacyAgreementAccepted', {
+    valid: [true],
+    invalid: [false, 'yes', 'no', '0', '1'],
+  });
+});


### PR DESCRIPTION
# New schema
For form 21-4142 for release and disclosure of medical records to the VA
- department-of-veterans-affairs/va.gov-team-forms#89

Notes on old PDF vs new PDF for `form4142`
The `providerFacility` property is similar to `#/definitions/form4142` (2018 version) with some slight differences to match the 2021 PDF:
- added `conditionsTreated` property 
- `treatmentDateRange` is no longer an array, but an object, since there is only one set of value in the new PDF
- `privacyAgreementAccepted` should be for the entire form 4142/4142a rather than just the definition, so pulled that out to the correct scope

For all these reasons, I didn't reuse the "common" definition `form4142`.

## Pull Requests to update the schema in related repositories
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
- [ ] department-of-veterans-affairs/vets-website#0000
- [ ] department-of-veterans-affairs/vets-api#0000