### PR TITLE
MBMS-40990 edited 40-10007 schema to better validate phone number input

### DIFF
--- a/dist/40-10007-schema.json
+++ b/dist/40-10007-schema.json
@@ -286,8 +286,8 @@
     "phone": {
       "type": "string",
       "minLength": 10,
-      "maxLength": 15,
-      "pattern": "^[0-9()-]{10,15}$"
+      "maxLength": 20,
+      "pattern": "^[0-9]{10,15}$"
     },
     "ssn": {
       "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.26.11",
+  "version": "20.26.12",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/40-10007/schema.js
+++ b/src/schemas/40-10007/schema.js
@@ -140,8 +140,8 @@ definitions.fullName.properties.middle.maxLength = 15;
 definitions.fullName.properties.suffix.maxLength = 3;
 
 definitions.phone.minLength = 10;
-definitions.phone.maxLength = 15;
-definitions.phone.pattern = '^[0-9()-]{10,15}$';
+definitions.phone.maxLength = 20;
+definitions.phone.pattern = '^[0-9]{10,15}$';
 
 definitions.ssn.pattern = '^\\d{3}-\\d{2}-\\d{4}$';
 

--- a/test/schemas/40-10007/schema.spec.js
+++ b/test/schemas/40-10007/schema.spec.js
@@ -19,256 +19,243 @@ describe('preneeds schema', () => {
   sharedTests.runTest('centralMailVaFile', ['application.veteran.vaClaimNumber']);
 
   schemaTestHelper.testValidAndInvalid('application.applicant.applicantEmail', {
-    valid: [
-      'foo@foo.com',
-      'foo@foo.net',
-      'foo+13@foo.com',
-      'foo@bar.co.uk',
-      'foo.foo@foo.com'
-    ],
-    invalid: [
-      'bad'
-    ]
+    valid: ['foo@foo.com', 'foo@foo.net', 'foo+13@foo.com', 'foo@bar.co.uk', 'foo.foo@foo.com'],
+    invalid: ['bad'],
   });
 
   schemaTestHelper.testValidAndInvalid('application.applicant.applicantPhoneNumber', {
-    valid: [
-      '415555-2671'
-    ],
-    invalid: [
-      'bad'
-    ]
+    valid: ['4155552671'],
+    invalid: ['bad'],
   });
 
   schemaTestHelper.testValidAndInvalid('application.claimant.ssn', {
-    valid: [
-      '000-12-3456'
-    ],
-    invalid: [
-      'bad'
-    ]
+    valid: ['000-12-3456'],
+    invalid: ['bad'],
   });
 
-  ['application.applicant.mailingAddress', 'application.claimant.address', 'application.veteran.address'].forEach((property) => {
-    schemaTestHelper.testValidAndInvalid(property, {
-      valid: [
-        {
-          street: '123 main',
-          city: 'Shelbyville',
-          postalCode: '11111-9876',
-          state: 'AK',
-          country: 'USA'
-        }
-      ],
-      invalid: [
-        {
-          // city too long
-          street: '123 main',
-          city: 'a really long city name',
-          postalCode: '11111',
-          state: 'AK',
-          country: 'USA'
-        },
-        {
-          // zip too long
-          street: '123 main',
-          city: 'Shelbyville',
-          postalCode: '11111-87658989',
-          state: 'AK',
-          country: 'USA'
-        },
-        {
-          // missing state
-          street: '123 main',
-          city: 'Shelbyville',
-          postalCode: '11111',
-          country: 'USA'
-        },
-        {
-          // missing country
-          street: '123 main',
-          city: 'Shelbyville',
-          postalCode: '11111',
-          state: 'AK',
-        },
-        {
-          // missing street
-          street2: '123 main',
-          city: 'Shelbyville',
-          postalCode: '11111',
-          state: 'AK',
-          country: 'USA'
-        },
-        {
-          // street too long
-          street: '123 main out in the country',
-          city: 'Shelbyville',
-          postalCode: '11111',
-          state: 'AK',
-          country: 'USA'
-        },
-        {
-          // street2 too long
-          street: '123 main',
-          street2: 'apt 123456789098765432123',
-          city: 'Shelbyville',
-          postalCode: '11111',
-          state: 'AK',
-          country: 'USA'
-        },
-        {
-          // state too long
-          street: '123 main',
-          city: 'Shelbyville',
-          postalCode: '11111',
-          state: 'Alaska',
-          country: 'USA'
-        }
-      ]
-    });
-  });
-  
+  ['application.applicant.mailingAddress', 'application.claimant.address', 'application.veteran.address'].forEach(
+    property => {
+      schemaTestHelper.testValidAndInvalid(property, {
+        valid: [
+          {
+            street: '123 main',
+            city: 'Shelbyville',
+            postalCode: '11111-9876',
+            state: 'AK',
+            country: 'USA',
+          },
+        ],
+        invalid: [
+          {
+            // city too long
+            street: '123 main',
+            city: 'a really long city name',
+            postalCode: '11111',
+            state: 'AK',
+            country: 'USA',
+          },
+          {
+            // zip too long
+            street: '123 main',
+            city: 'Shelbyville',
+            postalCode: '11111-87658989',
+            state: 'AK',
+            country: 'USA',
+          },
+          {
+            // missing state
+            street: '123 main',
+            city: 'Shelbyville',
+            postalCode: '11111',
+            country: 'USA',
+          },
+          {
+            // missing country
+            street: '123 main',
+            city: 'Shelbyville',
+            postalCode: '11111',
+            state: 'AK',
+          },
+          {
+            // missing street
+            street2: '123 main',
+            city: 'Shelbyville',
+            postalCode: '11111',
+            state: 'AK',
+            country: 'USA',
+          },
+          {
+            // street too long
+            street: '123 main out in the country',
+            city: 'Shelbyville',
+            postalCode: '11111',
+            state: 'AK',
+            country: 'USA',
+          },
+          {
+            // street2 too long
+            street: '123 main',
+            street2: 'apt 123456789098765432123',
+            city: 'Shelbyville',
+            postalCode: '11111',
+            state: 'AK',
+            country: 'USA',
+          },
+          {
+            // state too long
+            street: '123 main',
+            city: 'Shelbyville',
+            postalCode: '11111',
+            state: 'Alaska',
+            country: 'USA',
+          },
+        ],
+      });
+    },
+  );
+
   [
-   'application.applicant.name', 'application.claimant.name',
-   'application.veteran.currentName', 'application.veteran.serviceName',
-  ].forEach((name) => {
+    'application.applicant.name',
+    'application.claimant.name',
+    'application.veteran.currentName',
+    'application.veteran.serviceName',
+  ].forEach(name => {
     let valid = [
       {
         first: 'jon',
-        middle: "bob",
+        middle: 'bob',
         last: 'doe',
-        suffix: 'Jr.'
-      }
-    ]
+        suffix: 'Jr.',
+      },
+    ];
     let invalid = [
       {
         // first name too long
         first: 'jonathan seagull',
         last: 'doe',
         middle: 'bob',
-        suffix: 'Jr.'
+        suffix: 'Jr.',
       },
       {
         // last name too long
         first: 'jon',
-        middle: "bob",
+        middle: 'bob',
         last: 'doexxxxxxxxxxxxxxxxxxxxxxxx',
-        suffix: 'Jr.'
+        suffix: 'Jr.',
       },
       {
         // middle name too long
         first: 'jon',
-        middle: "bobxxxxxxxxxxxxxxxxxx",
+        middle: 'bobxxxxxxxxxxxxxxxxxx',
         last: 'doe',
-        suffix: 'Jr.'
+        suffix: 'Jr.',
       },
       {
         // suffix not in enum
         first: 'jon',
-        middle: "bob",
+        middle: 'bob',
         last: 'doe',
-        suffix: 'VI'
-      }
-    ]
+        suffix: 'VI',
+      },
+    ];
 
     if (['application.veteran.currentName', 'application.claimant.name'].includes(name)) {
-      valid[0].maiden = 'smith'
-      invalid = invalid.concat(
-        [
-          {
-            // maiden name too long
-            first: 'jon',
-            middle: "bob",
-            last: 'doe',
-            suffix: 'Jr.',
-            maiden: 'smith-jones-doe-wilson'
-          } 
-        ]
-      )
+      valid[0].maiden = 'smith';
+      invalid = invalid.concat([
+        {
+          // maiden name too long
+          first: 'jon',
+          middle: 'bob',
+          last: 'doe',
+          suffix: 'Jr.',
+          maiden: 'smith-jones-doe-wilson',
+        },
+      ]);
     }
 
     schemaTestHelper.testValidAndInvalid(name, {
       valid,
-      invalid
+      invalid,
     });
   });
 
