### PR TITLE
Capitalize schema file to fix errors in vets-api

### DIFF
--- a/dist/21-22A-schema.json
+++ b/dist/21-22A-schema.json
@@ -1,0 +1,303 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Form 2122a Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["veteran", "representative"],
+  "properties": {
+    "veteran": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["address"],
+      "properties": {
+        "serviceNumber": {
+          "description": "The Veteran's Service Number",
+          "type": "string",
+          "maxLength": 9
+        },
+        "serviceBranch": {
+          "description": "Service Branch for the veteran.",
+          "type": "string",
+          "enum": ["AIR_FORCE", "ARMY", "COAST_GUARD", "MARINE_CORPS", "NAVY", "SPACE_FORCE", "OTHER"],
+          "example": "ARMY"
+        },
+        "serviceBranchOther": {
+          "description": "For a 'service branch' of value 'other', please provide the service branch name.",
+          "type": "string",
+          "maxLength": 27,
+          "example": "Air National Guard"
+        },
+        "address": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["addressLine1", "city", "stateCode", "country", "zipCode"],
+          "properties": {
+            "addressLine1": {
+              "description": "Street address with number and name.",
+              "type": "string",
+              "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+              "maxLength": 30
+            },
+            "addressLine2": {
+              "type": "string",
+              "maxLength": 5
+            },
+            "city": {
+              "description": "City for the address.",
+              "type": "string",
+              "example": "Portland",
+              "maxLength": 18
+            },
+            "stateCode": {
+              "description": "State for the address.",
+              "type": "string",
+              "pattern": "^[a-z,A-Z]{2}$",
+              "example": "OR"
+            },
+            "country": {
+              "description": "Country of the address.",
+              "type": "string",
+              "example": "USA"
+            },
+            "zipCode": {
+              "description": "Zipcode (First 5 digits) of the address.",
+              "type": "string",
+              "pattern": "^[0-9]{5}$",
+              "example": "12345"
+            },
+            "zipCodeSuffix": {
+              "description": "Zipcode (Last 4 digits) of the address.",
+              "type": "string",
+              "pattern": "^[0-9]{4}$",
+              "example": "6789"
+            }
+          }
+        },
+        "phone": {
+          "$comment": "the phone fields must not exceed 20 chars, when concatenated",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["areaCode", "phoneNumber"],
+          "properties": {
+            "countryCode": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            "areaCode": {
+              "description": "Area code of the phone number.",
+              "type": "string",
+              "pattern": "^[2-9][0-9]{2}$",
+              "example": "555"
+            },
+            "phoneNumber": {
+              "description": "Phone number.",
+              "type": "string",
+              "pattern": "^[0-9]{1,14}$",
+              "example": "555-5555"
+            },
+            "phoneNumberExt": {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9]{1,10}$"
+            }
+          }
+        },
+        "email": {
+          "description": "Email address of the veteran.",
+          "type": "string",
+          "pattern": ".@.",
+          "maxLength": 61,
+          "example": "veteran@example.com"
+        }
+      }
+    },
+    "claimant": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "claimantId": {
+          "type": "string",
+          "example": "123456789",
+          "description": "Id of the claimant."
+        },
+        "address": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "addressLine1": {
+              "description": "Street address with number and name. Required if claimant information provided.",
+              "type": "string",
+              "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+              "maxLength": 30
+            },
+            "addressLine2": {
+              "type": "string",
+              "maxLength": 5
+            },
+            "city": {
+              "description": "City for the address. Required if claimant information provided.",
+              "type": "string",
+              "example": "Portland",
+              "maxLength": 18
+            },
+            "stateCode": {
+              "description": "State for the address. Required if claimant information provided.",
+              "type": "string",
+              "pattern": "^[a-z,A-Z]{2}$",
+              "example": "OR"
+            },
+            "country": {
+              "description": "Country of the address. Required if claimant information provided.",
+              "type": "string",
+              "example": "USA"
+            },
+            "zipCode": {
+              "description": "Zipcode (First 5 digits) of the address. Required if claimant information provided.",
+              "type": "string",
+              "pattern": "^[0-9]{5}$",
+              "example": "12345"
+            },
+            "zipCodeSuffix": {
+              "description": "Zipcode (Last 4 digits) of the address.",
+              "type": "string",
+              "pattern": "^[0-9]{4}$",
+              "example": "6789"
+            }
+          }
+        },
+        "phone": {
+          "$comment": "the phone fields must not exceed 20 chars, when concatenated",
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["areaCode", "phoneNumber"],
+          "properties": {
+            "countryCode": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            "areaCode": {
+              "description": "Area code of the phone number.",
+              "type": "string",
+              "pattern": "^[2-9][0-9]{2}$",
+              "example": "555"
+            },
+            "phoneNumber": {
+              "description": "Phone number.",
+              "type": "string",
+              "pattern": "^[0-9]{1,14}$",
+              "example": "555-5555"
+            },
+            "phoneNumberExt": {
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9]{1,10}$"
+            }
+          }
+        },
+        "email": {
+          "description": "Email address of the claimant.",
+          "type": "string",
+          "pattern": ".@.",
+          "maxLength": 61,
+          "example": "claimant@example.com"
+        },
+        "relationship": {
+          "description": "Relationship of claimant to the veteran. Required if claimant information provided.",
+          "type": "string",
+          "example": "Spouse"
+        }
+      }
+    },
+    "representative": {
+      "description": "Details of the individual representative representing the veteran.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["poaCode", "registrationNumber", "type"],
+      "properties": {
+        "poaCode": {
+          "description": "The POA code of the representative.",
+          "type": "string",
+          "example": "A1Q"
+        },
+        "registrationNumber": {
+          "description": "Registration Number of representative.",
+          "type": "string",
+          "example": "12345"
+        },
+        "type": {
+          "description": "Type of individual representative",
+          "type": "string",
+          "enum": ["ATTORNEY", "AGENT"],
+          "example": "ATTORNEY"
+        },
+        "address": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "addressLine1": {
+              "description": "Street address with number and name.",
+              "type": "string",
+              "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+              "maxLength": 30
+            },
+            "addressLine2": {
+              "type": "string",
+              "maxLength": 5
+            },
+            "city": {
+              "description": "City for the address.",
+              "type": "string",
+              "example": "Portland",
+              "maxLength": 18
+            },
+            "stateCode": {
+              "description": "State for the address.",
+              "type": "string",
+              "pattern": "^[a-z,A-Z]{2}$",
+              "example": "OR"
+            },
+            "country": {
+              "description": "Country of the address.",
+              "type": "string",
+              "example": "USA"
+            },
+            "zipCode": {
+              "description": "Zipcode (First 5 digits) of the address.",
+              "type": "string",
+              "pattern": "^[0-9]{5}$",
+              "example": "12345"
+            },
+            "zipCodeSuffix": {
+              "description": "Zipcode (Last 4 digits) of the address.",
+              "type": "string",
+              "pattern": "^[0-9]{4}$",
+              "example": "6789"
+            }
+          }
+        }
+      }
+    },
+    "recordConsent": {
+      "description": "AUTHORIZATION FOR REPRESENTATIVE'S ACCESS TO RECORDS PROTECTED BY SECTION 7332, TITLE 38, U.S.C.",
+      "type": "boolean"
+    },
+    "consentLimits": {
+      "description": "Consent in Item 19 for the disclosure of records relating to treatment for drug abuse, alcoholism or alcohol abuse, infection with the human immunodeficiency virus (HIV), or sickle cell anemia is limited as follows.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["DRUG_ABUSE", "ALCOHOLISM", "HIV", "SICKLE_CELL"]
+      },
+      "example": "DRUG ABUSE"
+    },
+    "consentAddressChange": {
+      "description": "AUTHORIZATION FOR REPRESENTATIVE TO ACT ON CLAIMANT'S BEHALF TO CHANGE CLAIMANT'S ADDRESS.",
+      "type": "boolean"
+    },
+    "conditionsOfAppointment": {
+      "description": "If the individual named in Item 15A is an accredited agent or attorney, the scope of representation provided before VA may be limited by the agent or attorney as indicated below in Item 23",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# New schema

`dist/21-22a-schema.json` is throwing an error when attempting to upgrade the vets-json-schema version in `vets-api` because it doesn't match the schema capitalization (`21-22A`). This PR changes the name to correct the error.

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
