### PR TITLE
Update pattern regex for toxic exposure in 1010 schemas

### DIFF
--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -2286,7 +2286,7 @@
     "otherToxicExposure": {
       "type": "string",
       "maxLength": 100,
-      "pattern": "^[a-zA-Z0-9 ]+$"
+      "pattern": "^[a-zA-Z0-9,.?! ]*$"
     },
     "toxicExposureStartDate": {
       "pattern": "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$",

--- a/dist/10-10EZR-schema.json
+++ b/dist/10-10EZR-schema.json
@@ -1335,7 +1335,7 @@
     "otherToxicExposure": {
       "type": "string",
       "maxLength": 100,
-      "pattern": "^[a-zA-Z0-9 ]+$"
+      "pattern": "^[a-zA-Z0-9,.?! ]*$"
     },
     "toxicExposureStartDate": {
       "pattern": "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$",

--- a/dist/definitions.json
+++ b/dist/definitions.json
@@ -100,7 +100,7 @@
     "otherToxicExposure": {
       "type": "string",
       "maxLength": 100,
-      "pattern": "^[a-zA-Z0-9 ]+$"
+      "pattern": "^[a-zA-Z0-9,.?! ]*$"
     },
     "toxicExposureStartDate": {
       "pattern": "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "24.1.0",
+  "version": "24.1.1",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/common/definitions.js
+++ b/src/common/definitions.js
@@ -958,7 +958,7 @@ const teraQuestions = {
   otherToxicExposure: {
     type: 'string',
     maxLength: 100,
-    pattern: '^[a-zA-Z0-9 ]+$',
+    pattern: '^[a-zA-Z0-9,.?! ]*$',
   },
   toxicExposureStartDate: date,
   toxicExposureEndDate: date,
@@ -1029,5 +1029,5 @@ export default {
   hcaPhone,
   insuranceProvider,
   hcaEmail,
-  yesNoSchema
+  yesNoSchema,
 };

--- a/test/common/definitions.spec.js
+++ b/test/common/definitions.spec.js
@@ -1,8 +1,8 @@
+import { cloneDeep } from 'lodash';
 import SchemaTestHelper from '../support/schema-test-helper';
 import { definitions as originalDefinitions } from '../../dist/schemas';
 import fixtures from '../support/fixtures';
 import testData from '../support/test-data';
-import { cloneDeep } from 'lodash';
 
 function stringGenerate(length) {
   return new Array(length + 1).join('a');
@@ -12,7 +12,7 @@ const definitions = cloneDeep(originalDefinitions);
 
 definitions.teraQuestions = {
   type: 'object',
-  properties: originalDefinitions.teraQuestions
+  properties: originalDefinitions.teraQuestions,
 };
 
 describe('schema definitions', () => {
@@ -33,11 +33,10 @@ describe('schema definitions', () => {
     valid: [
       { otherToxicExposure: 'foo' },
       { otherToxicExposure: 'foo bar' },
-      { otherToxicExposure: 'Foo123' }
+      { otherToxicExposure: 'Foo123' },
+      { otherToxicExposure: 'Foo123, Bar123' },
     ],
-    invalid: [
-      { otherToxicExposure: '$' }
-    ],
+    invalid: [{ otherToxicExposure: '$' }],
   });
 
   testValidAndInvalidDefinitions('insuranceProvider', {
@@ -472,7 +471,6 @@ describe('schema definitions', () => {
         street2: stringGenerate(13),
         street3: stringGenerate(5),
         city: stringGenerate(27),
-        postalCode: stringGenerate(5),
         postalCode: '   ',
       },
     ],

--- a/test/schemas/10-10EZ/schema.spec.js
+++ b/test/schemas/10-10EZ/schema.spec.js
@@ -1,11 +1,10 @@
-import { omit } from 'lodash';
-import schemas from '../../../dist/schemas';
-import { definitions } from '../../../dist/schemas';
-import SchemaTestHelper from '../../support/schema-test-helper';
+import { difference, omit } from 'lodash';
 import { expect } from 'chai';
-import { difference } from 'lodash';
+import schemas from '../../../dist/schemas';
+import SchemaTestHelper from '../../support/schema-test-helper';
 
 const applicationSchema = schemas['10-10EZ'];
+const { definitions } = schemas;
 
 const schemaTestHelper = new SchemaTestHelper(omit(applicationSchema, 'required'));
 
@@ -27,10 +26,10 @@ describe('healthcare-application json schema', () => {
     invalid: [1],
   });
 
-  it('has tera fields', () => {
-    expect(
-      difference(Object.keys(definitions.teraQuestions), Object.keys(applicationSchema.properties)).length
-    ).to.equal(0);
+  it('should have TERA fields', () => {
+    const teraKeys = Object.keys(definitions.teraQuestions);
+    const schemaKeys = Object.keys(applicationSchema.properties);
+    expect(difference(teraKeys, schemaKeys).length).to.equal(0);
   });
 
   schemaTestHelper.testValidAndInvalid('lastServiceBranch', {

--- a/test/schemas/10-10EZR/schema.spec.js
+++ b/test/schemas/10-10EZR/schema.spec.js
@@ -1,11 +1,10 @@
-import { omit } from 'lodash';
+import { difference, omit } from 'lodash';
+import { expect } from 'chai';
 import schemas from '../../../dist/schemas';
 import SchemaTestHelper from '../../support/schema-test-helper';
-import { definitions } from '../../../dist/schemas';
-import { expect } from 'chai';
-import { difference } from 'lodash';
 
 const applicationSchema = schemas['10-10EZR'];
+const { definitions } = schemas;
 
 const schemaTestHelper = new SchemaTestHelper(omit(applicationSchema, 'required'));
 
@@ -14,16 +13,14 @@ function stringGenerate(length) {
 }
 
 describe('ezr json schema', () => {
-  it('has tera fields', () => {
-    expect(
-      difference(Object.keys(definitions.teraQuestions), Object.keys(applicationSchema.properties)).length
-    ).to.equal(0);
+  it('should have TERA fields', () => {
+    const teraKeys = Object.keys(definitions.teraQuestions);
+    const schemaKeys = Object.keys(applicationSchema.properties);
+    expect(difference(teraKeys, schemaKeys).length).to.equal(0);
   });
 
   schemaTestHelper.testValidAndInvalid('medicareClaimNumber', {
-    valid: [
-      stringGenerate(30),
-    ],
+    valid: [stringGenerate(30)],
     invalid: [null, '', '     '],
   });
 });


### PR DESCRIPTION
# Description
This PR updates the pattern regex for a field related to Toxic Exposure in the 10-10EZ & EZR schemas. The previous pattern did not allow for any special characters, as our downstream system could not accept those. They have since updated their validation to allow for four special characters (`. ? ! ,`).

The specs were also updated for the definition(s) and schema(s) to correctly test the pattern.

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82212

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