-  ['application.veteran.dateOfBirth', 'application.veteran.dateOfDeath'].forEach((testDate) => {
+  ['application.veteran.dateOfBirth', 'application.veteran.dateOfDeath'].forEach(testDate => {
     schemaTestHelper.testValidAndInvalid(testDate, {
-      valid: [
-        '2000-12-12'
-      ],
-      invalid: [
-        '01-01-2000',
-        '01/01/2000',
-        '2000/01/01'
-      ]
+      valid: ['2000-12-12'],
+      invalid: ['01-01-2000', '01/01/2000', '2000/01/01'],
     });
   });
-  
+
   schemaTestHelper.testValidAndInvalid('application.veteran.serviceRecords', {
     valid: [
-      [{
-        serviceBranch: 'AF',
-        dischargeType: '1',
-        highestRank: 'General',
-        nationalGuardState: 'AK'
-      }]
+      [
+        {
+          serviceBranch: 'AF',
+          dischargeType: '1',
+          highestRank: 'General',
+          nationalGuardState: 'AK',
+        },
+      ],
     ],
     invalid: [
-      [{
-        // rank too long
-        serviceBranch: 'AF',
-        dischargeType: '1',
-        highestRank: 'General AAAAAAAAAAAAAAAAAAAAAA',
-        nationalGuardState: 'AK'
-      }],
-      [{
-        // nationalGuardState too long
-        serviceBranch: 'AF',
-        dischargeType: '1',
-        highestRank: 'General',
-        nationalGuardState: 'Alaska'
-      }]
-    ]
+      [
+        {
+          // rank too long
+          serviceBranch: 'AF',
+          dischargeType: '1',
+          highestRank: 'General AAAAAAAAAAAAAAAAAAAAAA',
+          nationalGuardState: 'AK',
+        },
+      ],
+      [
+        {
+          // nationalGuardState too long
+          serviceBranch: 'AF',
+          dischargeType: '1',
+          highestRank: 'General',
+          nationalGuardState: 'Alaska',
+        },
+      ],
+    ],
   });
 
   schemaTestHelper.testValidAndInvalid('application.veteran.placeOfBirth', {
     valid: ['anywhere, kentuck'],
-    invalid: ['Taumatawhakatangi­hangakoauauotamatea­turipukakapikimaunga­horonukupokaiwhen­uakitanatahu, New Zealand']
+    invalid: ['Taumatawhakatangi­hangakoauauotamatea­turipukakapikimaunga­horonukupokaiwhen­uakitanatahu, New Zealand'],
   });
 
   schemaTestHelper.testValidAndInvalid('application.veteran.race', {
     valid: [
       {
         isAmericanIndianOrAlaskanNative: true,
-        isAsian: true
+        isAsian: true,
       },
       {
-        isAmericanIndianOrAlaskanNative: true
-      }
+        isAmericanIndianOrAlaskanNative: true,
+      },
     ],
-    invalid: [
-      'race'
-    ]
+    invalid: ['race'],
   });
 
   schemaTestHelper.testValidAndInvalid('application.preneedAttachments', {
     valid: [
-      [{
-        attachmentId: '1',
-        confirmationCode: 'jkl34jkl34',
-        name: 'my_attachment_name.pdf'
-      }]
+      [
+        {
+          attachmentId: '1',
+          confirmationCode: 'jkl34jkl34',
+          name: 'my_attachment_name.pdf',
+        },
+      ],
     ],
     invalid: [
       // attachment name too long
-      [{
-        attachmentId: '1',
-        confirmationCode: 'jkl34jkl34',
-        name: 'my_attachment_name_that_is_really_really_long_DD214.pdf'
-      }]
-    ]
+      [
+        {
+          attachmentId: '1',
+          confirmationCode: 'jkl34jkl34',
+          name: 'my_attachment_name_that_is_really_really_long_DD214.pdf',
+        },
+      ],
+    ],
   });
-
 });


### PR DESCRIPTION
# New schema

<!--
Please describe the new schema that is being added and include links to any relevant
issues to help future developers understand the schema and related code.



Please ensure you have incremented the version in `package.json`.
-->
The new schema relates to the phone input field on form 40-10007. It edits the validation procedure so the phone number input has 10-15 numbers. The Minimum length of input is 10-20, this is to accomodate characters the user may input along with the phone number.

vets-json-schema version: **20.26.12**


## Pull Requests to update the schema in related repositories
<!--
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
-->
Will include these once this schema changes gets merges into master:

- department-of-veterans-affairs/vets-website#0000
- department-of-veterans-affairs/vets-api#0000

### Testing Use Cases:
- In the `form-systems` phoneWidget it strips any user input of the any characters that arent the numbers 0-9.
- Should Pass:
     - A String with 10-15 numbers
     