### PR TITLE
Update 0969 schema

### DIFF
--- a/dist/21P-0969-KITCHEN_SINK-cypress-example.json
+++ b/dist/21P-0969-KITCHEN_SINK-cypress-example.json
@@ -76,6 +76,30 @@
         "recipientRelationship": "OTHER",
         "otherRecipientRelationshipType": "Friend"
       }
+    ],
+    "ownedAssets": [
+      {
+        "assetType": "FARM",
+        "grossMonthlyIncome": 5555.55,
+        "ownedPortionValue": 5555555.55,
+        "recipientName": "Jim Brown",
+        "recipientRelationship": "CUSTODIAN"
+      },
+      {
+        "assetType": "BUSINESS",
+        "grossMonthlyIncome": 999.99,
+        "ownedPortionValue": 10000,
+        "recipientName": "Brandon Jones",
+        "recipientRelationship": "OTHER",
+        "otherRecipientRelationshipType": "Friend"
+      },
+      {
+        "assetType": "RENTAL_PROPERTY",
+        "grossMonthlyIncome": 123.45,
+        "ownedPortionValue": 12345.67,
+        "recipientName": "Edmund Doe",
+        "recipientRelationship": "PARENT"
+      }
     ]
   }
 }

--- a/dist/21P-0969-KITCHEN_SINK-example.json
+++ b/dist/21P-0969-KITCHEN_SINK-example.json
@@ -75,5 +75,29 @@
       "recipientRelationship": "OTHER",
       "otherRecipientRelationshipType": "Friend"
     }
+  ],
+  "ownedAssets": [
+    {
+      "assetType": "FARM",
+      "grossMonthlyIncome": 5555.55,
+      "ownedPortionValue": 5555555.55,
+      "recipientName": "Jim Brown",
+      "recipientRelationship": "CUSTODIAN"
+    },
+    {
+      "assetType": "BUSINESS",
+      "grossMonthlyIncome": 999.99,
+      "ownedPortionValue": 10000,
+      "recipientName": "Brandon Jones",
+      "recipientRelationship": "OTHER",
+      "otherRecipientRelationshipType": "Friend"
+    },
+    {
+      "assetType": "RENTAL_PROPERTY",
+      "grossMonthlyIncome": 123.45,
+      "ownedPortionValue": 12345.67,
+      "recipientName": "Edmund Doe",
+      "recipientRelationship": "PARENT"
+    }
   ]
 }

--- a/dist/21P-0969-KITCHEN_SINK-schema.json
+++ b/dist/21P-0969-KITCHEN_SINK-schema.json
@@ -158,8 +158,7 @@
         "required": [
           "recipientRelationship",
           "assetType",
-          "grossMonthlyIncome",
-          "payer"
+          "grossMonthlyIncome"
         ],
         "properties": {
           "recipientName": {
@@ -179,15 +178,9 @@
               "RENTAL_PROPERTY"
             ]
           },
-          "otherIncomeType": {
-            "type": "string"
-          },
           "grossMonthlyIncome": {
             "type": "number",
             "default": 0
-          },
-          "payer": {
-            "type": "string"
           },
           "ownedPortionValue": {
             "type": "number",

--- a/dist/21P-0969-OVERFLOW-cypress-example.json
+++ b/dist/21P-0969-OVERFLOW-cypress-example.json
@@ -107,6 +107,37 @@
         "recipientName": "Rand Lincoln",
         "recipientRelationship": "CHILD"
       }
+    ],
+    "ownedAssets": [
+      {
+        "assetType": "FARM",
+        "grossMonthlyIncome": 5555.55,
+        "ownedPortionValue": 5555555.55,
+        "recipientName": "Jim Brown",
+        "recipientRelationship": "CUSTODIAN"
+      },
+      {
+        "assetType": "BUSINESS",
+        "grossMonthlyIncome": 999.99,
+        "ownedPortionValue": 10000,
+        "recipientName": "Brandon Jones",
+        "recipientRelationship": "OTHER",
+        "otherRecipientRelationshipType": "Friend"
+      },
+      {
+        "assetType": "RENTAL_PROPERTY",
+        "grossMonthlyIncome": 123.45,
+        "ownedPortionValue": 12345.67,
+        "recipientName": "Edmund Doe",
+        "recipientRelationship": "PARENT"
+      },
+      {
+        "assetType": "FARM",
+        "grossMonthlyIncome": 1000,
+        "ownedPortionValue": 12345.67,
+        "recipientName": "Jim Brown",
+        "recipientRelationship": "CUSTODIAN"
+      }
     ]
   }
 }

--- a/dist/21P-0969-OVERFLOW-example.json
+++ b/dist/21P-0969-OVERFLOW-example.json
@@ -106,5 +106,36 @@
       "recipientName": "Rand Lincoln",
       "recipientRelationship": "CHILD"
     }
