### PR TITLE
Add repo access instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ node v8.10.0
 - After changes to `vets-json-schema` have been merged into master:
   - update `vets-website` to point to the latest `vets-json-schema` version by running `yarn update:schema` and making a PR
   - update `vets-api` by running `bundle update vets_json_schema` and making a PR. _Caution: verify that you changes are only related to vets_json_schema version. If you see sidekiq changes, follow [these instructions](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/platform/engineering/sidekiq-enterprise-setup.md)_
+ 
+## Not a member of the repository and want to be added?
+- If you're on a VA.gov Platform team, contact your Program Manager.
+- If you're on a VFS team, you must complete [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/platform-orientation) to be added to this repository. This includes completing your Platform Orientation ticket(s) in GitHub.


### PR DESCRIPTION
# New schema
No new schema. Adding instructions to README on how to get access to the repo to [align with VA GitHub Handbook](https://github.com/department-of-veterans-affairs/va.gov-team/issues/75538).

## Pull Requests to update the schema in related repositories

N/A. Updates to README only.
