### PR TITLE
0969: Make asset transfer sale value an optional field

### DIFF
--- a/dist/21P-0969-KITCHEN_SINK-schema.json
+++ b/dist/21P-0969-KITCHEN_SINK-schema.json
@@ -253,7 +253,6 @@
           "transferDate",
           "assetTransferredUnderFairMarketValue",
           "fairMarketValue",
-          "saleValue",
           "capitalGainValue"
         ],
         "properties": {
@@ -299,8 +298,7 @@
             "default": 0
           },
           "saleValue": {
-            "type": "number",
-            "default": 0
+            "type": "number"
           },
           "capitalGainValue": {
             "type": "number",

--- a/dist/21P-0969-OVERFLOW-schema.json
+++ b/dist/21P-0969-OVERFLOW-schema.json
@@ -253,7 +253,6 @@
           "transferDate",
           "assetTransferredUnderFairMarketValue",
           "fairMarketValue",
-          "saleValue",
           "capitalGainValue"
         ],
         "properties": {
@@ -299,8 +298,7 @@
             "default": 0
           },
           "saleValue": {
-            "type": "number",
-            "default": 0
+            "type": "number"
           },
           "capitalGainValue": {
             "type": "number",

--- a/dist/21P-0969-SIMPLE-schema.json
+++ b/dist/21P-0969-SIMPLE-schema.json
@@ -253,7 +253,6 @@
           "transferDate",
           "assetTransferredUnderFairMarketValue",
           "fairMarketValue",
-          "saleValue",
           "capitalGainValue"
         ],
         "properties": {
@@ -299,8 +298,7 @@
             "default": 0
           },
           "saleValue": {
-            "type": "number",
-            "default": 0
+            "type": "number"
           },
           "capitalGainValue": {
             "type": "number",

--- a/dist/21P-0969-schema.json
+++ b/dist/21P-0969-schema.json
@@ -253,7 +253,6 @@
           "transferDate",
           "assetTransferredUnderFairMarketValue",
           "fairMarketValue",
-          "saleValue",
           "capitalGainValue"
         ],
         "properties": {
@@ -299,8 +298,7 @@
             "default": 0
           },
           "saleValue": {
-            "type": "number",
-            "default": 0
+            "type": "number"
           },
           "capitalGainValue": {
             "type": "number",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "25.1.4",
+  "version": "25.1.5",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/schemas/21P-0969/schema.js
+++ b/src/schemas/21P-0969/schema.js
@@ -140,7 +140,6 @@ const schema = {
           'transferDate',
           'assetTransferredUnderFairMarketValue',
           'fairMarketValue',
-          'saleValue',
           'capitalGainValue',
         ],
         properties: {
@@ -158,7 +157,7 @@ const schema = {
           transferDate: schemaHelpers.getDefinition('date'),
           assetTransferredUnderFairMarketValue: definitions.yesNoSchema,
           fairMarketValue: financialNumber,
-          saleValue: financialNumber,
+          saleValue: { type: 'number' }, // This field is ignored in the context
           capitalGainValue: financialNumber,
         },
       },


### PR DESCRIPTION
# New schema
Modified the 0969 schema to make asset transfer sale value an optional field.

_Please ensure you have incremented the version in_ `package.json`.

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/112816

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
