### PR TITLE
MBMS-40990 Updated phone number schema to improve validation

### DIFF
--- a/dist/40-10007-schema.json
+++ b/dist/40-10007-schema.json
@@ -287,7 +287,7 @@
       "type": "string",
       "minLength": 10,
       "maxLength": 20,
-      "pattern": "^[0-9]{10,15}$"
+      "pattern": "^(?:\\D*\\d){10,15}\\D*$"
     },
     "ssn": {
       "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.26.12",
+  "version": "20.26.13",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/40-10007/schema.js
+++ b/src/schemas/40-10007/schema.js
@@ -141,7 +141,7 @@ definitions.fullName.properties.suffix.maxLength = 3;
 
 definitions.phone.minLength = 10;
 definitions.phone.maxLength = 20;
-definitions.phone.pattern = '^[0-9]{10,15}$';
+definitions.phone.pattern = '^(?:\\D*\\d){10,15}\\D*$';
 
 definitions.ssn.pattern = '^\\d{3}-\\d{2}-\\d{4}$';
 


### PR DESCRIPTION
# New schema

<!--
Please describe the new schema that is being added and include links to any relevant
issues to help future developers understand the schema and related code.



Please ensure you have incremented the version in `package.json`.
-->
The new schema relates to the phone input field on form 40-10007. It edits the validation procedure so the phone number input has 10-15 numbers. The length of input is 10-20, this is to accomodate characters the user may input along with the phone number.

vets-json-schema version: **20.26.13**


## Pull Requests to update the schema in related repositories
<!--
After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here.
-->
Will include these once this schema changes gets merges into master:

- [department-of-veterans-affairs/vets-website](https://github.com/department-of-veterans-affairs/vets-website/pull/24759)
- [department-of-veterans-affairs/vets-api]()

### Testing Use Cases:
- Should Pass:
     - A String with 10-15 numbers regardless of characters and symbols
     