### PR TITLE
21P-0969 update examples and required

### DIFF
--- a/dist/21P-0969-KITCHEN_SINK-cypress-example.json
+++ b/dist/21P-0969-KITCHEN_SINK-cypress-example.json
@@ -7,6 +7,43 @@
     },
     "veteranSocialSecurityNumber": "333224444",
     "statementOfTruthCertified": true,
-    "statementOfTruthSignature": "John Edmund Doe"
+    "statementOfTruthSignature": "John Edmund Doe",
+    "unassociatedIncomes": [
+      {
+        "recipientRelationship": "CHILD",
+        "recipientName": "Jane Doe",
+        "incomeType": "WAGES",
+        "grossMonthlyIncome": 99999.99,
+        "payer": "Generic Company, LLC"
+      },
+      {
+        "recipientRelationship": "OTHER",
+        "otherRecipientRelationshipType": "Cousin",
+        "recipientName": "Sam Jenkins",
+        "incomeType": "OTHER",
+        "otherIncomeType": "Stocks",
+        "grossMonthlyIncome": 99,
+        "payer": "Investment Company"
+      },
+      {
+        "recipientRelationship": "VETERAN",
+        "incomeType": "SOCIAL_SECURITY",
+        "grossMonthlyIncome": 102.33,
+        "payer": "Social Security Administration"
+      },
+      {
+        "recipientRelationship": "SPOUSE",
+        "incomeType": "RETIREMENT_PENSION",
+        "grossMonthlyIncome": 1099.99,
+        "payer": "Pension Benefit Management"
+      },
+      {
+        "recipientRelationship": "PARENT",
+        "recipientName": "Edmund Doe",
+        "incomeType": "CIVIL_SERVICE",
+        "grossMonthlyIncome": 12345.67,
+        "payer": "Personnel Management"
+      }
+    ]
   }
 }

--- a/dist/21P-0969-KITCHEN_SINK-example.json
+++ b/dist/21P-0969-KITCHEN_SINK-example.json
@@ -6,5 +6,42 @@
   },
   "veteranSocialSecurityNumber": "333224444",
   "statementOfTruthCertified": true,
-  "statementOfTruthSignature": "John Edmund Doe"
+  "statementOfTruthSignature": "John Edmund Doe",
+  "unassociatedIncomes": [
+    {
+      "recipientRelationship": "CHILD",
+      "recipientName": "Jane Doe",
+      "incomeType": "WAGES",
+      "grossMonthlyIncome": 99999.99,
+      "payer": "Generic Company, LLC"
+    },
+    {
+      "recipientRelationship": "OTHER",
+      "otherRecipientRelationshipType": "Cousin",
+      "recipientName": "Sam Jenkins",
+      "incomeType": "OTHER",
+      "otherIncomeType": "Stocks",
+      "grossMonthlyIncome": 99,
+      "payer": "Investment Company"
+    },
+    {
+      "recipientRelationship": "VETERAN",
+      "incomeType": "SOCIAL_SECURITY",
+      "grossMonthlyIncome": 102.33,
+      "payer": "Social Security Administration"
+    },
+    {
+      "recipientRelationship": "SPOUSE",
+      "incomeType": "RETIREMENT_PENSION",
+      "grossMonthlyIncome": 1099.99,
+      "payer": "Pension Benefit Management"
+    },
+    {
+      "recipientRelationship": "PARENT",
+      "recipientName": "Edmund Doe",
+      "incomeType": "CIVIL_SERVICE",
+      "grossMonthlyIncome": 12345.67,
+      "payer": "Personnel Management"
+    }
+  ]
 }

--- a/dist/21P-0969-KITCHEN_SINK-schema.json
+++ b/dist/21P-0969-KITCHEN_SINK-schema.json
@@ -202,9 +202,10 @@
         "type": "object",
         "required": [
           "recipientRelationship",
-          "assetType",
+          "incomeGenerationMethod",
           "grossMonthlyIncome",
-          "payer"
+          "fairMarketValue",
+          "canBeSold"
         ],
         "properties": {
           "recipientName": {

--- a/dist/21P-0969-OVERFLOW-cypress-example.json
+++ b/dist/21P-0969-OVERFLOW-cypress-example.json
@@ -7,6 +7,50 @@
     },
     "veteranSocialSecurityNumber": "333224444",
     "statementOfTruthCertified": true,
-    "statementOfTruthSignature": "John Edmund Doe"
+    "statementOfTruthSignature": "John Edmund Doe",
+    "unassociatedIncomes": [
+      {
+        "recipientRelationship": "CHILD",
+        "recipientName": "Jane Doe",
+        "incomeType": "WAGES",
+        "grossMonthlyIncome": 99999.99,
+        "payer": "Generic Company, LLC"
+      },
+      {
+        "recipientRelationship": "OTHER",
+        "otherRecipientRelationshipType": "Cousin",
+        "recipientName": "Sam Jenkins",
+        "incomeType": "OTHER",
+        "otherIncomeType": "Stocks",
+        "grossMonthlyIncome": 99,
+        "payer": "Investment Company"
+      },
+      {
+        "recipientRelationship": "VETERAN",
+        "incomeType": "SOCIAL_SECURITY",
+        "grossMonthlyIncome": 102.33,
+        "payer": "Social Security Administration"
+      },
+      {
+        "recipientRelationship": "SPOUSE",
+        "incomeType": "RETIREMENT_PENSION",
+        "grossMonthlyIncome": 1099.99,
+        "payer": "Pension Benefit Management"
+      },
+      {
+        "recipientRelationship": "PARENT",
+        "recipientName": "Edmund Doe",
+        "incomeType": "CIVIL_SERVICE",
+        "grossMonthlyIncome": 12345.67,
+        "payer": "Personnel Management"
+      },
+      {
+        "recipientRelationship": "CUSTODIAN",
+        "recipientName": "Sam Doe",
+        "incomeType": "UNEMPLOYMENT",
+        "grossMonthlyIncome": 1000,
+        "payer": "Agency of Unemployment"
+      }
+    ]
   }
 }