+  ],
+  "ownedAssets": [
+    {
+      "assetType": "FARM",
+      "grossMonthlyIncome": 5555.55,
+      "ownedPortionValue": 5555555.55,
+      "recipientName": "Jim Brown",
+      "recipientRelationship": "CUSTODIAN"
+    },
+    {
+      "assetType": "BUSINESS",
+      "grossMonthlyIncome": 999.99,
+      "ownedPortionValue": 10000,
+      "recipientName": "Brandon Jones",
+      "recipientRelationship": "OTHER",
+      "otherRecipientRelationshipType": "Friend"
+    },
+    {
+      "assetType": "RENTAL_PROPERTY",
+      "grossMonthlyIncome": 123.45,
+      "ownedPortionValue": 12345.67,
+      "recipientName": "Edmund Doe",
+      "recipientRelationship": "PARENT"
+    },
+    {
+      "assetType": "FARM",
+      "grossMonthlyIncome": 1000,
+      "ownedPortionValue": 12345.67,
+      "recipientName": "Jim Brown",
+      "recipientRelationship": "CUSTODIAN"
+    }
   ]
 }

--- a/dist/21P-0969-OVERFLOW-schema.json
+++ b/dist/21P-0969-OVERFLOW-schema.json
@@ -158,8 +158,7 @@
         "required": [
           "recipientRelationship",
           "assetType",
-          "grossMonthlyIncome",
-          "payer"
+          "grossMonthlyIncome"
         ],
         "properties": {
           "recipientName": {
@@ -179,15 +178,9 @@
               "RENTAL_PROPERTY"
             ]
           },
-          "otherIncomeType": {
-            "type": "string"
-          },
           "grossMonthlyIncome": {
             "type": "number",
             "default": 0
-          },
-          "payer": {
-            "type": "string"
           },
           "ownedPortionValue": {
             "type": "number",

--- a/dist/21P-0969-SIMPLE-schema.json
+++ b/dist/21P-0969-SIMPLE-schema.json
@@ -158,8 +158,7 @@
         "required": [
           "recipientRelationship",
           "assetType",
-          "grossMonthlyIncome",
-          "payer"
+          "grossMonthlyIncome"
         ],
         "properties": {
           "recipientName": {
@@ -179,15 +178,9 @@
               "RENTAL_PROPERTY"
             ]
           },
-          "otherIncomeType": {
-            "type": "string"
-          },
           "grossMonthlyIncome": {
             "type": "number",
             "default": 0
-          },
-          "payer": {
-            "type": "string"
           },
           "ownedPortionValue": {
             "type": "number",

--- a/dist/21P-0969-schema.json
+++ b/dist/21P-0969-schema.json
@@ -158,8 +158,7 @@
         "required": [
           "recipientRelationship",
           "assetType",
-          "grossMonthlyIncome",
-          "payer"
+          "grossMonthlyIncome"
         ],
         "properties": {
           "recipientName": {
@@ -179,15 +178,9 @@
               "RENTAL_PROPERTY"
             ]
           },
-          "otherIncomeType": {
-            "type": "string"
-          },
           "grossMonthlyIncome": {
             "type": "number",
             "default": 0
-          },
-          "payer": {
-            "type": "string"
           },
           "ownedPortionValue": {
             "type": "number",

--- a/dist/21P-530EZ-schema.json
+++ b/dist/21P-530EZ-schema.json
@@ -697,6 +697,50 @@
         "other": {
           "type": "string"
         }
+      },
+      "nursingHomeUnpaid": {
+        "type": "object",
+        "properties": {
+          "facilityName": {
+            "type": "string"
+          },
+          "facilityLocation": {
+            "type": "string"
+          }
+        }
+      },
+      "nursingHomePaid": {
+        "type": "object",
+        "properties": {
+          "facilityName": {
+            "type": "string"
+          },
+          "facilityLocation": {
+            "type": "string"
+          }
+        }
+      },
+      "vaMedicalCenter": {
+        "type": "object",
+        "properties": {
+          "facilityName": {
+            "type": "string"
+          },
+          "facilityLocation": {
+            "type": "string"
+          }
+        }
+      },
+      "stateVeteransHome": {
+        "type": "object",
+        "properties": {
+          "facilityName": {
+            "type": "string"
+          },
+          "facilityLocation": {
+            "type": "string"
+          }
+        }
       }
     },
     "finalRestingPlace": {

--- a/dist/21P-530V2-schema.json
+++ b/dist/21P-530V2-schema.json
@@ -697,6 +697,50 @@
         "other": {
           "type": "string"
         }
+      },
+      "nursingHomeUnpaid": {
+        "type": "object",
+        "properties": {
+          "facilityName": {
+            "type": "string"
+          },
+          "facilityLocation": {
+            "type": "string"
+          }
+        }
+      },
+      "nursingHomePaid": {
+        "type": "object",
+        "properties": {
+          "facilityName": {
+            "type": "string"
+          },
+          "facilityLocation": {
+            "type": "string"
+          }
+        }
+      },
+      "vaMedicalCenter": {
+        "type": "object",
+        "properties": {
+          "facilityName": {
+            "type": "string"
+          },
+          "facilityLocation": {
+            "type": "string"
+          }
+        }
+      },
+      "stateVeteransHome": {
+        "type": "object",
+        "properties": {
+          "facilityName": {
+            "type": "string"
+          },
+          "facilityLocation": {
+            "type": "string"
+          }
+        }
       }
     },
     "finalRestingPlace": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "24.8.1",
