### PR TITLE
58745 Switch to optional fields for va-medical-records page

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -496,9 +496,6 @@
     },
     "vaTreatmentCenterAddress": {
       "type": "object",
-      "required": [
-        "country"
-      ],
       "properties": {
         "country": {
           "$ref": "#/definitions/country"
@@ -987,14 +984,10 @@
     },
     "vaTreatmentFacilities": {
       "type": "array",
-      "minItems": 1,
+      "minItems": 0,
       "maxItems": 100,
       "items": {
         "type": "object",
-        "required": [
-          "treatmentCenterName",
-          "treatedDisabilityNames"
-        ],
         "properties": {
           "treatmentCenterName": {
             "type": "string",
@@ -1009,7 +1002,7 @@
           },
           "treatedDisabilityNames": {
             "type": "array",
-            "minItems": 1,
+            "minItems": 0,
             "maxItems": 100,
             "items": {
               "type": "string"

--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -500,13 +500,13 @@
         "country": {
           "$ref": "#/definitions/country"
         },
+        "state": {
+          "$ref": "#/definitions/state"
+        },
         "city": {
           "type": "string",
           "maxLength": 30,
-          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
-        },
-        "state": {
-          "$ref": "#/definitions/state"
+          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)*$"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.27.1",
+  "version": "20.27.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -69,9 +69,17 @@ const baseAddressDef = {
 
 const vaTreatmentCenterAddressDef = (addressSchema => {
   const { type, properties } = addressSchema;
+
   return {
     type,
-    properties: _.pick(['country', 'city', 'state'], properties),
+    properties: {
+      ..._.pick(['country', 'state'], properties),
+      city: {
+        type: 'string',
+        maxLength: 30,
+        pattern: "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)*$",
+      },
+    },
   };
 })(baseAddressDef);
 

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -71,7 +71,6 @@ const vaTreatmentCenterAddressDef = (addressSchema => {
   const { type, properties } = addressSchema;
   return {
     type,
-    required: ['country'],
     properties: _.pick(['country', 'city', 'state'], properties),
   };
 })(baseAddressDef);
@@ -455,11 +454,10 @@ const schema = {
     },
     vaTreatmentFacilities: {
       type: 'array',
-      minItems: 1,
+      minItems: 0,
       maxItems: 100,
       items: {
         type: 'object',
-        required: ['treatmentCenterName', 'treatedDisabilityNames'],
         properties: {
           treatmentCenterName: {
             type: 'string',
@@ -474,7 +472,7 @@ const schema = {
           },
           treatedDisabilityNames: {
             type: 'array',
-            minItems: 1,
+            minItems: 0,
             maxItems: 100,
             items: {
               type: 'string',

--- a/test/schemas/21-526EZ/schema.spec.js
+++ b/test/schemas/21-526EZ/schema.spec.js
@@ -302,14 +302,8 @@ const data = {
     ],
   },
   vaTreatmentCenterAddress: {
-    valid: [{ country: 'USA' }, { country: 'Spain', city: 'abc' }, { country: 'Spain', city: 'xyz', state: 'AL' }],
-    invalid: [
-      {},
-      { country: 'XYZ' },
-      { country: 'Spain', state: 'AB' },
-      { state: 'AL' },
-      { country: 'USA', city: 1234 },
-    ],
+    valid: [{}, { country: 'USA' }, { country: 'Spain', city: 'abc' }, { country: 'Spain', city: 'xyz', state: 'AL' }],
+    invalid: [{ country: 'XYZ' }, { country: 'Spain', state: 'AB' }, { country: 'USA', city: 1234 }],
   },
   homelessOrAtRisk: {
     valid: ['no', 'homeless', 'atRisk'],
@@ -335,8 +329,22 @@ const data = {
           vaTreatmentCenterAddress: { country: 'USA' },
         },
       ],
+      [][{}],
     ],
-    invalid: [[], [{}], [{ treatmentCenterName: 1234 }], [{ treatmentCenterName: 'foo', treatedDisabilityNames: [] }]],
+    invalid: [
+      {
+        treatmentCenterName: makeString(100, 'abc123'),
+        treatedDisabilityNames: ['xyz'],
+        treatmentDateRange: fixtures.dateRange,
+        vaTreatmentCenterAddress: { country: 'nowhere' },
+      },
+      {
+        treatmentCenterName: makeString(100, 'abc123'),
+        treatedDisabilityNames: ['xyz'],
+        treatmentDateRange: fixtures.dateRange,
+        vaTreatmentCenterAddress: { state: 'nope' },
+      },
+    ],
   },
   bankAccountType: {
     valid: ['Checking', 'Savings'],


### PR DESCRIPTION
# Modify schema for 526 EZ vaTreatmentFacilities 

The following fields should now be optional on the va-medical-records page in 526
- country
- treatmentCenterName
- treatedDisabilityNames

<!--
Please describe the new schema that is being added and include links to any relevant
issues to help future developers understand the schema and related code.

Please ensure you have incremented the version in `package.json`.
-->
Related issues: 
[department-of-veterans-affairs/va.gov-team#60578](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60578)
[department-of-veterans-affairs/va.gov-team#58745](https://github.com/department-of-veterans-affairs/va.gov-team/issues/58745)


## Pull Requests to update the schema in related repositories
<!--
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
-->
We're hoping to merge this pr and the following 2 pr's all around the same time.
https://github.com/department-of-veterans-affairs/vets-website/pull/24945
https://github.com/department-of-veterans-affairs/vets-api/pull/12996