### PR TITLE
add signature and datestamp to required fields

### DIFF
--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -780,8 +780,11 @@
     "previousNames": {
       "type": "array",
       "items": {
-        "previousFullName": {
-          "$ref": "#/definitions/fullName"
+        "type": "object",
+        "properties": {
+          "previousFullName": {
+            "$ref": "#/definitions/fullName"
+          }
         }
       }
     },

--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -1083,6 +1083,8 @@
   },
   "required": [
     "veteranFullName",
-    "veteranAddress"
+    "veteranAddress",
+    "statementOfTruthCertified",
+    "statementOfTruthSignature"
   ]
 }

--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -780,7 +780,9 @@
     "previousNames": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/fullName"
+        "previousFullName": {
+          "$ref": "#/definitions/fullName"
+        }
       }
     },
     "placeOfSeparation": {

--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -902,9 +902,6 @@
         }
       }
     },
-    "marriageHistory": {
-      "$ref": "#/definitions/marriages"
-    },
     "spouseIsVeteran": {
       "type": "boolean"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "20.34.0",
+  "version": "20.34.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21P-527EZ/schema.js
+++ b/src/schemas/21P-527EZ/schema.js
@@ -125,7 +125,12 @@ const schema = {
     serveUnderOtherNames: { type: 'boolean' },
     previousNames: {
       type: 'array',
-      items: { previousFullName: schemaHelpers.getDefinition('fullName') },
+      items: {
+        type: 'object',
+        properties: {
+          previousFullName: schemaHelpers.getDefinition('fullName'),
+        },
+      },
     },
     placeOfSeparation: {
       type: 'string',

--- a/src/schemas/21P-527EZ/schema.js
+++ b/src/schemas/21P-527EZ/schema.js
@@ -317,7 +317,7 @@ const schema = {
       type: 'string',
     },
   },
-  required: ['veteranFullName', 'veteranAddress'],
+  required: ['veteranFullName', 'veteranAddress', 'statementOfTruthCertified', 'statementOfTruthSignature'],
 };
 
 [

--- a/src/schemas/21P-527EZ/schema.js
+++ b/src/schemas/21P-527EZ/schema.js
@@ -125,7 +125,7 @@ const schema = {
     serveUnderOtherNames: { type: 'boolean' },
     previousNames: {
       type: 'array',
-      items: schemaHelpers.getDefinition('fullName'),
+      items: { previousFullName: schemaHelpers.getDefinition('fullName') },
     },
     placeOfSeparation: {
       type: 'string',

--- a/src/schemas/21P-527EZ/schema.js
+++ b/src/schemas/21P-527EZ/schema.js
@@ -216,9 +216,6 @@ const schema = {
         },
       },
     },
-    marriageHistory: {
-      $ref: '#/definitions/marriages',
-    },
     spouseIsVeteran: {
       type: 'boolean',
     },

--- a/test/schemas/21P-527EZ/schema.spec.js
+++ b/test/schemas/21P-527EZ/schema.spec.js
@@ -88,7 +88,7 @@ describe('21-527 schema', () => {
   });
 
   schemaTestHelper.testValidAndInvalid('previousNames', {
-    valid: [[fixtures.fullName, fixtures.fullName]],
+    valid: [[fixtures.previousFullName, fixtures.previousFullName]],
     invalid: [[false]]
   });
 

--- a/test/schemas/21P-527EZ/schema.spec.js
+++ b/test/schemas/21P-527EZ/schema.spec.js
@@ -21,7 +21,9 @@ describe('21-527 schema', () => {
   });
 
   it('should have the right required fields', () => {
-    expect(schema.required).to.deep.equal(['veteranFullName', 'veteranAddress']);
+    expect(schema.required).to.deep.equal([
+      'veteranFullName', 'veteranAddress', 'statementOfTruthCertified', 'statementOfTruthSignature'
+    ]);
   });
 
   sharedTests.runTest('usaPhone', ['phone', 'dayPhone', 'nightPhone', 'mobilePhone']);

--- a/test/support/fixtures.js
+++ b/test/support/fixtures.js
@@ -24,5 +24,6 @@ export default {
     name: 'other',
     amount: 123
   },
-  fullName: fullName
+  fullName: fullName,
+  previousFullName: fullName
 };


### PR DESCRIPTION
# New schema
Added signature fields as required in the pension form (in lieu of the `privacyAgreementAccepted` flag). Also added a new `previousFullName` attribute to the schema.

# Related Tickets
- [Link to epic](https://app.zenhub.com/workspaces/benefits-pension-64e775aaa6b1ca1ed49b2ede/issues/gh/department-of-veterans-affairs/va.gov-team/71917)

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