+  "version": "24.8.2",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/schemas/21P-0969-kitchen_sink/example.json
+++ b/src/schemas/21P-0969-kitchen_sink/example.json
@@ -76,6 +76,30 @@
         "recipientRelationship": "OTHER",
         "otherRecipientRelationshipType": "Friend"
         }
+      ],
+      "ownedAssets": [
+        {
+          "assetType": "FARM",
+          "grossMonthlyIncome": 5555.55,
+          "ownedPortionValue": 5555555.55,
+          "recipientName": "Jim Brown",
+          "recipientRelationship": "CUSTODIAN"
+        },
+        {
+          "assetType": "BUSINESS",
+          "grossMonthlyIncome": 999.99,
+          "ownedPortionValue": 10000.00,
+          "recipientName": "Brandon Jones",
+          "recipientRelationship": "OTHER",
+          "otherRecipientRelationshipType": "Friend"
+        },
+        {
+          "assetType": "RENTAL_PROPERTY",
+          "grossMonthlyIncome": 123.45,
+          "ownedPortionValue": 12345.67,
+          "recipientName": "Edmund Doe",
+          "recipientRelationship": "PARENT"
+        }
       ]
   }
 }

--- a/src/schemas/21P-0969-overflow/example.json
+++ b/src/schemas/21P-0969-overflow/example.json
@@ -107,6 +107,37 @@
         "recipientName": "Rand Lincoln",
         "recipientRelationship": "CHILD"
       }
-    ]
+    ],
+    "ownedAssets": [
+        {
+          "assetType": "FARM",
+          "grossMonthlyIncome": 5555.55,
+          "ownedPortionValue": 5555555.55,
+          "recipientName": "Jim Brown",
+          "recipientRelationship": "CUSTODIAN"
+        },
+        {
+          "assetType": "BUSINESS",
+          "grossMonthlyIncome": 999.99,
+          "ownedPortionValue": 10000.00,
+          "recipientName": "Brandon Jones",
+          "recipientRelationship": "OTHER",
+          "otherRecipientRelationshipType": "Friend"
+        },
+        {
+          "assetType": "RENTAL_PROPERTY",
+          "grossMonthlyIncome": 123.45,
+          "ownedPortionValue": 12345.67,
+          "recipientName": "Edmund Doe",
+          "recipientRelationship": "PARENT"
+        },
+        {
+          "assetType": "FARM",
+          "grossMonthlyIncome": 1000.00,
+          "ownedPortionValue": 12345.67,
+          "recipientName": "Jim Brown",
+          "recipientRelationship": "CUSTODIAN"
+        }
+      ]
   }
 }

--- a/src/schemas/21P-0969/schema.js
+++ b/src/schemas/21P-0969/schema.js
@@ -85,7 +85,7 @@ const schema = {
       type: 'array',
       items: {
         type: 'object',
-        required: ['recipientRelationship', 'assetType', 'grossMonthlyIncome', 'payer'],
+        required: ['recipientRelationship', 'assetType', 'grossMonthlyIncome'],
         properties: {
           recipientName: { type: 'string' },
           recipientRelationship: schemaHelpers.getDefinition('relationshipToVeteran'),
@@ -94,9 +94,7 @@ const schema = {
             type: 'string',
             enum: ['FARM', 'BUSINESS', 'RENTAL_PROPERTY'],
           },
-          otherIncomeType: { type: 'string' },
           grossMonthlyIncome: financialNumber,
-          payer: { type: 'string' },
           ownedPortionValue: financialNumber,
         },
       },


### PR DESCRIPTION
# New schema

- Removed 'payer' and 'otherIncomeType' from 'ownedAssets' in 21P-0969 (these aren't fields on the form)
- Updated the examples for 21P-0969 to include 'ownedAssets' examples
- Rebuilt the `dist` to update it

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82565

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
