### PR TITLE
Upgrade to latest actions/cache GitHub Action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/yarn


### PR DESCRIPTION
actions/cache v2 is deprecated. See https://github.com/actions/cache/discussions/1510
