### PR TITLE
add requirements for required insurance provider fields

### DIFF
--- a/dist/10-10EZ-schema.json
+++ b/dist/10-10EZ-schema.json
@@ -1069,6 +1069,10 @@
             "pattern": "^.*\\S.*"
           }
         },
+        "required": [
+          "insuranceName",
+          "insurancePolicyHolderName"
+        ],
         "anyOf": [
           {
             "required": [

--- a/dist/10-10EZR-schema.json
+++ b/dist/10-10EZR-schema.json
@@ -534,6 +534,10 @@
             "pattern": "^.*\\S.*"
           }
         },
+        "required": [
+          "insuranceName",
+          "insurancePolicyHolderName"
+        ],
         "anyOf": [
           {
             "required": [

--- a/dist/definitions.json
+++ b/dist/definitions.json
@@ -2742,6 +2742,10 @@
         "pattern": "^.*\\S.*"
       }
     },
+    "required": [
+      "insuranceName",
+      "insurancePolicyHolderName"
+    ],
     "anyOf": [
       {
         "required": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "25.1.8",
+  "version": "25.1.9",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/common/definitions.js
+++ b/src/common/definitions.js
@@ -90,6 +90,7 @@ const insuranceProvider = {
       ...rejectOnlyWhitespace,
     },
   },
+  required: ['insuranceName', 'insurancePolicyHolderName'],
   anyOf: [
     {
       required: ['insurancePolicyNumber'],

--- a/test/common/definitions.spec.js
+++ b/test/common/definitions.spec.js
@@ -47,8 +47,16 @@ describe('schema definitions', () => {
         insurancePolicyNumber: stringGenerate(30),
         insuranceGroupCode: stringGenerate(30),
       },
-      { insurancePolicyNumber: '123' },
-      { insuranceGroupCode: '123' },
+      {
+        insuranceName: stringGenerate(100),
+        insurancePolicyHolderName: stringGenerate(50),
+        insurancePolicyNumber: '123',
+      },
+      {
+        insuranceName: stringGenerate(100),
+        insurancePolicyHolderName: stringGenerate(50),
+        insuranceGroupCode: '123',
+      },
     ],
     invalid: [
       {
@@ -62,6 +70,8 @@ describe('schema definitions', () => {
       { insurancePolicyHolderName: ' ' },
       { insuranceGroupCode: ' ' },
       { insurancePolicyNumber: ' ' },
+      { insurancePolicyNumber: '123' },
+      { insuranceGroupCode: '123' },
     ],
   });
 


### PR DESCRIPTION
# New schema

Add requirements for two fields in 1010EZ which are required on the frontend and without which our submissions to VES fail.
https://github.com/department-of-veterans-affairs/va.gov-team/issues/116965

_Please ensure you have incremented the version in_ `package.json`.
✅ 

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
