### PR TITLE
Updates for form21a for employment endDate

### DIFF
--- a/dist/21A-schema.json
+++ b/dist/21A-schema.json
@@ -1407,8 +1407,7 @@
         },
         "required": [
           "employerName",
-          "startDate",
-          "endDate"
+          "startDate"
         ]
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "25.1.3",
+  "version": "25.1.4",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/schemas/21A/schema.js
+++ b/src/schemas/21A/schema.js
@@ -83,7 +83,7 @@ const schema = {
           supervisorName: { type: 'string', maxLength: 100 },
           supervisorEmail: { type: 'string', format: 'email', maxLength: 100 },
         },
-        required: ['employerName', 'startDate', 'endDate'],
+        required: ['employerName', 'startDate'],
       },
     },
     education: {


### PR DESCRIPTION
# New schema
- Removed the `endDate` as a required field in the form 21a schema since it can be null now that GCLAWS added their bug fix

_Please ensure you have incremented the version in_ `package.json`.

-_Link to ticket created in va.gov-team - https://github.com/department-of-veterans-affairs/va.gov-team/issues/114576

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