--- a/dist/21P-0969-OVERFLOW-example.json
+++ b/dist/21P-0969-OVERFLOW-example.json
@@ -6,5 +6,49 @@
   },
   "veteranSocialSecurityNumber": "333224444",
   "statementOfTruthCertified": true,
-  "statementOfTruthSignature": "John Edmund Doe"
+  "statementOfTruthSignature": "John Edmund Doe",
+  "unassociatedIncomes": [
+    {
+      "recipientRelationship": "CHILD",
+      "recipientName": "Jane Doe",
+      "incomeType": "WAGES",
+      "grossMonthlyIncome": 99999.99,
+      "payer": "Generic Company, LLC"
+    },
+    {
+      "recipientRelationship": "OTHER",
+      "otherRecipientRelationshipType": "Cousin",
+      "recipientName": "Sam Jenkins",
+      "incomeType": "OTHER",
+      "otherIncomeType": "Stocks",
+      "grossMonthlyIncome": 99,
+      "payer": "Investment Company"
+    },
+    {
+      "recipientRelationship": "VETERAN",
+      "incomeType": "SOCIAL_SECURITY",
+      "grossMonthlyIncome": 102.33,
+      "payer": "Social Security Administration"
+    },
+    {
+      "recipientRelationship": "SPOUSE",
+      "incomeType": "RETIREMENT_PENSION",
+      "grossMonthlyIncome": 1099.99,
+      "payer": "Pension Benefit Management"
+    },
+    {
+      "recipientRelationship": "PARENT",
+      "recipientName": "Edmund Doe",
+      "incomeType": "CIVIL_SERVICE",
+      "grossMonthlyIncome": 12345.67,
+      "payer": "Personnel Management"
+    },
+    {
+      "recipientRelationship": "CUSTODIAN",
+      "recipientName": "Sam Doe",
+      "incomeType": "UNEMPLOYMENT",
+      "grossMonthlyIncome": 1000,
+      "payer": "Agency of Unemployment"
+    }
+  ]
 }

