### PR TITLE
10-10EZR: Refactored a Few Variable Names

### DIFF
--- a/dist/10-10EZR-schema.json
+++ b/dist/10-10EZR-schema.json
@@ -970,7 +970,7 @@
         true
       ]
     },
-    "associations": {
+    "veteranContacts": {
       "type": "array",
       "items": {
         "type": "object",

--- a/dist/definitions.json
+++ b/dist/definitions.json
@@ -1297,7 +1297,7 @@
       "step"
     ]
   },
-  "associations": {
+  "hcaVeteranContacts": {
     "type": "array",
     "items": {
       "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.32.4",
+  "version": "20.33.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/common/definitions.js
+++ b/src/common/definitions.js
@@ -366,7 +366,7 @@ const hcaDependents = {
   },
 };
 
-const associationRelationships = {
+const hcaVeteranContactRelationships = {
   type: 'string',
   enum: [
     'BROTHER',
@@ -387,27 +387,27 @@ const associationRelationships = {
   ],
 };
 
-const associationTypes = {
+const hcaVeteranContactTypes = {
   type: 'string',
   enum: ['Primary Next of Kin', 'Other Next of Kin', 'Emergency Contact', 'Other emergency contact'],
 };
 
-const association = {
+const hcaVeteranContact = {
   type: 'object',
   properties: {
     fullName: hcaFullName,
     primaryPhone: hcaPhone,
     alternatePhone: hcaPhone,
     address: hcaAddress,
-    relationship: associationRelationships,
-    contactType: associationTypes,
+    relationship: hcaVeteranContactRelationships,
+    contactType: hcaVeteranContactTypes,
   },
   required: ['fullName', 'primaryPhone', 'address', 'relationship', 'contactType'],
 };
 
-const associations = {
+const hcaVeteranContacts = {
   type: 'array',
-  items: association,
+  items: hcaVeteranContact,
 };
 
 // Historically a veteran's service number has been between 5 and 8 digits,
@@ -942,7 +942,7 @@ export default {
   netWorthAccount,
   relationshipAndChildName,
   relationshipAndChildType,
-  associations,
+  hcaVeteranContacts,
   marriages,
   files,
   requiredServiceHistory,

--- a/src/schemas/10-10EZR/schema.js
+++ b/src/schemas/10-10EZR/schema.js
@@ -75,7 +75,7 @@ const schema = {
       type: 'boolean',
       enum: [true],
     },
-    associations: definitions.associations,
+    veteranContacts: definitions.hcaVeteranContacts,
   },
   required: [
     'privacyAgreementAccepted',


### PR DESCRIPTION
## What Does This Code Do?

- Changes `associations` to `veteranContacts` for both 10-10EZ and 10-10EZR implementation. `associations` can include spouse, dependents, NoK, Emergency Contact, etc., so these changes were made to help us be more specific with which association we're referring to.

_Please ensure you have incremented the version in_ `package.json`.

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
