### PR TITLE
89790: Add v2 schemas for Decision Review SHOW endpoints

### DIFF
--- a/dist/HLR-SHOW-RESPONSE-200_V2-example.json
+++ b/dist/HLR-SHOW-RESPONSE-200_V2-example.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "id": "00000000-1111-2222-3333-444444444444",
+    "type": "higherLevelReview",
+    "attributes": {
+      "status": "pending",
+      "updatedAt": "2020-01-02T03:04:05.067Z",
+      "createdAt": "2020-01-02T03:04:05.067Z"
+    }
+  }
+}

--- a/dist/HLR-SHOW-RESPONSE-200_V2-schema.json
+++ b/dist/HLR-SHOW-RESPONSE-200_V2-schema.json
@@ -28,6 +28,7 @@
           ]
         },
         "attributes": {
+          "type": "object",
           "properties": {
             "status": {
               "$ref": "#/definitions/hlrStatus"

--- a/dist/HLR-SHOW-RESPONSE-200_V2-schema.json
+++ b/dist/HLR-SHOW-RESPONSE-200_V2-schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Info about a single Higher-Level Review",
+  "$ref": "#/definitions/root",
+  "definitions": {
+    "root": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/data"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "higherLevelReview"
+          ]
+        },
+        "attributes": {
+          "properties": {
+            "status": {
+              "$ref": "#/definitions/hlrStatus"
+            },
+            "updatedAt": {
+              "$ref": "#/definitions/timeStamp"
+            },
+            "createdAt": {
+              "$ref": "#/definitions/timeStamp"
+            }
+          },
+          "required": [
+            "status",
+            "updatedAt",
+            "createdAt"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ]
+    },
+    "uuid": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+    },
+    "timeStamp": {
+      "type": "string",
+      "pattern": "\\d{4}(-\\d{2}){2}T\\d{2}(:\\d{2}){2}.\\d{3}Z"
+    },
+    "hlrStatus": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "submitting",
+        "submitted",
+        "processing",
+        "success",
+        "complete",
+        "error"
+      ]
+    }
+  }
+}

--- a/dist/NOD-SHOW-RESPONSE-200_V2-example.json
+++ b/dist/NOD-SHOW-RESPONSE-200_V2-example.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "id": "00000000-1111-2222-3333-444444444444",
+    "type": "noticeOfDisagreement",
+    "attributes": {
+      "status": "pending",
+      "updatedAt": "2020-01-02T03:04:05.067Z",
+      "createdAt": "2020-01-02T03:04:05.067Z"
+    }
+  }
+}

--- a/dist/NOD-SHOW-RESPONSE-200_V2-schema.json
+++ b/dist/NOD-SHOW-RESPONSE-200_V2-schema.json
@@ -28,6 +28,7 @@
           ]
         },
         "attributes": {
+          "type": "object",
           "properties": {
             "status": {
               "$ref": "#/definitions/nodStatus"

--- a/dist/NOD-SHOW-RESPONSE-200_V2-schema.json
+++ b/dist/NOD-SHOW-RESPONSE-200_V2-schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Info about a single Notice of Disagreement",
+  "$ref": "#/definitions/root",
+  "definitions": {
+    "root": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/data"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "noticeOfDisagreement"
+          ]
+        },
+        "attributes": {
+          "properties": {
+            "status": {
+              "$ref": "#/definitions/nodStatus"
+            },
+            "updatedAt": {
+              "$ref": "#/definitions/timeStamp"
+            },
+            "createdAt": {
+              "$ref": "#/definitions/timeStamp"
+            }
+          },
+          "required": [
+            "status",
+            "updatedAt",
+            "createdAt"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ]
+    },
+    "uuid": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+    },
+    "timeStamp": {
+      "type": "string",
+      "pattern": "\\d{4}(-\\d{2}){2}T\\d{2}(:\\d{2}){2}.\\d{3}Z"
+    },
+    "nodStatus": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "submitting",
+        "submitted",
+        "processing",
+        "success",
+        "complete",
+        "error"
+      ]
+    }
+  }
+}

--- a/dist/SC-SHOW-RESPONSE-200_V2-example.json
+++ b/dist/SC-SHOW-RESPONSE-200_V2-example.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "id": "00000000-1111-2222-3333-444444444444",
+    "type": "supplementalClaim",
+    "attributes": {
+      "status": "pending",
+      "updatedAt": "2020-01-02T03:04:05.067Z",
+      "createdAt": "2020-01-02T03:04:05.067Z"
+    }
+  }
+}

