### PR TITLE
Changed hoursPerWeek and jobHoursWeek fields from number to string

### DIFF
--- a/dist/21P-527EZ-KITCHEN_SINK-cypress-example.json
+++ b/dist/21P-527EZ-KITCHEN_SINK-cypress-example.json
@@ -56,7 +56,7 @@
     "currentEmployers": [
       {
         "jobType": "Customer service",
-        "jobHoursWeek": 20,
+        "jobHoursWeek": "20",
         "jobTitle": "Manager"
       }
     ],
@@ -226,7 +226,7 @@
         "provider": "NYC Care Provider",
         "careType": "CARE_FACILITY",
         "ratePerHour": 100,
-        "hoursPerWeek": 20,
+        "hoursPerWeek": "20",
         "careDateRange": {
           "from": "2020-08-01",
           "to": "2023-05-25"
@@ -239,7 +239,7 @@
         "provider": "MA Care Provider",
         "careType": "IN_HOME_CARE_PROVIDER",
         "ratePerHour": 150,
-        "hoursPerWeek": 15,
+        "hoursPerWeek": "15",
         "careDateRange": {
           "from": "2021-08-01",
           "to": "2022-05-25"
@@ -253,7 +253,7 @@
         "provider": "LA Care Provider",
         "careType": "CARE_FACILITY",
         "ratePerHour": 200,
-        "hoursPerWeek": 10,
+        "hoursPerWeek": "10",
         "careDateRange": {
           "from": "2020-08-01"
         },

--- a/dist/21P-527EZ-KITCHEN_SINK-example.json
+++ b/dist/21P-527EZ-KITCHEN_SINK-example.json
@@ -55,7 +55,7 @@
   "currentEmployers": [
     {
       "jobType": "Customer service",
-      "jobHoursWeek": 20,
+      "jobHoursWeek": "20",
       "jobTitle": "Manager"
     }
   ],
@@ -217,7 +217,7 @@
       "provider": "NYC Care Provider",
       "careType": "CARE_FACILITY",
       "ratePerHour": 100,
-      "hoursPerWeek": 20,
+      "hoursPerWeek": "20",
       "careDateRange": {
         "from": "2020-08-01",
         "to": "2023-05-25"
@@ -230,7 +230,7 @@
       "provider": "MA Care Provider",
       "careType": "IN_HOME_CARE_PROVIDER",
       "ratePerHour": 150,
-      "hoursPerWeek": 15,
+      "hoursPerWeek": "15",
       "careDateRange": {
         "from": "2021-08-01",
         "to": "2022-05-25"
@@ -244,7 +244,7 @@
       "provider": "LA Care Provider",
       "careType": "CARE_FACILITY",
       "ratePerHour": 200,
-      "hoursPerWeek": 10,
+      "hoursPerWeek": "10",
       "careDateRange": {
         "from": "2020-08-01"
       },

--- a/dist/21P-527EZ-KITCHEN_SINK-schema.json
+++ b/dist/21P-527EZ-KITCHEN_SINK-schema.json
@@ -140,7 +140,7 @@
             "type": "number"
           },
           "hoursPerWeek": {
-            "type": "number"
+            "type": "string"
           },
           "careDateRange": {
             "$ref": "#/definitions/dateRange"
@@ -869,7 +869,7 @@
             "type": "string"
           },
           "jobHoursWeek": {
-            "type": "number"
+            "type": "string"
           },
           "jobTitle": {
             "type": "string"
@@ -894,7 +894,7 @@
             "type": "string"
           },
           "jobHoursWeek": {
-            "type": "number"
+            "type": "string"
           },
           "jobTitle": {
             "type": "string"

--- a/dist/21P-527EZ-OVERFLOW-cypress-example.json
+++ b/dist/21P-527EZ-OVERFLOW-cypress-example.json
@@ -65,12 +65,12 @@
     "currentEmployers": [
       {
         "jobType": "Customer service",
-        "jobHoursWeek": 20,
+        "jobHoursWeek": "20",
         "jobTitle": "Manager"
       },
       {
         "jobType": "Customer service",
-        "jobHoursWeek": 20,
+        "jobHoursWeek": "20",
         "jobTitle": "Representative"
       }
     ],
@@ -291,7 +291,7 @@
         "provider": "NYC Care Provider Family Medical Facility",
         "careType": "CARE_FACILITY",
         "ratePerHour": 100,
-        "hoursPerWeek": 20,
+        "hoursPerWeek": "20",
         "careDateRange": {
           "from": "2020-08-01",
           "to": "2023-05-25"
@@ -304,7 +304,7 @@
         "provider": "MA Care Provider",
         "careType": "IN_HOME_CARE_PROVIDER",
         "ratePerHour": 150,
-        "hoursPerWeek": 15,
+        "hoursPerWeek": "15",
         "careDateRange": {
           "from": "2021-08-01",
           "to": "2022-05-25"
@@ -318,7 +318,7 @@
         "provider": "LA Care Provider",
         "careType": "CARE_FACILITY",
         "ratePerHour": 200,
-        "hoursPerWeek": 10,
+        "hoursPerWeek": "10",
         "careDateRange": {
           "from": "2020-08-01"
         },

--- a/dist/21P-527EZ-OVERFLOW-example.json
+++ b/dist/21P-527EZ-OVERFLOW-example.json
@@ -64,12 +64,12 @@
   "currentEmployers": [
     {
       "jobType": "Customer service",
-      "jobHoursWeek": 20,
+      "jobHoursWeek": "20",
       "jobTitle": "Manager"
     },
     {
       "jobType": "Customer service",
-      "jobHoursWeek": 20,
+      "jobHoursWeek": "20",
       "jobTitle": "Representative"
     }
   ],
@@ -278,7 +278,7 @@
       "provider": "NYC Care Provider Family Medical Facility",
       "careType": "CARE_FACILITY",
       "ratePerHour": 100,
-      "hoursPerWeek": 20,
+      "hoursPerWeek": "20",
       "careDateRange": {
         "from": "2020-08-01",
         "to": "2023-05-25"
@@ -291,7 +291,7 @@
       "provider": "MA Care Provider",
       "careType": "IN_HOME_CARE_PROVIDER",
       "ratePerHour": 150,
-      "hoursPerWeek": 15,
+      "hoursPerWeek": "15",
       "careDateRange": {
         "from": "2021-08-01",
         "to": "2022-05-25"
@@ -305,7 +305,7 @@
       "provider": "LA Care Provider",
       "careType": "CARE_FACILITY",
       "ratePerHour": 200,
-      "hoursPerWeek": 10,
+      "hoursPerWeek": "10",
       "careDateRange": {
         "from": "2020-08-01"
       },

--- a/dist/21P-527EZ-OVERFLOW-schema.json
+++ b/dist/21P-527EZ-OVERFLOW-schema.json
@@ -140,7 +140,7 @@
             "type": "number"
           },
           "hoursPerWeek": {
-            "type": "number"
+            "type": "string"
           },
           "careDateRange": {
             "$ref": "#/definitions/dateRange"
@@ -869,7 +869,7 @@
             "type": "string"
           },
           "jobHoursWeek": {
-            "type": "number"
+            "type": "string"
           },
           "jobTitle": {
             "type": "string"
@@ -894,7 +894,7 @@
             "type": "string"
           },
           "jobHoursWeek": {
-            "type": "number"
+            "type": "string"
           },
           "jobTitle": {
             "type": "string"

--- a/dist/21P-527EZ-SIMPLE-cypress-example.json
+++ b/dist/21P-527EZ-SIMPLE-cypress-example.json
@@ -31,7 +31,7 @@
       {
         "jobDate": "2020-06-15",
         "jobType": "Customer service",
-        "jobHoursWeek": 20,
+        "jobHoursWeek": "20",
         "jobTitle": "Manager"
       }
     ],

--- a/dist/21P-527EZ-SIMPLE-example.json
+++ b/dist/21P-527EZ-SIMPLE-example.json
@@ -30,7 +30,7 @@
     {
       "jobDate": "2020-06-15",
       "jobType": "Customer service",
-      "jobHoursWeek": 20,
+      "jobHoursWeek": "20",
       "jobTitle": "Manager"
     }
   ],

--- a/dist/21P-527EZ-SIMPLE-schema.json
+++ b/dist/21P-527EZ-SIMPLE-schema.json
@@ -140,7 +140,7 @@
             "type": "number"
           },
           "hoursPerWeek": {
-            "type": "number"
+            "type": "string"
           },
           "careDateRange": {
             "$ref": "#/definitions/dateRange"
@@ -869,7 +869,7 @@
             "type": "string"
           },
           "jobHoursWeek": {
-            "type": "number"
+            "type": "string"
           },
           "jobTitle": {
             "type": "string"
@@ -894,7 +894,7 @@
             "type": "string"
           },
           "jobHoursWeek": {
-            "type": "number"
+            "type": "string"
           },
           "jobTitle": {
             "type": "string"

--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -140,7 +140,7 @@
             "type": "number"
           },
           "hoursPerWeek": {
-            "type": "number"
+            "type": "string"
           },
           "careDateRange": {
             "$ref": "#/definitions/dateRange"
@@ -869,7 +869,7 @@
             "type": "string"
           },
           "jobHoursWeek": {
-            "type": "number"
+            "type": "string"
           },
           "jobTitle": {
             "type": "string"
@@ -894,7 +894,7 @@
             "type": "string"
           },
           "jobHoursWeek": {
-            "type": "number"
+            "type": "string"
           },
           "jobTitle": {
             "type": "string"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "21.0.0",
+  "version": "21.0.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"

--- a/src/schemas/21P-527EZ-kitchen_sink/example.json
+++ b/src/schemas/21P-527EZ-kitchen_sink/example.json
@@ -56,7 +56,7 @@
     "currentEmployers": [
       {
         "jobType": "Customer service",
-        "jobHoursWeek": 20,
+        "jobHoursWeek": "20",
         "jobTitle": "Manager"
       }
     ],
@@ -226,7 +226,7 @@
         "provider": "NYC Care Provider",
         "careType": "CARE_FACILITY",
         "ratePerHour": 100,
-        "hoursPerWeek": 20,
+        "hoursPerWeek": "20",
         "careDateRange": {
           "from": "2020-08-01",
           "to": "2023-05-25"
@@ -239,7 +239,7 @@
         "provider": "MA Care Provider",
         "careType": "IN_HOME_CARE_PROVIDER",
         "ratePerHour": 150,
-        "hoursPerWeek": 15,
+        "hoursPerWeek": "15",
         "careDateRange": {
           "from": "2021-08-01",
           "to": "2022-05-25"
@@ -253,7 +253,7 @@
         "provider": "LA Care Provider",
         "careType": "CARE_FACILITY",
         "ratePerHour": 200,
-        "hoursPerWeek": 10,
+        "hoursPerWeek": "10",
         "careDateRange": {
           "from": "2020-08-01"
         },

--- a/src/schemas/21P-527EZ-overflow/example.json
+++ b/src/schemas/21P-527EZ-overflow/example.json
@@ -65,12 +65,12 @@
     "currentEmployers": [
       {
         "jobType": "Customer service",
-        "jobHoursWeek": 20,
+        "jobHoursWeek": "20",
         "jobTitle": "Manager"
       },
       {
         "jobType": "Customer service",
-        "jobHoursWeek": 20,
+        "jobHoursWeek": "20",
         "jobTitle": "Representative"
       }
     ],
@@ -291,7 +291,7 @@
         "provider": "NYC Care Provider Family Medical Facility",
         "careType": "CARE_FACILITY",
         "ratePerHour": 100,
-        "hoursPerWeek": 20,
+        "hoursPerWeek": "20",
         "careDateRange": {
           "from": "2020-08-01",
           "to": "2023-05-25"
@@ -304,7 +304,7 @@
         "provider": "MA Care Provider",
         "careType": "IN_HOME_CARE_PROVIDER",
         "ratePerHour": 150,
-        "hoursPerWeek": 15,
+        "hoursPerWeek": "15",
         "careDateRange": {
           "from": "2021-08-01",
           "to": "2022-05-25"
@@ -318,7 +318,7 @@
         "provider": "LA Care Provider",
         "careType": "CARE_FACILITY",
         "ratePerHour": 200,
-        "hoursPerWeek": 10,
+        "hoursPerWeek": "10",
         "careDateRange": {
           "from": "2020-08-01"
         },

--- a/src/schemas/21P-527EZ-simple/example.json
+++ b/src/schemas/21P-527EZ-simple/example.json
@@ -31,7 +31,7 @@
       {
         "jobDate": "2020-06-15",
         "jobType": "Customer service",
-        "jobHoursWeek": 20,
+        "jobHoursWeek": "20",
         "jobTitle": "Manager"
       }
     ],

--- a/src/schemas/21P-527EZ/schema.js
+++ b/src/schemas/21P-527EZ/schema.js
@@ -72,7 +72,7 @@ const schema = {
           provider: { type: 'string' },
           careType: { type: 'string', enum: ['CARE_FACILITY', 'IN_HOME_CARE_PROVIDER'] },
           ratePerHour: { type: 'number' },
-          hoursPerWeek: { type: 'number' },
+          hoursPerWeek: { type: 'string' },
           careDateRange: schemaHelpers.getDefinition('dateRange'),
           noCareEndDate: { type: 'boolean' },
           paymentFrequency: { type: 'string', enum: ['ONCE_MONTH', 'ONCE_YEAR'] },
@@ -191,7 +191,7 @@ const schema = {
             type: 'string',
           },
           jobHoursWeek: {
-            type: 'number',
+            type: 'string',
           },
           jobTitle: {
             type: 'string',
@@ -212,7 +212,7 @@ const schema = {
             type: 'string',
           },
           jobHoursWeek: {
-            type: 'number',
+            type: 'string',
           },
           jobTitle: {
             type: 'string',

--- a/test/schemas/21P-527EZ/schema.spec.js
+++ b/test/schemas/21P-527EZ/schema.spec.js
@@ -87,12 +87,12 @@ describe('21-527 schema', () => {
   schemaTestHelper.testValidAndInvalid('currentEmployers', {
     valid: [[{
       jobType: 'analyst',
-      jobHoursWeek: 40,
+      jobHoursWeek: '40',
       jobTitle: 'analyst',
     }]],
     invalid: [[{
       jobType: 1,
-      jobHoursWeek: '40',
+      jobHoursWeek: 40,
       jobTitle: 234,
     }]]
   });
@@ -101,13 +101,13 @@ describe('21-527 schema', () => {
     valid: [[{
       jobDate: '2020-01-01',
       jobType: 'analyst',
-      jobHoursWeek: 40,
+      jobHoursWeek: '40',
       jobTitle: 'analyst',
     }]],
     invalid: [[{
       jobDate: '2020/01/01',
       jobType: 1,
-      jobHoursWeek: '40',
+      jobHoursWeek: 40,
       jobTitle: 234,
     }]]
   });


### PR DESCRIPTION
# New schema
_Updating some of our web components to v3 have forced us to change some number field values into strings. This PR also includes updates to the test fixture data to be used downstream._

_Version has been incremented from 21.0.0 to 21.0.1 in `package.json`._

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/76773
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/76777

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
