### PR TITLE
Pre-need and pre-need-integration ssn changes

### DIFF
--- a/dist/40-10007-INTEGRATION-schema.json
+++ b/dist/40-10007-INTEGRATION-schema.json
@@ -291,7 +291,7 @@
     },
     "ssn": {
       "type": "string",
-      "pattern": "^\\d{3}-\\d{2}-\\d{4}$"
+      "pattern": "^\\d{3}\\d{2}\\d{4}$"
     },
     "centralMailVaFile": {
       "type": "string",

--- a/dist/40-10007-schema.json
+++ b/dist/40-10007-schema.json
@@ -291,7 +291,7 @@
     },
     "ssn": {
       "type": "string",
-      "pattern": "^\\d{3}-\\d{2}-\\d{4}$"
+      "pattern": "^\\d{3}\\d{2}\\d{4}$"
     },
     "centralMailVaFile": {
       "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "24.5.2",
+  "version": "24.5.3",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/schemas/40-10007-integration/schema.js
+++ b/src/schemas/40-10007-integration/schema.js
@@ -186,7 +186,7 @@ definitions.phone.minLength = 10;
 definitions.phone.maxLength = 20;
 definitions.phone.pattern = '^(?:\\D*\\d){10,15}\\D*$';
 
-definitions.ssn.pattern = '^\\d{3}-\\d{2}-\\d{4}$';
+definitions.ssn.pattern = '^\\d{3}\\d{2}\\d{4}$';
 
 definitions.ethnicity = {
   type: 'string',

--- a/src/schemas/40-10007/schema.js
+++ b/src/schemas/40-10007/schema.js
@@ -185,7 +185,7 @@ definitions.phone.minLength = 10;
 definitions.phone.maxLength = 20;
 definitions.phone.pattern = '^(?:\\D*\\d){10,15}\\D*$';
 
-definitions.ssn.pattern = '^\\d{3}-\\d{2}-\\d{4}$';
+definitions.ssn.pattern = '^\\d{3}\\d{2}\\d{4}$';
 
 definitions.race = {
   type: 'object',

--- a/test/schemas/40-10007/schema.spec.js
+++ b/test/schemas/40-10007/schema.spec.js
@@ -29,7 +29,7 @@ describe('preneeds schema', () => {
   });
 
   schemaTestHelper.testValidAndInvalid('application.claimant.ssn', {
-    valid: ['000-12-3456'],
+    valid: ['000123456'],
     invalid: ['bad'],
   });
 


### PR DESCRIPTION
# New schema
The new Social Secutiy Number (SSN) Web Component Strips the data input of `-` characters. This update in schema updates the pre-need and pre-need integration forms with the correct data pattern for the SSN.

_Please ensure you have incremented the version in_ `package.json`.

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/32895
