### PR TITLE
Form 4142: Remove providerFacility maxItems

### DIFF
--- a/dist/21-4142-schema.json
+++ b/dist/21-4142-schema.json
@@ -889,19 +889,22 @@
             "type": "string"
           },
           "treatmentDateRange": {
-            "type": "object",
-            "properties": {
-              "from": {
-                "$ref": "#/definitions/date"
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "from": {
+                  "$ref": "#/definitions/date"
+                },
+                "to": {
+                  "$ref": "#/definitions/date"
+                }
               },
-              "to": {
-                "$ref": "#/definitions/date"
-              }
-            },
-            "required": [
-              "from",
-              "to"
-            ]
+              "required": [
+                "from",
+                "to"
+              ]
+            }
           },
           "providerFacilityAddress": {
             "$ref": "#/definitions/address"

--- a/dist/SC-CREATE-REQUEST-BODY-FOR-VA-GOV-example.json
+++ b/dist/SC-CREATE-REQUEST-BODY-FOR-VA-GOV-example.json
@@ -7,12 +7,12 @@
         "providerFacilityName": "provider 1",
         "treatmentDateRange": [
           {
-            "from": "1980-1-1",
-            "to": "1985-1-1"
+            "from": "1980-01-01",
+            "to": "1985-01-01"
           },
           {
-            "from": "1986-1-1",
-            "to": "1987-1-1"
+            "from": "1986-01-01",
+            "to": "1987-01-01"
           }
         ],
         "providerFacilityAddress": {
@@ -28,12 +28,12 @@
         "providerFacilityName": "provider 2",
         "treatmentDateRange": [
           {
-            "from": "1980-2-1",
-            "to": "1985-2-1"
+            "from": "1980-02-01",
+            "to": "1985-02-01"
           },
           {
-            "from": "1986-2-1",
-            "to": "1987-2-1"
+            "from": "1986-02-01",
+            "to": "1987-02-01"
           }
         ],
         "providerFacilityAddress": {
@@ -49,12 +49,12 @@
         "providerFacilityName": "provider 3",
         "treatmentDateRange": [
           {
-            "from": "1980-3-1",
-            "to": "1985-3-1"
+            "from": "1980-03-01",
+            "to": "1985-03-01"
           },
           {
-            "from": "1986-3-1",
-            "to": "1987-3-1"
+            "from": "1986-03-01",
+            "to": "1987-03-01"
           }
         ],
         "providerFacilityAddress": {
@@ -70,12 +70,12 @@
         "providerFacilityName": "provider 4",
         "treatmentDateRange": [
           {
-            "from": "1980-4-1",
-            "to": "1985-4-1"
+            "from": "1980-04-01",
+            "to": "1985-04-01"
           },
           {
-            "from": "1986-4-1",
-            "to": "1987-4-1"
+            "from": "1986-04-01",
+            "to": "1987-04-01"
           }
         ],
         "providerFacilityAddress": {
@@ -91,12 +91,12 @@
         "providerFacilityName": "provider 5",
         "treatmentDateRange": [
           {
-            "from": "1980-5-1",
-            "to": "1985-5-1"
+            "from": "1980-05-01",
+            "to": "1985-05-01"
           },
           {
-            "from": "1986-5-1",
-            "to": "1987-5-1"
+            "from": "1986-05-01",
+            "to": "1987-05-01"
           }
         ],
         "providerFacilityAddress": {

--- a/src/schemas/21-4142/schema.js
+++ b/src/schemas/21-4142/schema.js
@@ -93,16 +93,19 @@ const schema = {
             type: 'string',
           },
           treatmentDateRange: {
-            type: 'object',
-            properties: {
-              from: {
-                $ref: '#/definitions/date',
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                from: {
+                  $ref: '#/definitions/date',
+                },
+                to: {
+                  $ref: '#/definitions/date',
+                },
               },
-              to: {
-                $ref: '#/definitions/date',
-              },
+              required: ['from', 'to'],
             },
-            required: ['from', 'to'],
           },
           providerFacilityAddress: {
             $ref: '#/definitions/address',

--- a/test/schemas/21-4142/schema.spec.js
+++ b/test/schemas/21-4142/schema.spec.js
@@ -114,7 +114,7 @@ describe('21-4142 Authorization to Disclose Information json-schema', () => {
         {
           providerFacilityName: 'Test',
           providerFacilityAddress: usAddressFixture,
-          treatmentDateRange: fixtures.dateRange,
+          treatmentDateRange: [fixtures.dateRange],
           conditionsTreated: 'Test',
         },
       ],


### PR DESCRIPTION
# New schema
PR #973 made an incorrect assumption that there should be a maximum of 5 items on `providerFacility`, when in fact those items are stored in a PDF overflow page. This PR reverses that max limit.

- [x] _Please ensure you have incremented the version in_ `package.json`.

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/20873
- https://github.com/department-of-veterans-affairs/vets-website/pull/
