### PR TITLE
VFEP-60 Create benefitsUpdate and remove chapter32 in non-production env

### DIFF
--- a/dist/22-1995-schema.json
+++ b/dist/22-1995-schema.json
@@ -423,6 +423,16 @@
         "chapter32"
       ]
     },
+    "benefitUpdate": {
+      "type": "string",
+      "enum": [
+        "chapter33Post911",
+        "chapter33FryScholarship",
+        "chapter30",
+        "chapter1606",
+        "transferOfEntitlement"
+      ]
+    },
     "educationType": {
       "$ref": "#/definitions/educationType"
     },

--- a/src/schemas/22-1995/schema.js
+++ b/src/schemas/22-1995/schema.js
@@ -67,6 +67,10 @@ const schema = {
         'chapter32',
       ],
     },
+    benefitUpdate: {
+      type: 'string',
+      enum: ['chapter33Post911', 'chapter33FryScholarship', 'chapter30', 'chapter1606', 'transferOfEntitlement'],
+    },
     educationType: {
       $ref: '#/definitions/educationType',
     },


### PR DESCRIPTION
# New schema
- Create benefitsUpdate and remove chapter32 in non-production env

## Jira Notes

As a...
VFEP Business User
I want...
the Post-Vietnam Era Veterans' Education Assistance Program (VEAP, Chapter 32) option removed from the Education benefit section
So that...
it can no longer be selected.
Acceptance Criteria:
Post-Vietnam Era Veterans’ Educational Assistance Program (VEAP, Chapter 32) is no longer listed is an option for selection in the Education benefit section
Assumptions & Preconditions:

## Jira

[VFEP-60](https://vajira.max.gov/browse/VFEP-60)

## Image

<img width="705" alt="Screenshot 2023-09-12 at 8 26 55 AM" src="https://github.com/department-of-veterans-affairs/vets-json-schema/assets/95312667/d6bf182a-0bff-40a8-a163-0c6ff0f1634f">
