### PR TITLE
Update schema definitions for 21-4142 form

### DIFF
--- a/dist/21-4142-schema.json
+++ b/dist/21-4142-schema.json
@@ -878,6 +878,7 @@
     },
     "providerFacility": {
       "type": "array",
+      "maxItems": 5,
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -889,31 +890,33 @@
             "type": "string"
           },
           "treatmentDateRange": {
-            "type": "object",
-            "properties": {
-              "from": {
-                "$ref": "#/definitions/date"
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "from": {
+                  "$ref": "#/definitions/date"
+                },
+                "to": {
+                  "$ref": "#/definitions/date"
+                }
               },
-              "to": {
-                "$ref": "#/definitions/date"
-              }
-            },
-            "required": [
-              "from",
-              "to"
-            ]
+              "required": [
+                "from",
+                "to"
+              ]
+            }
           },
           "providerFacilityAddress": {
             "$ref": "#/definitions/address"
           }
-        }
-      },
-      "required": [
-        "conditionsTreated",
-        "providerFacilityName",
-        "treatmentDateRange",
-        "providerFacilityAddress"
-      ]
+        },
+        "required": [
+          "providerFacilityName",
+          "treatmentDateRange",
+          "providerFacilityAddress"
+        ]
+      }
     },
     "acknowledgeToReleaseInformation": {
       "$ref": "#/definitions/privacyAgreementAccepted"
@@ -952,11 +955,7 @@
     }
   },
   "required": [
-    "veteran",
-    "patientIdentification",
-    "acknowledgeToReleaseInformation",
     "providerFacility",
-    "preparerIdentification",
     "privacyAgreementAccepted"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "24.7.5",
+  "version": "24.8.0",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/schemas/21-4142/schema.js
+++ b/src/schemas/21-4142/schema.js
@@ -82,6 +82,7 @@ const schema = {
     },
     providerFacility: {
       type: 'array',
+      maxItems: 5,
       items: {
         type: 'object',
         additionalProperties: false,
@@ -93,23 +94,26 @@ const schema = {
             type: 'string',
           },
           treatmentDateRange: {
-            type: 'object',
-            properties: {
-              from: {
-                $ref: '#/definitions/date',
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                from: {
+                  $ref: '#/definitions/date',
+                },
+                to: {
+                  $ref: '#/definitions/date',
+                },
               },
-              to: {
-                $ref: '#/definitions/date',
-              },
+              required: ['from', 'to'],
             },
-            required: ['from', 'to'],
           },
           providerFacilityAddress: {
             $ref: '#/definitions/address',
           },
         },
+        required: ['providerFacilityName', 'treatmentDateRange', 'providerFacilityAddress'],
       },
-      required: ['conditionsTreated', 'providerFacilityName', 'treatmentDateRange', 'providerFacilityAddress'],
     },
     acknowledgeToReleaseInformation: {
       $ref: '#/definitions/privacyAgreementAccepted',
@@ -145,14 +149,7 @@ const schema = {
       required: ['relationshipToVeteran'],
     },
   },
-  required: [
-    'veteran',
-    'patientIdentification',
-    'acknowledgeToReleaseInformation',
-    'providerFacility',
-    'preparerIdentification',
-    'privacyAgreementAccepted',
-  ],
+  required: ['providerFacility', 'privacyAgreementAccepted'],
 };
 
 export default schema;

--- a/test/schemas/21-4142/schema.spec.js
+++ b/test/schemas/21-4142/schema.spec.js
@@ -114,7 +114,7 @@ describe('21-4142 Authorization to Disclose Information json-schema', () => {
         {
           providerFacilityName: 'Test',
           providerFacilityAddress: usAddressFixture,
-          treatmentDateRange: fixtures.dateRange,
+          treatmentDateRange: [fixtures.dateRange],
           conditionsTreated: 'Test',
         },
       ],


### PR DESCRIPTION
# New schema
This PR makes the following changes to ensure consistency between the vets-website frontend and vets-api PDF filler:
- Set a maximum of 5 items on `providerFacility` (PDF limitation)
- Changed `treatmentDateRange` to be an array
- Removed some properties from the required lists to better align with the form4142 JSON payload shape

- [x] _Please ensure you have incremented the version in_ `package.json`.

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
