### PR TITLE
Bump codeql-action to v3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       # If you wish to specify custom queries, you can do so here or in a config file.
       # By default, queries listed here will override any specified in a config file.
       # Prefix the list here with "+" to use these queries and those in the config file.
@@ -29,7 +29,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -43,4 +43,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
This PR updates the `.github/workflows/codeql.yml` GitHub action to use an updated version of [codeql-action](https://github.com/github/codeql-action). 

We started seeing this error today:

```
Error: Code Scanning could not process the submitted SARIF file: 

A delivery cannot contain multiple runs with the same category. Please upload a single run per category. For more information, see https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/
```
https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/

Support request: https://dsva.slack.com/archives/CBU0KDSB1/p1753728681317399
