### PR TITLE
Update 26-4555 schema to use the centralMailVaFile definition

### DIFF
--- a/dist/26-4555-schema.json
+++ b/dist/26-4555-schema.json
@@ -762,9 +762,9 @@
       "type": "string",
       "pattern": "^[0-9]{9}$"
     },
-    "vaFileNumber": {
+    "centralMailVaFile": {
       "type": "string",
-      "pattern": "^[cC]{0,1}\\d{7,9}$"
+      "pattern": "^\\d{8,9}$"
     },
     "privacyAgreementAccepted": {
       "type": "boolean",
@@ -794,7 +794,7 @@
           "$ref": "#/definitions/ssn"
         },
         "vaFileNumber": {
-          "$ref": "#/definitions/vaFileNumber"
+          "$ref": "#/definitions/centralMailVaFile"
         },
         "address": {
           "$ref": "#/definitions/profileAddress"

--- a/dist/40-10007-schema.json
+++ b/dist/40-10007-schema.json
@@ -297,11 +297,6 @@
       "type": "string",
       "pattern": "^\\d{8,9}$"
     },
-    "militaryServiceNumber": {
-      "type": "string",
-      "maxLength": 10,
-      "pattern": "^\\d{4,10}$"
-    },
     "date": {
       "type": "string",
       "format": "date"
@@ -549,7 +544,8 @@
               ]
             },
             "militaryServiceNumber": {
-              "$ref": "#/definitions/militaryServiceNumber"
+              "type": "string",
+              "maxLength": 9
             },
             "militaryStatus": {
               "type": "string",

--- a/dist/40-10007-schema.json
+++ b/dist/40-10007-schema.json
@@ -297,6 +297,11 @@
       "type": "string",
       "pattern": "^\\d{8,9}$"
     },
+    "militaryServiceNumber": {
+      "type": "string",
+      "maxLength": 10,
+      "pattern": "^\\d{4,10}$"
+    },
     "date": {
       "type": "string",
       "format": "date"
@@ -544,8 +549,7 @@
               ]
             },
             "militaryServiceNumber": {
-              "type": "string",
-              "maxLength": 9
+              "$ref": "#/definitions/militaryServiceNumber"
             },
             "militaryStatus": {
               "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.26.4",
+  "version": "20.26.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/26-4555/schema.js
+++ b/src/schemas/26-4555/schema.js
@@ -18,7 +18,7 @@ const schema = {
     'phone',
     'profileAddress',
     'ssn',
-    'vaFileNumber',
+    'centralMailVaFile',
     'privacyAgreementAccepted',
   ]),
   properties: {
@@ -34,7 +34,7 @@ const schema = {
           $ref: '#/definitions/date',
         },
         ssn: { $ref: '#/definitions/ssn' },
-        vaFileNumber: { $ref: '#/definitions/vaFileNumber' },
+        vaFileNumber: { $ref: '#/definitions/centralMailVaFile' },
         address: { $ref: '#/definitions/profileAddress' },
         homePhone: { $ref: '#/definitions/phone' },
         mobilePhone: { $ref: '#/definitions/phone' },


### PR DESCRIPTION
### Description
This pull request updates the 26-4555 schema to use the `centralMailVaFile` definition instead of the `vaFileNumber` definition. 
**EDIT: Removed these changes** There are also changes in here to 40-10007 schema that appeared when I rain the build script, so I assume these were missed by a previous PR.

### Related issues
department-of-veterans-affairs/va.gov-team-forms#149

<!--
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
-->