--- a/dist/SC-SHOW-RESPONSE-200_V2-schema.json
+++ b/dist/SC-SHOW-RESPONSE-200_V2-schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Info about a single Supplemental Claim",
+  "$ref": "#/definitions/root",
+  "definitions": {
+    "root": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/data"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "supplementalClaim"
+          ]
+        },
+        "attributes": {
+          "properties": {
+            "status": {
+              "$ref": "#/definitions/scStatus"
+            },
+            "updatedAt": {
+              "$ref": "#/definitions/timeStamp"
+            },
+            "createdAt": {
+              "$ref": "#/definitions/timeStamp"
+            }
+          },
+          "required": [
+            "status",
+            "updatedAt",
+            "createdAt"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ]
+    },
+    "uuid": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+    },
+    "timeStamp": {
+      "type": "string",
+      "pattern": "\\d{4}(-\\d{2}){2}T\\d{2}(:\\d{2}){2}.\\d{3}Z"
+    },
+    "scStatus": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "submitting",
+        "submitted",
+        "processing",
+        "success",
+        "complete",
+        "error"
+      ]
+    }
+  }
+}

--- a/dist/SC-SHOW-RESPONSE-200_V2-schema.json
+++ b/dist/SC-SHOW-RESPONSE-200_V2-schema.json
@@ -28,6 +28,7 @@
           ]
         },
         "attributes": {
+          "type": "object",
           "properties": {
             "status": {
               "$ref": "#/definitions/scStatus"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "24.1.1",
+  "version": "24.2.0",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/examples/HLR-show-response-200_v2/example.js
+++ b/src/examples/HLR-show-response-200_v2/example.js
@@ -1,0 +1,1 @@
+export default require('../../schemas/HLR-show-response-200_v2/example.json');

--- a/src/examples/NOD-show-response-200_v2/example.js
+++ b/src/examples/NOD-show-response-200_v2/example.js
@@ -1,0 +1,1 @@
+export default require('../../schemas/NOD-show-response-200_v2/example.json');

--- a/src/examples/SC-show-response-200_v2/example.js
+++ b/src/examples/SC-show-response-200_v2/example.js
@@ -1,0 +1,1 @@
+export default require('../../schemas/SC-show-response-200_v2/example.json');

--- a/src/schemas/HLR-show-response-200_v2/example.json
+++ b/src/schemas/HLR-show-response-200_v2/example.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "id": "00000000-1111-2222-3333-444444444444",
+    "type": "higherLevelReview",
+    "attributes": {
+      "status": "pending",
+      "updatedAt": "2020-01-02T03:04:05.067Z",
+      "createdAt": "2020-01-02T03:04:05.067Z"
+    }
+  }
+}

--- a/src/schemas/HLR-show-response-200_v2/schema.js
+++ b/src/schemas/HLR-show-response-200_v2/schema.js
@@ -1,0 +1,4 @@
+// The schema is supplied to us from Lighthouse: https://dev-developer.va.gov/explore/appeals/docs/decision_reviews?version=current
+import schema from './schema.json';
+schema.$schema = 'http://json-schema.org/draft-07/schema#';
+export default schema;

--- a/src/schemas/HLR-show-response-200_v2/schema.json
+++ b/src/schemas/HLR-show-response-200_v2/schema.json
@@ -28,6 +28,7 @@
           ]
         },
         "attributes": {
+          "type": "object",
           "properties": {
             "status": {
               "$ref": "#/definitions/hlrStatus"

--- a/src/schemas/HLR-show-response-200_v2/schema.json
+++ b/src/schemas/HLR-show-response-200_v2/schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Info about a single Higher-Level Review",
+  "$ref": "#/definitions/root",
+  "definitions": {
+    "root": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/data"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "higherLevelReview"
+          ]
+        },
+        "attributes": {
+          "properties": {
+            "status": {
+              "$ref": "#/definitions/hlrStatus"
+            },
+            "updatedAt": {
+              "$ref": "#/definitions/timeStamp"
+            },
+            "createdAt": {
+              "$ref": "#/definitions/timeStamp"
+            }
+          },
+          "required": [
+            "status",
+            "updatedAt",
+            "createdAt"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ]
+    },
+    "uuid": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+    },
+    "timeStamp": {
+      "type": "string",
+      "pattern": "\\d{4}(-\\d{2}){2}T\\d{2}(:\\d{2}){2}.\\d{3}Z"
+    },
+    "hlrStatus": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "submitting",
+        "submitted",
+        "processing",
+        "success",
+        "complete",
+        "error"
+      ]
+    }
+  }
+}

--- a/src/schemas/NOD-show-response-200_v2/example.json
+++ b/src/schemas/NOD-show-response-200_v2/example.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "id": "00000000-1111-2222-3333-444444444444",
+    "type": "noticeOfDisagreement",
+    "attributes": {
+      "status": "pending",
+      "updatedAt": "2020-01-02T03:04:05.067Z",
+      "createdAt": "2020-01-02T03:04:05.067Z"
+    }
+  }
+}

