### PR TITLE
Remove minLength from street2 & 3

### DIFF
--- a/dist/21-4142-schema.json
+++ b/dist/21-4142-schema.json
@@ -767,12 +767,10 @@
         },
         "street2": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "street3": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "city": {

--- a/dist/21P-527EZ-KITCHEN_SINK-schema.json
+++ b/dist/21P-527EZ-KITCHEN_SINK-schema.json
@@ -823,12 +823,10 @@
         },
         "street2": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "street3": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "city": {

--- a/dist/21P-527EZ-OVERFLOW-schema.json
+++ b/dist/21P-527EZ-OVERFLOW-schema.json
@@ -823,12 +823,10 @@
         },
         "street2": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "street3": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "city": {

--- a/dist/21P-527EZ-SIMPLE-schema.json
+++ b/dist/21P-527EZ-SIMPLE-schema.json
@@ -823,12 +823,10 @@
         },
         "street2": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "street3": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "city": {

--- a/dist/21P-527EZ-schema.json
+++ b/dist/21P-527EZ-schema.json
@@ -823,12 +823,10 @@
         },
         "street2": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "street3": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "city": {

--- a/dist/21P-530EZ-schema.json
+++ b/dist/21P-530EZ-schema.json
@@ -501,12 +501,10 @@
         },
         "street2": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "street3": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "city": {

--- a/dist/21P-530V2-schema.json
+++ b/dist/21P-530V2-schema.json
@@ -501,12 +501,10 @@
         },
         "street2": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "street3": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "city": {

--- a/dist/22-1919-schema.json
+++ b/dist/22-1919-schema.json
@@ -488,12 +488,10 @@
         },
         "street2": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "street3": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "city": {

--- a/dist/26-4555-schema.json
+++ b/dist/26-4555-schema.json
@@ -738,12 +738,10 @@
         },
         "street2": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "street3": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "city": {

--- a/dist/28-1900-schema.json
+++ b/dist/28-1900-schema.json
@@ -530,12 +530,10 @@
         },
         "street2": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "street3": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "city": {

--- a/dist/28-1900_V2-schema.json
+++ b/dist/28-1900_V2-schema.json
@@ -530,12 +530,10 @@
         },
         "street2": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "street3": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "city": {

--- a/dist/28-8832-schema.json
+++ b/dist/28-8832-schema.json
@@ -483,12 +483,10 @@
         },
         "street2": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "street3": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "city": {

--- a/dist/BENEFITS-INTAKE-schema.json
+++ b/dist/BENEFITS-INTAKE-schema.json
@@ -13,15 +13,9 @@
           "example": "796126859"
         },
         "dateOfBirth": {
-          "oneOf": [
-            { "type": "null" },
-            {
-              "type": "string",
-              "format": "date",
-              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
-              "example": "1932-02-05"
-            }
-          ]
+          "type": "string",
+          "format": "date",
+          "example": "1932-02-05"
         },
         "postalCode": {
           "type": "string",
@@ -34,79 +28,83 @@
           "properties": {
             "first": {
               "type": "string",
-              "minLength": 1,
-              "maxLength": 30,
               "example": "Hector"
             },
             "last": {
               "type": "string",
-              "minLength": 1,
-              "maxLength": 30,
               "example": "Allen"
             }
           },
-          "required": ["first", "last"]
+          "required": [
+            "first",
+            "last"
+          ]
         }
       },
-      "required": ["ssn", "dateOfBirth", "postalCode", "name"]
+      "required": [
+        "ssn",
+        "dateOfBirth",
+        "postalCode",
+        "name"
+      ]
     },
     "dependent": {
-      "type": ["object", "null"],
+      "type": [
+        "object",
+        "null"
+      ],
       "additionalProperties": false,
       "properties": {
         "ssn": {
-          "oneOf": [
-            { "type": "null" },
-            {
-              "type": "string",
-              "pattern": "^\\d{9}$",
-              "example": "796126859"
-            }
-          ]
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^\\d{9}$",
+          "example": "796229088"
         },
         "dateOfBirth": {
-          "oneOf": [
-            { "type": "null" },
-            {
-              "type": "string",
-              "format": "date",
-              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
-              "example": "1976-01-16"
-            }
-          ]
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date",
+          "example": "1976-01-16"
         },
         "name": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "first": {
-              "oneOf": [
-                { "type": "null" },
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 30,
-                  "example": "Derrick"
-                }
-              ]
+              "type": [
+                "string",
+                "null"
+              ],
+              "example": "Derrick"
             },
             "last": {
-              "oneOf": [
-                { "type": "null" },
-                {
-                  "type": "string",
-                  "minLength": 1,
-                  "maxLength": 30,
-                  "example": "Reid"
-                }
-              ]
+              "type": [
+                "string",
+                "null"
+              ],
+              "example": "Reid"
             }
           },
-          "required": ["first", "last"]
+          "required": [
+            "first",
+            "last"
+          ]
         }
       },
-      "required": ["ssn", "dateOfBirth", "name"]
+      "required": [
+        "ssn",
+        "dateOfBirth",
+        "name"
+      ]
     }
   },
-  "required": ["veteran", "dependent"]
+  "required": [
+    "veteran",
+    "dependent"
+  ]
 }

--- a/dist/COVID-VACCINATION-EXPANSION-schema.json
+++ b/dist/COVID-VACCINATION-EXPANSION-schema.json
@@ -505,12 +505,10 @@
         },
         "street2": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "street3": {
           "type": "string",
-          "minLength": 1,
           "maxLength": 100
         },
         "city": {

--- a/dist/DISPUTE-DEBT-schema.json
+++ b/dist/DISPUTE-DEBT-schema.json
@@ -491,12 +491,10 @@
             },
             "street2": {
               "type": "string",
-              "minLength": 1,
               "maxLength": 100
             },
             "street3": {
               "type": "string",
-              "minLength": 1,
               "maxLength": 100
             },
             "city": {

--- a/dist/definitions.json
+++ b/dist/definitions.json
@@ -933,12 +933,10 @@
       },
       "street2": {
         "type": "string",
-        "minLength": 1,
         "maxLength": 100
       },
       "street3": {
         "type": "string",
-        "minLength": 1,
         "maxLength": 100
       },
       "city": {

--- a/src/common/definitions.js
+++ b/src/common/definitions.js
@@ -293,12 +293,10 @@ const profileAddress = {
     },
     street2: {
       type: 'string',
-      minLength: 1,
       maxLength: 100,
     },
     street3: {
       type: 'string',
-      minLength: 1,
       maxLength: 100,
     },
     city: {


### PR DESCRIPTION
# New schema

Removing the `minLength: 1` from common address definition. Including this causes an empty string to throw an error on these non-required fields.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/113941

