### PR TITLE
106118 - Add new schema for form 10-7959f-2 in preparation for prefill - IVC CHAMPVA

### DIFF
--- a/dist/10-7959F-2-schema.json
+++ b/dist/10-7959F-2-schema.json
@@ -1,0 +1,315 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Foreign Medical Program (FMP) Claim Cover Sheet",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "privacyAgreementAccepted": {
+      "type": "boolean",
+      "enum": [
+        true
+      ]
+    },
+    "date": {
+      "pattern": "^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$",
+      "type": "string"
+    },
+    "ssn": {
+      "type": "string",
+      "pattern": "^[0-9]{9}$"
+    },
+    "address": {
+      "type": "object",
+      "oneOf": [
+        {
+          "properties": {
+            "country": {
+              "type": "string",
+              "enum": [
+                "CAN"
+              ]
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "AB",
+                "BC",
+                "MB",
+                "NB",
+                "NL",
+                "NT",
+                "NS",
+                "NU",
+                "ON",
+                "PE",
+                "QC",
+                "SK",
+                "YT"
+              ]
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "country": {
+              "type": "string",
+              "enum": [
+                "MEX"
+              ]
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "aguascalientes",
+                "baja-california-norte",
+                "baja-california-sur",
+                "campeche",
+                "chiapas",
+                "chihuahua",
+                "coahuila",
+                "colima",
+                "distrito-federal",
+                "durango",
+                "guanajuato",
+                "guerrero",
+                "hidalgo",
+                "jalisco",
+                "mexico",
+                "michoacan",
+                "morelos",
+                "nayarit",
+                "nuevo-leon",
+                "oaxaca",
+                "puebla",
+                "queretaro",
+                "quintana-roo",
+                "san-luis-potosi",
+                "sinaloa",
+                "sonora",
+                "tabasco",
+                "tamaulipas",
+                "tlaxcala",
+                "veracruz",
+                "yucatan",
+                "zacatecas"
+              ]
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "country": {
+              "type": "string",
+              "enum": [
+                "USA"
+              ]
+            },
+            "state": {
+              "type": "string",
+              "enum": [
+                "AL",
+                "AK",
+                "AS",
+                "AZ",
+                "AR",
+                "AA",
+                "AE",
+                "AP",
+                "CA",
+                "CO",
+                "CT",
+                "DE",
+                "DC",
+                "FM",
+                "FL",
+                "GA",
+                "GU",
+                "HI",
+                "ID",
+                "IL",
+                "IN",
+                "IA",
+                "KS",
+                "KY",
+                "LA",
+                "ME",
+                "MH",
+                "MD",
+                "MA",
+                "MI",
+                "MN",
+                "MS",
+                "MO",
+                "MT",
+                "NE",
+                "NV",
+                "NH",
+                "NJ",
+                "NM",
+                "NY",
+                "NC",
+                "ND",
+                "MP",
+                "OH",
+                "OK",
+                "OR",
+                "PW",
+                "PA",
+                "PR",
+                "RI",
+                "SC",
+                "SD",
+                "TN",
+                "TX",
+                "UT",
+                "VT",
+                "VI",
+                "VA",
+                "WA",
+                "WV",
+                "WI",
+                "WY"
+              ]
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 10
+            }
+          }
+        },
+        {
+          "properties": {
+            "country": {
+              "not": {
+                "type": "string",
+                "enum": [
+                  "CAN",
+                  "MEX",
+                  "USA"
+                ]
+              }
+            },
+            "state": {
+              "type": "string",
+              "maxLength": 51
+            },
+            "postalCode": {
+              "type": "string",
+              "maxLength": 51
+            }
+          }
+        }
+      ],
+      "properties": {
+        "street": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50
+        },
+        "street2": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50
+        },
+        "city": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 51
+        }
+      }
+    },
+    "yesNoSchema": {
+      "type": "boolean"
+    },
+    "phone": {
+      "type": "string",
+      "minLength": 10
+    },
+    "email": {
+      "type": "string",
+      "maxLength": 256,
+      "format": "email"
+    },
+    "files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "confirmationCode": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "sendPayment": {
+      "type": "string",
+      "enum": [
+        "Veteran",
+        "Provider"
+      ]
+    },
+    "privacyAgreementAccepted": {
+      "$ref": "#/definitions/privacyAgreementAccepted"
+    },
+    "veteranFullName": {
+      "$ref": "#/definitions/name"
+    },
+    "veteranDateOfBirth": {
+      "$ref": "#/definitions/date"
+    },
+    "veteranSocialSecurityNumber": {
+      "$ref": "#/definitions/ssn"
+    },
+    "veteranAddress": {
+      "$ref": "#/definitions/address"
+    },
+    "sameMailingAddress": {
+      "$ref": "#/definitions/yesNoSchema"
+    },
+    "physicalAddress": {
+      "$ref": "#/definitions/address"
+    },
+    "veteranPhoneNumber": {
+      "$ref": "#/definitions/phone"
+    },
+    "veteranEmailAddress": {
+      "$ref": "#/definitions/email"
+    },
+    "uploadSectionVeteran": {
+      "$ref": "#/definitions/files"
+    },
+    "uploadSectionProvider": {
+      "$ref": "#/definitions/files"
+    }
+  },
+  "required": [
+    "privacyAgreementAccepted",
+    "veteranFullName",
+    "veteranDateOfBirth",
+    "veteranSocialSecurityNumber",
+    "veteranAddress",
+    "sameMailingAddress",
+    "physicalAddress",
+    "veteranPhoneNumber",
+    "veteranEmailAddress",
+    "sendPayment",
+    "uploadSectionVeteran",
+    "uploadSectionProvider"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "24.13.0",
+  "version": "24.13.1",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/schemas/10-7959f-2/schema.js
+++ b/src/schemas/10-7959f-2/schema.js
@@ -1,0 +1,47 @@
+import schemaHelpers from '../../common/schema-helpers';
+
+const schema = {
+  $schema: 'http://json-schema.org/draft-04/schema#',
+  title: 'Foreign Medical Program (FMP) Claim Cover Sheet',
+  type: 'object',
+  additionalProperties: false,
+  definitions: {},
+  properties: {
+    sendPayment: {
+      type: 'string',
+      enum: ['Veteran', 'Provider'],
+    },
+  },
+  required: [
+    'privacyAgreementAccepted',
+    'veteranFullName',
+    'veteranDateOfBirth',
+    'veteranSocialSecurityNumber',
+    'veteranAddress',
+    'sameMailingAddress',
+    'physicalAddress',
+    'veteranPhoneNumber',
+    'veteranEmailAddress',
+    'sendPayment',
+    'uploadSectionVeteran',
+    'uploadSectionProvider',
+  ],
+};
+
+[
+  ['privacyAgreementAccepted'],
+  ['name', 'veteranFullName'],
+  ['date', 'veteranDateOfBirth'],
+  ['ssn', 'veteranSocialSecurityNumber'],
+  ['address', 'veteranAddress'],
+  ['yesNoSchema', 'sameMailingAddress'],
+  ['address', 'physicalAddress'],
+  ['phone', 'veteranPhoneNumber'],
+  ['email', 'veteranEmailAddress'],
+  ['files', 'uploadSectionVeteran'],
+  ['files', 'uploadSectionProvider'],
+].forEach(args => {
+  schemaHelpers.addDefinitionToSchema(schema, ...args);
+});
+
+export default schema;


### PR DESCRIPTION
# New schema
The schema added here is for form 10-7959f-2. [Link to the existing form work in vets-website.](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/ivc-champva/10-7959f-2)

_Please ensure you have incremented the version in_ `package.json`.

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/106118

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/21701
- https://github.com/department-of-veterans-affairs/vets-website/pull/35841
