### PR TITLE
[10-10EZ] Make isEssentialAcaCoverage optional

### DIFF
--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -1252,7 +1252,6 @@
     "isSpanishHispanicLatino",
     "veteranAddress",
     "isMedicaidEligible",
-    "isEssentialAcaCoverage",
     "vaMedicalFacility"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "24.16.3",
+  "version": "24.17.0",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/schemas/10-10EZ/schema.js
+++ b/src/schemas/10-10EZ/schema.js
@@ -192,7 +192,6 @@ const schema = {
     'isSpanishHispanicLatino',
     'veteranAddress',
     'isMedicaidEligible',
-    'isEssentialAcaCoverage',
     'vaMedicalFacility',
   ],
 };


### PR DESCRIPTION
# New schema
- Make `isEssentialAcaCoverage` optional since we plan to remove it from the schema entirely soon. This is the first step to removing it while keeping `vets-website` and `vets-api` in sync. 

_Please ensure you have incremented the version in_ `package.json`. ✅ 

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
