### PR TITLE
Updated fixtures to include section 1 and 2 sample data

### DIFF
--- a/dist/21P-0969-KITCHEN_SINK-cypress-example.json
+++ b/dist/21P-0969-KITCHEN_SINK-cypress-example.json
@@ -1,11 +1,24 @@
 {
   "data": {
+    "vaFileNumber": "123456789",
     "veteranFullName": {
       "first": "John",
       "middle": "Edmund",
       "last": "Doe"
     },
     "veteranSocialSecurityNumber": "333224444",
+    "claimantFullName": {
+      "first": "Jane",
+      "middle": "Elizabeth",
+      "last": "Doe"
+    },
+    "claimantSocialSecurityNumber": "333224445",
+    "claimantPhone": "5552345555",
+    "claimantType": "SPOUSE",
+    "incomeNetWorthDateRange": {
+      "from": "2020-01-01",
+      "to": "2020-12-31"
+    },
     "statementOfTruthCertified": true,
     "statementOfTruthSignature": "John Edmund Doe",
     "unassociatedIncomes": [

--- a/dist/21P-0969-KITCHEN_SINK-example.json
+++ b/dist/21P-0969-KITCHEN_SINK-example.json
@@ -1,10 +1,23 @@
 {
+  "vaFileNumber": "123456789",
   "veteranFullName": {
     "first": "John",
     "middle": "Edmund",
     "last": "Doe"
   },
   "veteranSocialSecurityNumber": "333224444",
+  "claimantFullName": {
+    "first": "Jane",
+    "middle": "Elizabeth",
+    "last": "Doe"
+  },
+  "claimantSocialSecurityNumber": "333224445",
+  "claimantPhone": "5552345555",
+  "claimantType": "SPOUSE",
+  "incomeNetWorthDateRange": {
+    "from": "2020-01-01",
+    "to": "2020-12-31"
+  },
   "statementOfTruthCertified": true,
   "statementOfTruthSignature": "John Edmund Doe",
   "unassociatedIncomes": [

--- a/dist/21P-0969-OVERFLOW-cypress-example.json
+++ b/dist/21P-0969-OVERFLOW-cypress-example.json
@@ -1,11 +1,24 @@
 {
   "data": {
+    "vaFileNumber": "123456789",
     "veteranFullName": {
       "first": "John",
       "middle": "Edmund",
       "last": "Doe"
     },
     "veteranSocialSecurityNumber": "333224444",
+    "claimantFullName": {
+      "first": "Jane",
+      "middle": "Elizabeth",
+      "last": "Doe"
+    },
+    "claimantSocialSecurityNumber": "333224445",
+    "claimantPhone": "5552345555",
+    "claimantType": "SPOUSE",
+    "incomeNetWorthDateRange": {
+      "from": "2020-01-01",
+      "to": "2020-12-31"
+    },
     "statementOfTruthCertified": true,
     "statementOfTruthSignature": "John Edmund Doe",
     "unassociatedIncomes": [

--- a/dist/21P-0969-OVERFLOW-example.json
+++ b/dist/21P-0969-OVERFLOW-example.json
@@ -1,10 +1,23 @@
 {
+  "vaFileNumber": "123456789",
   "veteranFullName": {
     "first": "John",
     "middle": "Edmund",
     "last": "Doe"
   },
   "veteranSocialSecurityNumber": "333224444",
+  "claimantFullName": {
+    "first": "Jane",
+    "middle": "Elizabeth",
+    "last": "Doe"
+  },
+  "claimantSocialSecurityNumber": "333224445",
+  "claimantPhone": "5552345555",
+  "claimantType": "SPOUSE",
+  "incomeNetWorthDateRange": {
+    "from": "2020-01-01",
+    "to": "2020-12-31"
+  },
   "statementOfTruthCertified": true,
   "statementOfTruthSignature": "John Edmund Doe",
   "unassociatedIncomes": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "24.2.6",
+  "version": "24.2.7",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/schemas/21P-0969-kitchen_sink/example.json
+++ b/src/schemas/21P-0969-kitchen_sink/example.json
@@ -1,49 +1,62 @@
 {
   "data": {
+    "vaFileNumber": "123456789",
     "veteranFullName": {
-    "first": "John",
-    "middle": "Edmund",
-    "last": "Doe"
-  },
-  "veteranSocialSecurityNumber": "333224444",
-  "statementOfTruthCertified": true,
-  "statementOfTruthSignature": "John Edmund Doe",
+      "first": "John",
+      "middle": "Edmund",
+      "last": "Doe"
+    },
+    "veteranSocialSecurityNumber": "333224444",
+    "claimantFullName": {
+      "first": "Jane",
+      "middle": "Elizabeth",
+      "last": "Doe"
+    },
+    "claimantSocialSecurityNumber": "333224445",
+    "claimantPhone": "5552345555",
+    "claimantType": "SPOUSE",
+    "incomeNetWorthDateRange": {
+      "from": "2020-01-01",
+      "to": "2020-12-31"
+    },
+    "statementOfTruthCertified": true,
+    "statementOfTruthSignature": "John Edmund Doe",
     "unassociatedIncomes": [
-        {
-            "recipientRelationship": "CHILD",
-            "recipientName": "Jane Doe",
-            "incomeType": "WAGES",
-            "grossMonthlyIncome": 99999.99,
-            "payer": "Generic Company, LLC"
-        },
-        {
-            "recipientRelationship": "OTHER",
-            "otherRecipientRelationshipType": "Cousin",
-            "recipientName": "Sam Jenkins",
-            "incomeType": "OTHER",
-            "otherIncomeType": "Stocks",
-            "grossMonthlyIncome": 99,
-            "payer": "Investment Company"
-        },
-        {
-            "recipientRelationship": "VETERAN",
-            "incomeType": "SOCIAL_SECURITY",
-            "grossMonthlyIncome": 102.33,
-            "payer": "Social Security Administration"
-        },
-        {
-            "recipientRelationship": "SPOUSE",
-            "incomeType": "RETIREMENT_PENSION",
-            "grossMonthlyIncome": 1099.99,
-            "payer": "Pension Benefit Management"
-        },
-        {
-            "recipientRelationship": "PARENT",
-            "recipientName": "Edmund Doe",
-            "incomeType": "CIVIL_SERVICE",
-            "grossMonthlyIncome": 12345.67,
-            "payer": "Personnel Management"
-        }
+      {
+          "recipientRelationship": "CHILD",
+          "recipientName": "Jane Doe",
+          "incomeType": "WAGES",
+          "grossMonthlyIncome": 99999.99,
+          "payer": "Generic Company, LLC"
+      },
+      {
+          "recipientRelationship": "OTHER",
+          "otherRecipientRelationshipType": "Cousin",
+          "recipientName": "Sam Jenkins",
+          "incomeType": "OTHER",
+          "otherIncomeType": "Stocks",
+          "grossMonthlyIncome": 99,
+          "payer": "Investment Company"
+      },
+      {
+          "recipientRelationship": "VETERAN",
+          "incomeType": "SOCIAL_SECURITY",
+          "grossMonthlyIncome": 102.33,
+          "payer": "Social Security Administration"
+      },
+      {
+          "recipientRelationship": "SPOUSE",
+          "incomeType": "RETIREMENT_PENSION",
+          "grossMonthlyIncome": 1099.99,
+          "payer": "Pension Benefit Management"
+      },
+      {
+          "recipientRelationship": "PARENT",
+          "recipientName": "Edmund Doe",
+          "incomeType": "CIVIL_SERVICE",
+          "grossMonthlyIncome": 12345.67,
+          "payer": "Personnel Management"
+      }
     ]
   }
 }

--- a/src/schemas/21P-0969-overflow/example.json
+++ b/src/schemas/21P-0969-overflow/example.json
@@ -1,55 +1,68 @@
 {
   "data": {
+    "vaFileNumber": "123456789",
     "veteranFullName": {
-    "first": "John",
-    "middle": "Edmund",
-    "last": "Doe"
-  },
-  "veteranSocialSecurityNumber": "333224444",
-  "statementOfTruthCertified": true,
-  "statementOfTruthSignature": "John Edmund Doe",
+      "first": "John",
+      "middle": "Edmund",
+      "last": "Doe"
+    },
+    "veteranSocialSecurityNumber": "333224444",
+    "claimantFullName": {
+      "first": "Jane",
+      "middle": "Elizabeth",
+      "last": "Doe"
+    },
+    "claimantSocialSecurityNumber": "333224445",
+    "claimantPhone": "5552345555",
+    "claimantType": "SPOUSE",
+    "incomeNetWorthDateRange": {
+      "from": "2020-01-01",
+      "to": "2020-12-31"
+    },
+    "statementOfTruthCertified": true,
+    "statementOfTruthSignature": "John Edmund Doe",
     "unassociatedIncomes": [
-        {
-            "recipientRelationship": "CHILD",
-            "recipientName": "Jane Doe",
-            "incomeType": "WAGES",
-            "grossMonthlyIncome": 99999.99,
-            "payer": "Generic Company, LLC"
-        },
-        {
-            "recipientRelationship": "OTHER",
-            "otherRecipientRelationshipType": "Cousin",
-            "recipientName": "Sam Jenkins",
-            "incomeType": "OTHER",
-            "otherIncomeType": "Stocks",
-            "grossMonthlyIncome": 99,
-            "payer": "Investment Company"
-        },
-        {
-            "recipientRelationship": "VETERAN",
-            "incomeType": "SOCIAL_SECURITY",
-            "grossMonthlyIncome": 102.33,
-            "payer": "Social Security Administration"
-        },
-        {
-            "recipientRelationship": "SPOUSE",
-            "incomeType": "RETIREMENT_PENSION",
-            "grossMonthlyIncome": 1099.99,
-            "payer": "Pension Benefit Management"
-        },
-        {
-            "recipientRelationship": "PARENT",
-            "recipientName": "Edmund Doe",
-            "incomeType": "CIVIL_SERVICE",
-            "grossMonthlyIncome": 12345.67,
-            "payer": "Personnel Management"
-        },
-        {
-          "recipientRelationship": "CUSTODIAN",
-          "recipientName": "Sam Doe",
-          "incomeType": "UNEMPLOYMENT",
-          "grossMonthlyIncome": 1000.00,
-          "payer": "Agency of Unemployment"
+      {
+          "recipientRelationship": "CHILD",
+          "recipientName": "Jane Doe",
+          "incomeType": "WAGES",
+          "grossMonthlyIncome": 99999.99,
+          "payer": "Generic Company, LLC"
+      },
+      {
+          "recipientRelationship": "OTHER",
+          "otherRecipientRelationshipType": "Cousin",
+          "recipientName": "Sam Jenkins",
+          "incomeType": "OTHER",
+          "otherIncomeType": "Stocks",
+          "grossMonthlyIncome": 99,
+          "payer": "Investment Company"
+      },
+      {
+          "recipientRelationship": "VETERAN",
+          "incomeType": "SOCIAL_SECURITY",
+          "grossMonthlyIncome": 102.33,
+          "payer": "Social Security Administration"
+      },
+      {
+          "recipientRelationship": "SPOUSE",
+          "incomeType": "RETIREMENT_PENSION",
+          "grossMonthlyIncome": 1099.99,
+          "payer": "Pension Benefit Management"
+      },
+      {
+          "recipientRelationship": "PARENT",
+          "recipientName": "Edmund Doe",
+          "incomeType": "CIVIL_SERVICE",
+          "grossMonthlyIncome": 12345.67,
+          "payer": "Personnel Management"
+      },
+      {
+        "recipientRelationship": "CUSTODIAN",
+        "recipientName": "Sam Doe",
+        "incomeType": "UNEMPLOYMENT",
+        "grossMonthlyIncome": 1000.00,
+        "payer": "Agency of Unemployment"
       }
     ]
   }


### PR DESCRIPTION
Updated test fixtures for the 0969 income and assets form that includes sample data for sections 1 and 2.

_Please ensure you have incremented the version in_ `package.json`.

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82563

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
