### PR TITLE
VFEP-1502 remove benefits relinquished.

### DIFF
--- a/dist/22-1990-schema.json
+++ b/dist/22-1990-schema.json
@@ -654,9 +654,6 @@
     "applyingUsingOwnBenefits": {
       "type": "boolean"
     },
-    "benefitsRelinquishedDate": {
-      "$ref": "#/definitions/date"
-    },
     "privacyAgreementAccepted": {
       "$ref": "#/definitions/privacyAgreementAccepted"
     },

--- a/dist/22-1990-schema.json
+++ b/dist/22-1990-schema.json
@@ -533,15 +533,6 @@
     "chapter32": {
       "type": "boolean"
     },
-    "benefitsRelinquished": {
-      "type": "string",
-      "enum": [
-        "unknown",
-        "chapter30",
-        "chapter1606",
-        "chapter1607"
-      ]
-    },
     "veteranFullName": {
       "$ref": "#/definitions/fullName"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "22.3.2",
+  "version": "22.3.3",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/schemas/22-1990/schema.js
+++ b/src/schemas/22-1990/schema.js
@@ -2,8 +2,6 @@ import _ from 'lodash';
 import definitions from '../../common/definitions';
 import schemaHelpers from '../../common/schema-helpers';
 
-const benefits = ['chapter33', 'chapter30', 'chapter1606', 'chapter32'];
-
 const schema = {
   $schema: 'http://json-schema.org/draft-04/schema#',
   title: 'APPLICATION FOR VA EDUCATION BENEFITS (22-1990)',
@@ -46,10 +44,6 @@ const schema = {
     },
     chapter32: {
       type: 'boolean',
-    },
-    benefitsRelinquished: {
-      type: 'string',
-      enum: ['unknown', ..._.without(benefits, 'chapter33', 'chapter32'), 'chapter1607'],
     },
     veteranFullName: {
       $ref: '#/definitions/fullName',

--- a/src/schemas/22-1990/schema.js
+++ b/src/schemas/22-1990/schema.js
@@ -166,9 +166,6 @@ const schema = {
     applyingUsingOwnBenefits: {
       type: 'boolean',
     },
-    benefitsRelinquishedDate: {
-      $ref: '#/definitions/date',
-    },
     privacyAgreementAccepted: {
       $ref: '#/definitions/privacyAgreementAccepted',
     },

--- a/test/schemas/22-1990/schema.spec.js
+++ b/test/schemas/22-1990/schema.spec.js
@@ -102,17 +102,10 @@ describe('education benefits json schema', () => {
     });
   });
 
-  context('benefitsRelinquished validation', () => {
-    schemaTestHelper.testValidAndInvalid('benefitsRelinquished', {
-      valid: ['chapter30', 'unknown', 'chapter1607', 'chapter1606'],
-      invalid: ['chapter33']
-    });
-  });
-
   context('serviceBefore1977 validation', () => {
     schemaTestHelper.testValidAndInvalid('serviceBefore1977', {
       valid: [{
-        married: true,
+          married: true,
         haveDependents: true,
         parentDependent: false
       }],


### PR DESCRIPTION
# New schema
- Remove benefits relinquished.


As a...
VFEP Business User
I want...
to view my benefit choices
So that...
I can select the benefit I would like to use
 
Acceptance Criteria:
•	The 22-1990 has a question in the Benefit eligibility section "Select the benefit that is the best match for you."  If the user selects Post-9/11 GI Bill (Chapter 33), the following text is displayed and should be removed: "When you choose to apply for your Post-9/11 benefit, you have to relinquish (give up) 1 other benefit you may be eligible for. You’ll make this decision on the next page." ( Done )

![image](https://github.com/department-of-veterans-affairs/vets-json-schema/assets/95312667/24f53367-c8bf-4265-aeee-42812c11d23f)


The 22-1990 has a question in the Benefit eligibility section "Select the benefit that is the best match for you."  If the user selects Post-9/11 GI Bill (Chapter 33),  the following page is presented to the user and should be removed:


![image](https://github.com/department-of-veterans-affairs/vets-json-schema/assets/95312667/28957782-8c2b-4876-b79b-7d3cbbc36c62)