### PR TITLE
Fix Lodash Pick Method Parameters for 28-1900 schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "24.2.8",
+  "version": "24.2.9",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/schemas/28-1900/schema.js
+++ b/src/schemas/28-1900/schema.js
@@ -9,7 +9,7 @@ const schema = {
   title: 'DISABLED VETERANS APPLICATION FOR VOCATIONAL REHABILITATION (28-1900)',
   type: 'object',
   additionalProperties: true,
-  definitions: pick(definitions, 'date', 'fullName', 'phone', 'email', 'profileAddress'),
+  definitions: pick(definitions, ['date', 'fullName', 'phone', 'email', 'profileAddress']),
   properties: {
     veteranInformation: {
       type: 'object',


### PR DESCRIPTION
# New schema
This simply fixes how the definitions were being added into the 28-1900 schema, the pick method was missing the enclosing array brackets for the definitions being added.

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92840

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
