### PR TITLE
[Disability Benefits] Revert regex pattern improvements

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -438,22 +438,22 @@
         "addressLine1": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^[-a-zA-Z0-9'.,&#]+( [-a-zA-Z0-9'.,&#]+)*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "addressLine2": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^[-a-zA-Z0-9'.,&#]+( [-a-zA-Z0-9'.,&#]+)*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "addressLine3": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^[-a-zA-Z0-9'.,&#]+( [-a-zA-Z0-9'.,&#]+)*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "city": {
           "type": "string",
           "maxLength": 30,
-          "pattern": "^[-a-zA-Z0-9'.#]+( [-a-zA-Z0-9'.#]+)*$"
+          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
         },
         "state": {
           "$ref": "#/definitions/state"
@@ -473,22 +473,22 @@
         "addressLine1": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^[-a-zA-Z0-9'.,&#]+( [-a-zA-Z0-9'.,&#]+)*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "addressLine2": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^[-a-zA-Z0-9'.,&#]+( [-a-zA-Z0-9'.,&#]+)*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "addressLine3": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^[-a-zA-Z0-9'.,&#]+( [-a-zA-Z0-9'.,&#]+)*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "city": {
           "type": "string",
           "maxLength": 30,
-          "pattern": "^[-a-zA-Z0-9'.#]+( [-a-zA-Z0-9'.#]+)*$"
+          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
         },
         "state": {
           "$ref": "#/definitions/state"
@@ -511,7 +511,7 @@
         "city": {
           "type": "string",
           "maxLength": 30,
-          "pattern": "^[-a-zA-Z0-9'.#]+( [-a-zA-Z0-9'.#]+)*$"
+          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
         },
         "state": {
           "$ref": "#/definitions/state"
@@ -770,19 +770,19 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^([-a-zA-Z0-9/']+(?: [-a-zA-Z0-9/']+)*)$"
+            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
           },
           "middle": {
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^([-a-zA-Z0-9/']+(?: [-a-zA-Z0-9/']+)*)$"
+            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
           },
           "last": {
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^([-a-zA-Z0-9/']+(?: [-a-zA-Z0-9/']+)*)$"
+            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
           }
         }
       }
@@ -961,7 +961,7 @@
             "separationLocationName": {
               "type": "string",
               "maxLength": 256,
-              "pattern": "^[a-zA-Z0-9\\/\\-'.#,*()&]+( [a-zA-Z0-9\\/\\-'.#,*()&]+)*$"
+              "pattern": "^([a-zA-Z0-9\\/\\-'.#,*()&][a-zA-Z0-9\\/\\-'.#,*()& ]?)*$"
             }
           }
         },