--- a/dist/21P-0969-OVERFLOW-schema.json
+++ b/dist/21P-0969-OVERFLOW-schema.json
@@ -202,9 +202,10 @@
         "type": "object",
         "required": [
           "recipientRelationship",
-          "assetType",
+          "incomeGenerationMethod",
           "grossMonthlyIncome",
-          "payer"
+          "fairMarketValue",
+          "canBeSold"
         ],
         "properties": {
           "recipientName": {

--- a/dist/21P-0969-SIMPLE-schema.json
+++ b/dist/21P-0969-SIMPLE-schema.json
@@ -202,9 +202,10 @@
         "type": "object",
         "required": [
           "recipientRelationship",
-          "assetType",
+          "incomeGenerationMethod",
           "grossMonthlyIncome",
-          "payer"
+          "fairMarketValue",
+          "canBeSold"
         ],
         "properties": {
           "recipientName": {

--- a/dist/21P-0969-schema.json
+++ b/dist/21P-0969-schema.json
@@ -202,9 +202,10 @@
         "type": "object",
         "required": [
           "recipientRelationship",
-          "assetType",
+          "incomeGenerationMethod",
           "grossMonthlyIncome",
-          "payer"
+          "fairMarketValue",
+          "canBeSold"
         ],
         "properties": {
           "recipientName": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "24.2.2",
+  "version": "24.2.3",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "24.2.1",
+  "version": "24.2.2",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/schemas/21P-0969-kitchen_sink/example.json
+++ b/src/schemas/21P-0969-kitchen_sink/example.json
@@ -1,12 +1,49 @@
 {
   "data": {
     "veteranFullName": {
-      "first": "John",
-      "middle": "Edmund",
-      "last": "Doe"
-    },
-    "veteranSocialSecurityNumber": "333224444",
-    "statementOfTruthCertified": true,
-    "statementOfTruthSignature": "John Edmund Doe"
+    "first": "John",
+    "middle": "Edmund",
+    "last": "Doe"
+  },
+  "veteranSocialSecurityNumber": "333224444",
+  "statementOfTruthCertified": true,
+  "statementOfTruthSignature": "John Edmund Doe",
+    "unassociatedIncomes": [
+        {
+            "recipientRelationship": "CHILD",
+            "recipientName": "Jane Doe",
+            "incomeType": "WAGES",
+            "grossMonthlyIncome": 99999.99,
+            "payer": "Generic Company, LLC"
+        },
+        {
+            "recipientRelationship": "OTHER",
+            "otherRecipientRelationshipType": "Cousin",
+            "recipientName": "Sam Jenkins",
+            "incomeType": "OTHER",
+            "otherIncomeType": "Stocks",
+            "grossMonthlyIncome": 99,
+            "payer": "Investment Company"
+        },
+        {
+            "recipientRelationship": "VETERAN",
+            "incomeType": "SOCIAL_SECURITY",
+            "grossMonthlyIncome": 102.33,
+            "payer": "Social Security Administration"
+        },
+        {
+            "recipientRelationship": "SPOUSE",
+            "incomeType": "RETIREMENT_PENSION",
+            "grossMonthlyIncome": 1099.99,
+            "payer": "Pension Benefit Management"
+        },
+        {
+            "recipientRelationship": "PARENT",
+            "recipientName": "Edmund Doe",
+            "incomeType": "CIVIL_SERVICE",
+            "grossMonthlyIncome": 12345.67,
+            "payer": "Personnel Management"
+        }
+    ]
   }
 }

--- a/src/schemas/21P-0969-overflow/example.json
+++ b/src/schemas/21P-0969-overflow/example.json
@@ -1,12 +1,56 @@
 {
   "data": {
     "veteranFullName": {
-      "first": "John",
-      "middle": "Edmund",
-      "last": "Doe"
-    },
-    "veteranSocialSecurityNumber": "333224444",
-    "statementOfTruthCertified": true,
-    "statementOfTruthSignature": "John Edmund Doe"
+    "first": "John",
+    "middle": "Edmund",
+    "last": "Doe"
+  },
+  "veteranSocialSecurityNumber": "333224444",
+  "statementOfTruthCertified": true,
+  "statementOfTruthSignature": "John Edmund Doe",
+    "unassociatedIncomes": [
+        {
+            "recipientRelationship": "CHILD",
+            "recipientName": "Jane Doe",
+            "incomeType": "WAGES",
+            "grossMonthlyIncome": 99999.99,
+            "payer": "Generic Company, LLC"
+        },
+        {
+            "recipientRelationship": "OTHER",
+            "otherRecipientRelationshipType": "Cousin",
+            "recipientName": "Sam Jenkins",
+            "incomeType": "OTHER",
+            "otherIncomeType": "Stocks",
+            "grossMonthlyIncome": 99,
+            "payer": "Investment Company"
+        },
+        {
+            "recipientRelationship": "VETERAN",
+            "incomeType": "SOCIAL_SECURITY",
+            "grossMonthlyIncome": 102.33,
+            "payer": "Social Security Administration"
+        },
+        {
+            "recipientRelationship": "SPOUSE",
+            "incomeType": "RETIREMENT_PENSION",
+            "grossMonthlyIncome": 1099.99,
+            "payer": "Pension Benefit Management"
+        },
+        {
+            "recipientRelationship": "PARENT",
+            "recipientName": "Edmund Doe",
+            "incomeType": "CIVIL_SERVICE",
+            "grossMonthlyIncome": 12345.67,
+            "payer": "Personnel Management"
+        },
+        {
+          "recipientRelationship": "CUSTODIAN",
+          "recipientName": "Sam Doe",
+          "incomeType": "UNEMPLOYMENT",
+          "grossMonthlyIncome": 1000.00,
+          "payer": "Agency of Unemployment"
+      }
+    ]
   }
 }

--- a/src/schemas/21P-0969/schema.js
+++ b/src/schemas/21P-0969/schema.js
@@ -105,7 +105,13 @@ const schema = {
       type: 'array',
       items: {
         type: 'object',
-        required: ['recipientRelationship', 'assetType', 'grossMonthlyIncome', 'payer'],
+        required: [
+          'recipientRelationship',
+          'incomeGenerationMethod',
+          'grossMonthlyIncome',
+          'fairMarketValue',
+          'canBeSold',
+        ],
         properties: {
           recipientName: { type: 'string' },
           recipientRelationship: schemaHelpers.getDefinition('relationshipToVeteran'),


### PR DESCRIPTION
# Updated schema

Adds data for unassociated income to 21P-0969 in order to enable PDF mapping tests.
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82564
The schema for 21P-0969 royalties income listed the incorrect required fields; this has been updated to match the vets-website required fields.
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86362

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
