### PR TITLE
VFEP-659 clean up JSON schema after merging 1990 form.

### DIFF
--- a/dist/22-1990-schema.json
+++ b/dist/22-1990-schema.json
@@ -320,20 +320,6 @@
         "tuitionTopUp"
       ]
     },
-    "educationProgram": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "address": {
-          "$ref": "#/definitions/address"
-        },
-        "educationType": {
-          "$ref": "#/definitions/educationType"
-        }
-      }
-    },
     "preferredContactMethod": {
       "type": "string",
       "enum": [
@@ -355,107 +341,6 @@
         "F",
         "M"
       ]
-    },
-    "postHighSchoolTrainings": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "city": {
-            "type": "string"
-          },
-          "state": {
-            "type": "string",
-            "enum": [
-              "AL",
-              "AK",
-              "AS",
-              "AZ",
-              "AR",
-              "AA",
-              "AE",
-              "AP",
-              "CA",
-              "CO",
-              "CT",
-              "DE",
-              "DC",
-              "FM",
-              "FL",
-              "GA",
-              "GU",
-              "HI",
-              "ID",
-              "IL",
-              "IN",
-              "IA",
-              "KS",
-              "KY",
-              "LA",
-              "ME",
-              "MH",
-              "MD",
-              "MA",
-              "MI",
-              "MN",
-              "MS",
-              "MO",
-              "MT",
-              "NE",
-              "NV",
-              "NH",
-              "NJ",
-              "NM",
-              "NY",
-              "NC",
-              "ND",
-              "MP",
-              "OH",
-              "OK",
-              "OR",
-              "PW",
-              "PA",
-              "PR",
-              "RI",
-              "SC",
-              "SD",
-              "TN",
-              "TX",
-              "UT",
-              "VT",
-              "VI",
-              "VA",
-              "WA",
-              "WV",
-              "WI",
-              "WY"
-            ]
-          },
-          "dateRange": {
-            "$ref": "#/definitions/dateRange"
-          },
-          "hours": {
-            "type": "number"
-          },
-          "hoursType": {
-            "type": "string",
-            "enum": [
-              "semester",
-              "quarter",
-              "clock"
-            ]
-          },
-          "degreeReceived": {
-            "type": "string"
-          },
-          "major": {
-            "type": "string"
-          }
-        }
-      }
     },
     "nonMilitaryJobs": {
       "type": "array",
@@ -530,9 +415,6 @@
     "chapter1606": {
       "type": "boolean"
     },
-    "chapter32": {
-      "type": "boolean"
-    },
     "benefitsRelinquished": {
       "type": "string",
       "enum": [
@@ -570,43 +452,11 @@
     "preferredContactMethod": {
       "$ref": "#/definitions/preferredContactMethod"
     },
-    "secondaryContact": {
-      "type": "object",
-      "properties": {
-        "fullName": {
-          "type": "string"
-        },
-        "sameAddress": {
-          "type": "boolean"
-        },
-        "address": {
-          "$ref": "#/definitions/address"
-        },
-        "phone": {
-          "$ref": "#/definitions/usaPhone"
-        }
-      }
-    },
     "bankAccount": {
       "$ref": "#/definitions/bankAccount"
     },
-    "educationStartDate": {
-      "$ref": "#/definitions/date"
-    },
-    "educationObjective": {
-      "type": "string"
-    },
     "educationType": {
       "$ref": "#/definitions/educationType"
-    },
-    "educationProgram": {
-      "$ref": "#/definitions/educationProgram"
-    },
-    "highSchoolOrGedCompletionDate": {
-      "$ref": "#/definitions/date"
-    },
-    "faaFlightCertificatesInformation": {
-      "type": "string"
     },
     "serviceAcademyGraduationYear": {
       "$ref": "#/definitions/year"
@@ -636,9 +486,6 @@
     "seniorRotcScholarshipProgram": {
       "type": "boolean"
     },
-    "civilianBenefitsAssistance": {
-      "type": "boolean"
-    },
     "additionalContributions": {
       "type": "boolean"
     },
@@ -653,9 +500,6 @@
     },
     "serviceBefore1977": {
       "$ref": "#/definitions/serviceBefore1977"
-    },
-    "postHighSchoolTrainings": {
-      "$ref": "#/definitions/postHighSchoolTrainings"
     },
     "nonMilitaryJobs": {
       "$ref": "#/definitions/nonMilitaryJobs"

--- a/src/schemas/22-1990/schema.js
+++ b/src/schemas/22-1990/schema.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import definitions from '../../common/definitions';
 import schemaHelpers from '../../common/schema-helpers';
 
-const benefits = ['chapter33', 'chapter30', 'chapter1606', 'chapter32'];
+const benefits = ['chapter33', 'chapter30', 'chapter1606',];
 
 const schema = {
   $schema: 'http://json-schema.org/draft-04/schema#',
@@ -25,11 +25,9 @@ const schema = {
       'date',
       'dateRange',
       'educationType',
-      'educationProgram',
       'preferredContactMethod',
       'privacyAgreementAccepted',
       'gender',
-      'postHighSchoolTrainings',
       'nonMilitaryJobs',
     ]),
   ),
@@ -44,12 +42,9 @@ const schema = {
     chapter1606: {
       type: 'boolean',
     },
-    chapter32: {
-      type: 'boolean',
-    },
     benefitsRelinquished: {
       type: 'string',
-      enum: ['unknown', ..._.without(benefits, 'chapter33', 'chapter32'), 'chapter1607'],
+      enum: ['unknown', ..._.without(benefits, 'chapter33'), 'chapter1607'],
     },
     veteranFullName: {
       $ref: '#/definitions/fullName',
@@ -79,43 +74,11 @@ const schema = {
     preferredContactMethod: {
       $ref: '#/definitions/preferredContactMethod',
     },
-    secondaryContact: {
-      type: 'object',
-      properties: {
-        fullName: {
-          type: 'string',
-        },
-        sameAddress: {
-          type: 'boolean',
-        },
-        address: {
-          $ref: '#/definitions/address',
-        },
-        phone: {
-          $ref: '#/definitions/usaPhone',
-        },
-      },
-    },
     bankAccount: {
       $ref: '#/definitions/bankAccount',
     },
-    educationStartDate: {
-      $ref: '#/definitions/date',
-    },
-    educationObjective: {
-      type: 'string',
-    },
     educationType: {
       $ref: '#/definitions/educationType',
-    },
-    educationProgram: {
-      $ref: '#/definitions/educationProgram',
-    },
-    highSchoolOrGedCompletionDate: {
-      $ref: '#/definitions/date',
-    },
-    faaFlightCertificatesInformation: {
-      type: 'string',
     },
     serviceAcademyGraduationYear: {
       $ref: '#/definitions/year',
@@ -145,9 +108,6 @@ const schema = {
     seniorRotcScholarshipProgram: {
       type: 'boolean',
     },
-    civilianBenefitsAssistance: {
-      type: 'boolean',
-    },
     additionalContributions: {
       type: 'boolean',
     },
@@ -162,9 +122,6 @@ const schema = {
     },
     serviceBefore1977: {
       $ref: '#/definitions/serviceBefore1977',
-    },
-    postHighSchoolTrainings: {
-      $ref: '#/definitions/postHighSchoolTrainings',
     },
     nonMilitaryJobs: {
       $ref: '#/definitions/nonMilitaryJobs',

--- a/test/schemas/22-1990/schema.spec.js
+++ b/test/schemas/22-1990/schema.spec.js
@@ -29,19 +29,13 @@ describe('education benefits json schema', () => {
     'bankAccount',
     'date',
     'email',
-    'postHighSchoolTrainings',
     'educationType',
-    'educationProgram',
     'nonMilitaryJobs',
     'toursOfDuty',
     'currentlyActiveDuty'
   ].forEach((test) => {
     sharedTests.runTest(test);
   });
-
-  sharedTests.runTest('address', ['veteranAddress', 'secondaryContact.address']);
-
-  sharedTests.runTest('usaPhone', ['homePhone', 'mobilePhone', 'secondaryContact.phone']);
 
   context('serviceAcademyGraduationYear validations', () => {
     schemaTestHelper.testValidAndInvalid('serviceAcademyGraduationYear', {


### PR DESCRIPTION
# New schema
Remove un-used fields after updating 1990 form in vets-website the previous Sprint.

## Jira

https://vajira.max.gov/browse/VFEP-659

## List of Items Removed

VFEP-10 - 22-1990 Revise Contact Info Section, Remove Secondary Contact – Front End
secondaryContact
 
 
secondaryContact: {
      type: 'object',
      properties: {
        fullName: {
          type: 'string',
        },
        sameAddress: {
          type: 'boolean',
        },
        address: {
          $ref: '#/definitions/address',
        },
        phone: {
          $ref: '#/definitions/usaPhone',
        },
      },
    }
 
VFEP-12 – 22-1990 Remove Chapter 32 as a benefit choice – Front End
chapter32
 
 
 
VFEP-14 - 22-1990 Remove Education History – Front End
 
highSchoolOrGedCompletionDate ( done )
postHighSchoolTrainings ( done )
faaFlightCertificatesInformation
 
 
VFEP-15 - 22-1990 Remove Employment History – Front End
 
 
 
 
VFEP-16 - 22-1990 Remove School Selection – Front End
 
educationProgram
educationObjective
educationStartDate
currentlyActiveDuty
 
 
 
VFEP-17 - 22-1990 Remove GETA question – Front End
 
civilianBenefitsAssistance


# Side Note

These are the vets-JSON schema changes for this previous pull request.

https://github.com/department-of-veterans-affairs/vets-website/pull/24805