### PR TITLE
Make Veteran Date of Birth Optional

### DIFF
--- a/dist/BENEFITS-INTAKE-schema.json
+++ b/dist/BENEFITS-INTAKE-schema.json
@@ -13,7 +13,10 @@
           "example": "796126859"
         },
         "dateOfBirth": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "format": "date",
           "example": "1932-02-05"
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "24.17.1",
+  "version": "24.17.2",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# New schema
We want to remove Veteran Date Of Birth from dependent claims. That means it is now an optional param depending on the type of claim

## Pull Requests to update the schema in related repositories
https://github.com/department-of-veterans-affairs/va.gov-team/issues/113003


