### PR TITLE
VEBT-750: 22-10282 - Modify default option for Country selected

### DIFF
--- a/dist/22-10282-schema.json
+++ b/dist/22-10282-schema.json
@@ -49,6 +49,7 @@
     "country": {
       "type": "string",
       "enum": [
+        "United States",
         "Afghanistan",
         "Aland Islands",
         "Albania",
@@ -276,7 +277,6 @@
         "Ukraine",
         "United Arab Emirates",
         "United Kingdom",
-        "United States",
         "Uruguay",
         "Uzbekistan",
         "Vanuatu",
@@ -288,7 +288,8 @@
         "Yemen",
         "Zambia",
         "Zimbabwe"
-      ]
+      ],
+      "default": "United States"
     },
     "state": {
       "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "24.5.1",
+  "version": "24.5.2",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# New schema

This PR reflects changes in the latest `vets-json-schema` build for the 22-10282 Form
- The default country selection should be `United States`
- This option should also be shown at the top of the dropdown list

- https://jira.devops.va.gov/browse/VEBT-750

**As a...**

VEBT Developer

**I want…**

To modify default option for Country selected

**So that…**

It remains consistent with other forms

**Acceptance Criteria**

Requires two changes to the Country drop-down.

Change 1 - Modify default option for Country selected as United States instead of "select".
Change 2 - Make 'United States' appear as the first option in the Drop-down. Currently the user has to scroll down to "U".

**Technical Details:**

Dependencies: No

Feature Flag needed: Yes

Demo needed: No

UAT needed: No

Additional Notes: 

**Testing Details:**

(  ) Quick Turn Around/Direct to Production

( X ) Remains in Staging

(  ) Staging Environment unavailable, coordinate w/ developer

**Requested by and when:**

Team, 10/15

**Definition of Done:** 

( )  Demo/UAT completed with EDU

(  )  Passed all internal testing in Staging

( )  Passed all internal testing in Production

(  )  All work documented in Jira ticket

_Please ensure you have incremented the version in_ `package.json`.

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-website/pull/32726