@@ -975,7 +975,7 @@
             "unitName": {
               "type": "string",
               "maxLength": 256,
-              "pattern": "^[a-zA-Z0-9\\-'.#]+( [a-zA-Z0-9\\-'.#]+)*$"
+              "pattern": "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
             },
             "obligationTermOfServiceDateRange": {
               "$ref": "#/definitions/dateRangeAllRequired"
@@ -1047,22 +1047,22 @@
         "addressLine1": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "^[-a-zA-Z0-9'.,&#]+( [-a-zA-Z0-9'.,&#]+)*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "addressLine2": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "^[-a-zA-Z0-9'.,&#]+( [-a-zA-Z0-9'.,&#]+)*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "addressLine3": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "^[-a-zA-Z0-9'.,&#]+( [-a-zA-Z0-9'.,&#]+)*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "city": {
           "type": "string",
           "maxLength": 30,
-          "pattern": "^[-a-zA-Z0-9'.#]+( [-a-zA-Z0-9'.#]+)*$"
+          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
         },
         "state": {
           "$ref": "#/definitions/state"
@@ -1133,7 +1133,7 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 100,
-          "pattern": "^([-a-zA-Z0-9/']( ?))*$"
+          "pattern": "^([-a-zA-Z0-9/']+( ?))*$"
         },
         "phoneNumber": {
           "$ref": "#/definitions/phone"
@@ -1157,7 +1157,7 @@
           "treatmentCenterName": {
             "type": "string",
             "maxLength": 100,
-            "pattern": "^([-a-zA-Z0-9\"\\/&()'.#]+( [-a-zA-Z0-9\"\\/&()'.#]+)*)$"
+            "pattern": "([-a-zA-Z0-9\"\\/&()'.#]([-a-zA-Z0-9()'.# ])?)+$"
           },
           "treatmentDateRange": {
             "$ref": "#/definitions/dateRange"
@@ -1358,7 +1358,7 @@
                   "city": {
                     "type": "string",
                     "maxLength": 30,
-                    "pattern": "^[-a-zA-Z0-9'.#]+( [-a-zA-Z0-9'.#]+)*$"
+                    "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
                   },
                   "state": {
                     "$ref": "#/definitions/state"
@@ -1441,17 +1441,17 @@
                         "addressLine1": {
                           "type": "string",
                           "maxLength": 20,
-                          "pattern": "^[-a-zA-Z0-9'.,&#]+( [-a-zA-Z0-9'.,&#]+)*$"
+                          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
                         },
                         "addressLine2": {
                           "type": "string",
                           "maxLength": 20,
-                          "pattern": "^[-a-zA-Z0-9'.,&#]+( [-a-zA-Z0-9'.,&#]+)*$"
+                          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
                         },
                         "city": {
                           "type": "string",
                           "maxLength": 30,
-                          "pattern": "^[-a-zA-Z0-9'.#]+( [-a-zA-Z0-9'.#]+)*$"
+                          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
                         },
                         "state": {
                           "$ref": "#/definitions/state"

--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -438,22 +438,22 @@
         "addressLine1": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "addressLine2": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "addressLine3": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "city": {
           "type": "string",
           "maxLength": 30,
-          "pattern": "^[ ]*[-a-zA-Z0-9'.#]+([ ]+[-a-zA-Z0-9'.#]+)*[ ]*$"
+          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
         },
         "state": {
           "$ref": "#/definitions/state"
@@ -473,22 +473,22 @@
         "addressLine1": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "addressLine2": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "addressLine3": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "city": {
           "type": "string",
           "maxLength": 30,
-          "pattern": "^[ ]*[-a-zA-Z0-9'.#]+([ ]+[-a-zA-Z0-9'.#]+)*[ ]*$"
+          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
         },
         "state": {
           "$ref": "#/definitions/state"
@@ -511,7 +511,7 @@
         "city": {
           "type": "string",
           "maxLength": 30,
-          "pattern": "^[ ]*[-a-zA-Z0-9'.#]+([ ]+[-a-zA-Z0-9'.#]+)*[ ]*$"
+          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
         },
         "state": {
           "$ref": "#/definitions/state"
@@ -770,19 +770,19 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^[ ]*[-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*[ ]*$"
+            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
           },
           "middle": {
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^[ ]*[-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*[ ]*$"
+            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
           },
           "last": {
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^[ ]*[-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*[ ]*$"
+            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
           }
         }
       }
@@ -961,7 +961,7 @@
             "separationLocationName": {
               "type": "string",
               "maxLength": 256,
-              "pattern": "^[ ]*([a-zA-Z0-9\\/\\-'.#,*()&]+( *[a-zA-Z0-9\\/\\-'.#,*()&]+)*)?[ ]*$"
+              "pattern": "^([a-zA-Z0-9\\/\\-'.#,*()&][a-zA-Z0-9\\/\\-'.#,*()& ]?)*$"
             }
           }
         },
@@ -975,7 +975,7 @@
             "unitName": {
               "type": "string",
               "maxLength": 256,
-              "pattern": "^[ ]*([a-zA-Z0-9\\-'.#]+( *[a-zA-Z0-9\\-'.#]+)*)?[ ]*$"
+              "pattern": "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
             },
             "obligationTermOfServiceDateRange": {
               "$ref": "#/definitions/dateRangeAllRequired"
@@ -1047,22 +1047,22 @@
         "addressLine1": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "addressLine2": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "addressLine3": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
+          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
         },
         "city": {
           "type": "string",
           "maxLength": 30,
-          "pattern": "^[ ]*[-a-zA-Z0-9'.#]+([ ]+[-a-zA-Z0-9'.#]+)*[ ]*$"
+          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
         },
         "state": {
           "$ref": "#/definitions/state"
@@ -1133,7 +1133,7 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 100,
-          "pattern": "^[ ]*([-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*)?[ ]*$"
+          "pattern": "^([-a-zA-Z0-9/']+( ?))*$"
         },
         "phoneNumber": {
           "$ref": "#/definitions/phone"
@@ -1157,7 +1157,7 @@
           "treatmentCenterName": {
             "type": "string",
             "maxLength": 100,
-            "pattern": "^[ ]*[-a-zA-Z0-9\"\\/&()'.#]+( *[-a-zA-Z0-9\"\\/&()'.#]+)*[ ]*$"
+            "pattern": "([-a-zA-Z0-9\"\\/&()'.#]([-a-zA-Z0-9()'.# ])?)+$"
           },
           "treatmentDateRange": {
             "$ref": "#/definitions/dateRange"
@@ -1358,7 +1358,7 @@
                   "city": {
                     "type": "string",
                     "maxLength": 30,
-                    "pattern": "^[ ]*[-a-zA-Z0-9'.#]+([ ]+[-a-zA-Z0-9'.#]+)*[ ]*$"
+                    "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
                   },
                   "state": {
                     "$ref": "#/definitions/state"
@@ -1441,17 +1441,17 @@
                         "addressLine1": {
                           "type": "string",
                           "maxLength": 20,
-                          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
+                          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
                         },
                         "addressLine2": {
                           "type": "string",
                           "maxLength": 20,
-                          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
+                          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
                         },
                         "city": {
                           "type": "string",
                           "maxLength": 30,
-                          "pattern": "^[ ]*[-a-zA-Z0-9'.#]+([ ]+[-a-zA-Z0-9'.#]+)*[ ]*$"
+                          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
                         },
                         "state": {
                           "$ref": "#/definitions/state"

--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -438,22 +438,22 @@
         "addressLine1": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
         },
         "addressLine2": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
         },
         "addressLine3": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
         },
         "city": {
           "type": "string",
           "maxLength": 30,
-          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
+          "pattern": "^[ ]*[-a-zA-Z0-9'.#]+([ ]+[-a-zA-Z0-9'.#]+)*[ ]*$"
         },
         "state": {
           "$ref": "#/definitions/state"
@@ -473,22 +473,22 @@
         "addressLine1": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
         },
         "addressLine2": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
         },
         "addressLine3": {
           "type": "string",
           "maxLength": 20,
-          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
         },
         "city": {
           "type": "string",
           "maxLength": 30,
-          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
+          "pattern": "^[ ]*[-a-zA-Z0-9'.#]+([ ]+[-a-zA-Z0-9'.#]+)*[ ]*$"
         },
         "state": {
           "$ref": "#/definitions/state"
@@ -511,7 +511,7 @@
         "city": {
           "type": "string",
           "maxLength": 30,
-          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
+          "pattern": "^[ ]*[-a-zA-Z0-9'.#]+([ ]+[-a-zA-Z0-9'.#]+)*[ ]*$"
         },
         "state": {
           "$ref": "#/definitions/state"
@@ -770,19 +770,19 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
+            "pattern": "^[ ]*[-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*[ ]*$"
           },
           "middle": {
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
+            "pattern": "^[ ]*[-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*[ ]*$"
           },
           "last": {
             "type": "string",
             "minLength": 1,
             "maxLength": 30,
-            "pattern": "^([-a-zA-Z0-9/']+( ?))+$"
+            "pattern": "^[ ]*[-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*[ ]*$"
           }
         }
       }
@@ -961,7 +961,7 @@
             "separationLocationName": {
               "type": "string",
               "maxLength": 256,
-              "pattern": "^([a-zA-Z0-9\\/\\-'.#,*()&][a-zA-Z0-9\\/\\-'.#,*()& ]?)*$"
+              "pattern": "^[ ]*([a-zA-Z0-9\\/\\-'.#,*()&]+( *[a-zA-Z0-9\\/\\-'.#,*()&]+)*)?[ ]*$"
             }
           }
         },
@@ -975,7 +975,7 @@
             "unitName": {
               "type": "string",
               "maxLength": 256,
-              "pattern": "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$"
+              "pattern": "^[ ]*([a-zA-Z0-9\\-'.#]+( *[a-zA-Z0-9\\-'.#]+)*)?[ ]*$"
             },
             "obligationTermOfServiceDateRange": {
               "$ref": "#/definitions/dateRangeAllRequired"
@@ -1047,22 +1047,22 @@
         "addressLine1": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
         },
         "addressLine2": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
         },
         "addressLine3": {
           "type": "string",
           "maxLength": 35,
-          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
         },
         "city": {
           "type": "string",
           "maxLength": 30,
-          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
+          "pattern": "^[ ]*[-a-zA-Z0-9'.#]+([ ]+[-a-zA-Z0-9'.#]+)*[ ]*$"
         },
         "state": {
           "$ref": "#/definitions/state"
@@ -1133,7 +1133,7 @@
           "type": "string",
           "minLength": 1,
           "maxLength": 100,
-          "pattern": "^([-a-zA-Z0-9/']+( ?))*$"
+          "pattern": "^[ ]*([-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*)?[ ]*$"
         },
         "phoneNumber": {
           "$ref": "#/definitions/phone"
@@ -1157,7 +1157,7 @@
           "treatmentCenterName": {
             "type": "string",
             "maxLength": 100,
-            "pattern": "([-a-zA-Z0-9\"\\/&()'.#]([-a-zA-Z0-9()'.# ])?)+$"
+            "pattern": "^[ ]*[-a-zA-Z0-9\"\\/&()'.#]+( *[-a-zA-Z0-9\"\\/&()'.#]+)*[ ]*$"
           },
           "treatmentDateRange": {
             "$ref": "#/definitions/dateRange"
@@ -1358,7 +1358,7 @@
                   "city": {
                     "type": "string",
                     "maxLength": 30,
-                    "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
+                    "pattern": "^[ ]*[-a-zA-Z0-9'.#]+([ ]+[-a-zA-Z0-9'.#]+)*[ ]*$"
                   },
                   "state": {
                     "$ref": "#/definitions/state"
@@ -1441,17 +1441,17 @@
                         "addressLine1": {
                           "type": "string",
                           "maxLength": 20,
-                          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+                          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
                         },
                         "addressLine2": {
                           "type": "string",
                           "maxLength": 20,
-                          "pattern": "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$"
+                          "pattern": "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$"
                         },
                         "city": {
                           "type": "string",
                           "maxLength": 30,
-                          "pattern": "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$"
+                          "pattern": "^[ ]*[-a-zA-Z0-9'.#]+([ ]+[-a-zA-Z0-9'.#]+)*[ ]*$"
                         },
                         "state": {
                           "$ref": "#/definitions/state"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "25.2.3",
+  "version": "25.2.4",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -40,22 +40,22 @@ const baseAddressDef = {
     addressLine1: {
       type: 'string',
       maxLength: 20,
-      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+      pattern: "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$",
     },
     addressLine2: {
       type: 'string',
       maxLength: 20,
-      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+      pattern: "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$",
     },
     addressLine3: {
       type: 'string',
       maxLength: 20,
-      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+      pattern: "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$",
     },
     city: {
       type: 'string',
       maxLength: 30,
-      pattern: "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
+      pattern: "^[ ]*[-a-zA-Z0-9'.#]+([ ]+[-a-zA-Z0-9'.#]+)*[ ]*$",
     },
     state: {
       $ref: '#/definitions/state',
@@ -260,19 +260,19 @@ const schema = {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^([-a-zA-Z0-9/']+( ?))+$",
+            pattern: "^[ ]*[-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*[ ]*$",
           },
           middle: {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^([-a-zA-Z0-9/']+( ?))+$",
+            pattern: "^[ ]*[-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*[ ]*$",
           },
           last: {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^([-a-zA-Z0-9/']+( ?))+$",
+            pattern: "^[ ]*[-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*[ ]*$",
           },
         },
       },
@@ -446,7 +446,7 @@ const schema = {
             separationLocationName: {
               type: 'string',
               maxLength: 256,
-              pattern: "^([a-zA-Z0-9\\/\\-'.#,*()&][a-zA-Z0-9\\/\\-'.#,*()& ]?)*$",
+              pattern: "^[ ]*([a-zA-Z0-9\\/\\-'.#,*()&]+( *[a-zA-Z0-9\\/\\-'.#,*()&]+)*)?[ ]*$",
             },
           },
         },
@@ -457,7 +457,7 @@ const schema = {
             unitName: {
               type: 'string',
               maxLength: 256,
-              pattern: "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$",
+              pattern: "^[ ]*([a-zA-Z0-9\\-'.#]+( *[a-zA-Z0-9\\-'.#]+)*)?[ ]*$",
             },
             obligationTermOfServiceDateRange: {
               $ref: '#/definitions/dateRangeAllRequired',
@@ -588,7 +588,7 @@ const schema = {
           type: 'string',
           minLength: 1,
           maxLength: 100,
-          pattern: "^([-a-zA-Z0-9/']+( ?))*$",
+          pattern: "^[ ]*([-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*)?[ ]*$",
         },
         phoneNumber: {
           $ref: '#/definitions/phone',
@@ -609,7 +609,7 @@ const schema = {
           treatmentCenterName: {
             type: 'string',
             maxLength: 100,
-            pattern: "([-a-zA-Z0-9\"\\/&()'.#]([-a-zA-Z0-9()'.# ])?)+$",
+            pattern: '^[ ]*[-a-zA-Z0-9"\\/&()\'.#]+( *[-a-zA-Z0-9"\\/&()\'.#]+)*[ ]*$',
           },
           treatmentDateRange: {
             $ref: '#/definitions/dateRange',

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -40,22 +40,22 @@ const baseAddressDef = {
     addressLine1: {
       type: 'string',
       maxLength: 20,
-      pattern: "^[-a-zA-Z0-9'.,&#]+( [-a-zA-Z0-9'.,&#]+)*$",
+      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
     },
     addressLine2: {
       type: 'string',
       maxLength: 20,
-      pattern: "^[-a-zA-Z0-9'.,&#]+( [-a-zA-Z0-9'.,&#]+)*$",
+      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
     },
     addressLine3: {
       type: 'string',
       maxLength: 20,
-      pattern: "^[-a-zA-Z0-9'.,&#]+( [-a-zA-Z0-9'.,&#]+)*$",
+      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
     },
     city: {
       type: 'string',
       maxLength: 30,
-      pattern: "^[-a-zA-Z0-9'.#]+( [-a-zA-Z0-9'.#]+)*$",
+      pattern: "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
     },
     state: {
       $ref: '#/definitions/state',
@@ -260,19 +260,19 @@ const schema = {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^([-a-zA-Z0-9/']+(?: [-a-zA-Z0-9/']+)*)$",
+            pattern: "^([-a-zA-Z0-9/']+( ?))+$",
           },
           middle: {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^([-a-zA-Z0-9/']+(?: [-a-zA-Z0-9/']+)*)$",
+            pattern: "^([-a-zA-Z0-9/']+( ?))+$",
           },
           last: {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^([-a-zA-Z0-9/']+(?: [-a-zA-Z0-9/']+)*)$",
+            pattern: "^([-a-zA-Z0-9/']+( ?))+$",
           },
         },
       },
@@ -446,7 +446,7 @@ const schema = {
             separationLocationName: {
               type: 'string',
               maxLength: 256,
-              pattern: "^[a-zA-Z0-9\\/\\-'.#,*()&]+( [a-zA-Z0-9\\/\\-'.#,*()&]+)*$",
+              pattern: "^([a-zA-Z0-9\\/\\-'.#,*()&][a-zA-Z0-9\\/\\-'.#,*()& ]?)*$",
             },
           },
         },
@@ -457,7 +457,7 @@ const schema = {
             unitName: {
               type: 'string',
               maxLength: 256,
-              pattern: "^[a-zA-Z0-9\\-'.#]+( [a-zA-Z0-9\\-'.#]+)*$",
+              pattern: "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$",
             },
             obligationTermOfServiceDateRange: {
               $ref: '#/definitions/dateRangeAllRequired',
@@ -588,7 +588,7 @@ const schema = {
           type: 'string',
           minLength: 1,
           maxLength: 100,
-          pattern: "^([-a-zA-Z0-9/']( ?))*$",
+          pattern: "^([-a-zA-Z0-9/']+( ?))*$",
         },
         phoneNumber: {
           $ref: '#/definitions/phone',
@@ -609,7 +609,7 @@ const schema = {
           treatmentCenterName: {
             type: 'string',
             maxLength: 100,
-            pattern: '^([-a-zA-Z0-9"\\/&()\'.#]+( [-a-zA-Z0-9"\\/&()\'.#]+)*)$',
+            pattern: "([-a-zA-Z0-9\"\\/&()'.#]([-a-zA-Z0-9()'.# ])?)+$",
           },
           treatmentDateRange: {
             $ref: '#/definitions/dateRange',

--- a/src/schemas/21-526EZ-allclaims/schema.js
+++ b/src/schemas/21-526EZ-allclaims/schema.js
@@ -40,22 +40,22 @@ const baseAddressDef = {
     addressLine1: {
       type: 'string',
       maxLength: 20,
-      pattern: "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$",
+      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
     },
     addressLine2: {
       type: 'string',
       maxLength: 20,
-      pattern: "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$",
+      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
     },
     addressLine3: {
       type: 'string',
       maxLength: 20,
-      pattern: "^[ ]*[-a-zA-Z0-9'.,&#]+([ ]+[-a-zA-Z0-9'.,&#]+)*[ ]*$",
+      pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
     },
     city: {
       type: 'string',
       maxLength: 30,
-      pattern: "^[ ]*[-a-zA-Z0-9'.#]+([ ]+[-a-zA-Z0-9'.#]+)*[ ]*$",
+      pattern: "^([-a-zA-Z0-9'.#]([-a-zA-Z0-9'.# ])?)+$",
     },
     state: {
       $ref: '#/definitions/state',
@@ -260,19 +260,19 @@ const schema = {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^[ ]*[-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*[ ]*$",
+            pattern: "^([-a-zA-Z0-9/']+( ?))+$",
           },
           middle: {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^[ ]*[-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*[ ]*$",
+            pattern: "^([-a-zA-Z0-9/']+( ?))+$",
           },
           last: {
             type: 'string',
             minLength: 1,
             maxLength: 30,
-            pattern: "^[ ]*[-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*[ ]*$",
+            pattern: "^([-a-zA-Z0-9/']+( ?))+$",
           },
         },
       },
@@ -446,7 +446,7 @@ const schema = {
             separationLocationName: {
               type: 'string',
               maxLength: 256,
-              pattern: "^[ ]*([a-zA-Z0-9\\/\\-'.#,*()&]+( *[a-zA-Z0-9\\/\\-'.#,*()&]+)*)?[ ]*$",
+              pattern: "^([a-zA-Z0-9\\/\\-'.#,*()&][a-zA-Z0-9\\/\\-'.#,*()& ]?)*$",
             },
           },
         },
@@ -457,7 +457,7 @@ const schema = {
             unitName: {
               type: 'string',
               maxLength: 256,
-              pattern: "^[ ]*([a-zA-Z0-9\\-'.#]+( *[a-zA-Z0-9\\-'.#]+)*)?[ ]*$",
+              pattern: "^([a-zA-Z0-9\\-'.#][a-zA-Z0-9\\-'.# ]?)*$",
             },
             obligationTermOfServiceDateRange: {
               $ref: '#/definitions/dateRangeAllRequired',
@@ -588,7 +588,7 @@ const schema = {
           type: 'string',
           minLength: 1,
           maxLength: 100,
-          pattern: "^[ ]*([-a-zA-Z0-9/']+( *[-a-zA-Z0-9/']+)*)?[ ]*$",
+          pattern: "^([-a-zA-Z0-9/']+( ?))*$",
         },
         phoneNumber: {
           $ref: '#/definitions/phone',
@@ -609,7 +609,7 @@ const schema = {
           treatmentCenterName: {
             type: 'string',
             maxLength: 100,
-            pattern: '^[ ]*[-a-zA-Z0-9"\\/&()\'.#]+( *[-a-zA-Z0-9"\\/&()\'.#]+)*[ ]*$',
+            pattern: "([-a-zA-Z0-9\"\\/&()'.#]([-a-zA-Z0-9()'.# ])?)+$",
           },
           treatmentDateRange: {
             $ref: '#/definitions/dateRange',


### PR DESCRIPTION
# New schema
On May 29 and July 8 of 2025, updates to pattern regex for a number of fields in Form 21-526EZ schema were made to address code scanning alerts. However, it was discovered that, for some fields, these updates resulted in unexpected validation errors for inputs with leading/trailing or double spaces. This reverts all pattern regex changes made in the 2 PRs identified as being the source of undesired validation errors. A future update will again modify the same pattern regex such that it addresses the original CodeQL scanning alerts without breaking intended validation.

_Please ensure you have incremented the version in_ `package.json`. ✅ 

- https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1007
- https://github.com/department-of-veterans-affairs/vets-json-schema/pull/1025
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/119382

## Pull Requests to update the schema in related repositories
_After you've merged your changes to vets-json-schema you'll need to make PR's to vets-website and vets-api. Please link them here._

- **TODO** https://github.com/department-of-veterans-affairs/vets-api/pull/
- **TODO** https://github.com/department-of-veterans-affairs/vets-website/pull/
