### PR TITLE
Add script dir to packaged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "main": "dist/schemas.js",
   "files": [
-    "dist"
+    "dist",
+    "scripts"
   ],
   "devDependencies": {
     "@babel/core": "^7.18.10",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "main": "dist/schemas.js",
   "files": [
     "dist",
-    "scripts"
+    "script"
   ],
   "devDependencies": {
     "@babel/core": "^7.18.10",


### PR DESCRIPTION
## Summary

This adds the `script` directory to the files that will be installed. This is necessary because the `postinstall` command relies on the check-node-version script in that directory. (We did not run into this before because older versions of yarn apparently don't respect the `files` field in `package.json`.

## Related Issues

Slack thread: https://dsva.slack.com/archives/C07V6D8L4GK/p1732111243756289