### PR TITLE
Fixing version numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "24.6.3",
+  "version": "24.7.0",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# New schema
Two commits went in that updated to the same version number. Updating the package.json to reflect that change hoping it will fix some CI issues on `vets-website`. 

- [PR A](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/965/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R3)
- [PR B](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/964/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R3) (this one included a new schema so I bumped the minor version number to capture that)

_Please ensure you have incremented the version in_ `package.json`.

- [Slack thread that prompted this change](https://dsva.slack.com/archives/CBU0KDSB1/p1734014554176849?thread_ts=1733761378.310059&cid=CBU0KDSB1)

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
  - TBD
- https://github.com/department-of-veterans-affairs/vets-website/pull/33495
