### PR TITLE
Update emass.json

### DIFF
--- a/.github/emass.json
+++ b/.github/emass.json
@@ -1,6 +1,6 @@
 {
-  "systemID": 0,
-  "systemName": "<system_name>",
-  "systemOwnerName": "<full_name>",
-  "systemOwnerEmail": "<email>"
+  "systemID": 2103,
+  "systemName": "VA.gov",
+  "systemOwnerName": "Christopher Johnston",
+  "systemOwnerEmail": "Christopher.Johnston2@va.gov"
 }


### PR DESCRIPTION
This updates the emass.json file with the necessary system information required for code scanning. GH Actions are currently failing/blocked without this information being defined.

Automated code scanning is required of all the repos under VA Github Enterprise Cloud. [Originally enabled here ](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/774)

Used the VEAR system to verify the information: https://vaww.vear.ea.oit.va.gov/#system_and_application_domain_defs_system_24234.htm