### PR TITLE
update frontend codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 
-*       @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/platform-release-tools 
+*       @department-of-veterans-affairs/backend-review-group @department-of-veterans-affairs/va-platform-cop-frontend 


### PR DESCRIPTION
Update the frontend code owners from "platform-release-tools" to "va-platform-cop-frontend"

The platform-release-tools team has not existed for a few years.