--- a/src/schemas/NOD-show-response-200_v2/schema.js
+++ b/src/schemas/NOD-show-response-200_v2/schema.js
@@ -1,0 +1,4 @@
+// The schema is supplied to us from Lighthouse: https://dev-developer.va.gov/explore/appeals/docs/decision_reviews?version=current
+import schema from './schema.json';
+schema.$schema = 'http://json-schema.org/draft-07/schema#';
+export default schema;

--- a/src/schemas/NOD-show-response-200_v2/schema.json
+++ b/src/schemas/NOD-show-response-200_v2/schema.json
@@ -28,6 +28,7 @@
           ]
         },
         "attributes": {
+          "type": "object",
           "properties": {
             "status": {
               "$ref": "#/definitions/nodStatus"

--- a/src/schemas/NOD-show-response-200_v2/schema.json
+++ b/src/schemas/NOD-show-response-200_v2/schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Info about a single Notice of Disagreement",
+  "$ref": "#/definitions/root",
+  "definitions": {
+    "root": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/data"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "noticeOfDisagreement"
+          ]
+        },
+        "attributes": {
+          "properties": {
+            "status": {
+              "$ref": "#/definitions/nodStatus"
+            },
+            "updatedAt": {
+              "$ref": "#/definitions/timeStamp"
+            },
+            "createdAt": {
+              "$ref": "#/definitions/timeStamp"
+            }
+          },
+          "required": [
+            "status",
+            "updatedAt",
+            "createdAt"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ]
+    },
+    "uuid": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+    },
+    "timeStamp": {
+      "type": "string",
+      "pattern": "\\d{4}(-\\d{2}){2}T\\d{2}(:\\d{2}){2}.\\d{3}Z"
+    },
+    "nodStatus": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "submitting",
+        "submitted",
+        "processing",
+        "success",
+        "complete",
+        "error"
+      ]
+    }
+  }
+}

--- a/src/schemas/SC-show-response-200_v2/example.json
+++ b/src/schemas/SC-show-response-200_v2/example.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "id": "00000000-1111-2222-3333-444444444444",
+    "type": "supplementalClaim",
+    "attributes": {
+      "status": "pending",
+      "updatedAt": "2020-01-02T03:04:05.067Z",
+      "createdAt": "2020-01-02T03:04:05.067Z"
+    }
+  }
+}

--- a/src/schemas/SC-show-response-200_v2/schema.js
+++ b/src/schemas/SC-show-response-200_v2/schema.js
@@ -1,0 +1,4 @@
+// The schema is supplied to us from Lighthouse: https://dev-developer.va.gov/explore/appeals/docs/decision_reviews?version=current
+import schema from './schema.json';
+schema.$schema = 'http://json-schema.org/draft-07/schema#';
+export default schema;

--- a/src/schemas/SC-show-response-200_v2/schema.json
+++ b/src/schemas/SC-show-response-200_v2/schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Info about a single Supplemental Claim",
+  "$ref": "#/definitions/root",
+  "definitions": {
+    "root": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/data"
+        }
+      },
+      "required": [
+        "data"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/uuid"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "supplementalClaim"
+          ]
+        },
+        "attributes": {
+          "properties": {
+            "status": {
+              "$ref": "#/definitions/scStatus"
+            },
+            "updatedAt": {
+              "$ref": "#/definitions/timeStamp"
+            },
+            "createdAt": {
+              "$ref": "#/definitions/timeStamp"
+            }
+          },
+          "required": [
+            "status",
+            "updatedAt",
+            "createdAt"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "attributes"
+      ]
+    },
+    "uuid": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+    },
+    "timeStamp": {
+      "type": "string",
+      "pattern": "\\d{4}(-\\d{2}){2}T\\d{2}(:\\d{2}){2}.\\d{3}Z"
+    },
+    "scStatus": {
+      "type": "string",
+      "enum": [
+        "pending",
+        "submitting",
+        "submitted",
+        "processing",
+        "success",
+        "complete",
+        "error"
+      ]
+    }
+  }
+}

--- a/src/schemas/SC-show-response-200_v2/schema.json
+++ b/src/schemas/SC-show-response-200_v2/schema.json
@@ -28,6 +28,7 @@
           ]
         },
         "attributes": {
+          "type": "object",
           "properties": {
             "status": {
               "$ref": "#/definitions/scStatus"


### PR DESCRIPTION
# New schema
This adds the newest schema for the SHOW (GET) endpoints for the Decision Review forms (HLR, NOD, and SC). See https://dev-developer.va.gov/explore/api/decision-reviews/docs?version=current

_Please ensure you have incremented the version in_ `package.json`.

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
