### PR TITLE
Vfep 603 repush

### DIFF
--- a/dist/22-1995-schema.json
+++ b/dist/22-1995-schema.json
@@ -395,7 +395,8 @@
     "benefit": {
       "type": "string",
       "enum": [
-        "chapter33",
+        "chapter33Post911",
+        "chapter33FryScholarship",
         "chapter30",
         "chapter1606",
         "transferOfEntitlement",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.26.9",
+  "version": "20.26.10",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/22-1995/schema.js
+++ b/src/schemas/22-1995/schema.js
@@ -57,7 +57,7 @@ const schema = {
     },
     benefit: {
       type: 'string',
-      enum: ['chapter33', 'chapter30', 'chapter1606', 'transferOfEntitlement', 'chapter32'],
+      enum: ['chapter33Post911', 'chapter33FryScholarship', 'chapter30', 'chapter1606', 'transferOfEntitlement', 'chapter32'],
     },
     educationType: {
       $ref: '#/definitions/educationType',

--- a/test/schemas/22-1995/schema.spec.js
+++ b/test/schemas/22-1995/schema.spec.js
@@ -39,7 +39,7 @@ describe('change of program json schema', () => {
   });
 
   schemaTestHelper.testValidAndInvalid('benefit', {
-    valid: ['chapter33'],
+    valid: ['chapter33FryScholarship'],
     invalid: ['foo']
   });
 


### PR DESCRIPTION
**Note this code was previously reverted until changes to vets-api were approved. Changes have been approved, push code once more.

# New schema
Schema changes made to schema 22-1995. Minor changes made, in the benefits definition, the value of 'chapter33' was replace with 'chapter33Post911' and 'chapter33FryScholarship'. Changes made so that the backend can differentiate between the chapter 33 benefits that is selected in the form 22-1995 when submitted.
 

## Pull Requests to update the schema in related repositories
Jira ticket for the JSON schema update https://vajira.max.gov/browse/VFEP-603

Jira ticket for the changes made within form 22-1995 in the vets-website repo
https://vajira.max.gov/browse/VFEP-597

PR for vets-website repo for the frontend changes need for the JSON schema update
https://github.com/department-of-veterans-affairs/vets-website/pull/24285

PR for vets-api changes
https://github.com/department-of-veterans-affairs/vets-api/pull/12772