### PR TITLE
VEBT-3447: 22-10297 - Implement international phone numbers

### DIFF
--- a/dist/22-10297-schema.json
+++ b/dist/22-10297-schema.json
@@ -274,10 +274,6 @@
       "type": "string",
       "pattern": "^[0-9]{9}$"
     },
-    "usaPhone": {
-      "type": "string",
-      "pattern": "^\\d{10}$"
-    },
     "vaFileNumber": {
       "type": "string",
       "pattern": "^[cC]{0,1}\\d{7,9}$"
@@ -306,10 +302,10 @@
       "type": "object",
       "properties": {
         "mobilePhone": {
-          "$ref": "#/definitions/usaPhone"
+          "type": "string"
         },
         "homePhone": {
-          "$ref": "#/definitions/usaPhone"
+          "type": "string"
         },
         "emailAddress": {
           "$ref": "#/definitions/email"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "25.2.9",
+  "version": "25.2.10",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/schemas/22-10297/schema.js
+++ b/src/schemas/22-10297/schema.js
@@ -11,7 +11,6 @@ const pickedDefinitions = _.pick(origDefinitions, [
   'fullNameNoSuffix',
   'privacyAgreementAccepted',
   'ssn',
-  'usaPhone',
   'vaFileNumber',
   'yesNoSchema',
 ]);
@@ -42,10 +41,10 @@ const schema = {
       type: 'object',
       properties: {
         mobilePhone: {
-          $ref: '#/definitions/usaPhone',
+          type: 'string',
         },
         homePhone: {
-          $ref: '#/definitions/usaPhone',
+          type: 'string',
         },
         emailAddress: {
           $ref: '#/definitions/email',

--- a/test/schemas/22-10297/schema.spec.js
+++ b/test/schemas/22-10297/schema.spec.js
@@ -86,15 +86,15 @@ const testData = {
   contactInfo: {
     valid: [
       {
-        mobilePhone: '1234567890',
-        homePhone: '1112223333',
+        mobilePhone: '+1 1234567890 (US)',
+        homePhone: '+44 7654321 (GB)',
         emailAddress: 'test@email.com',
       },
     ],
     invalid: [
       {
-        mobilePhone: '',
-        homePhone: '1112223333',
+        mobilePhone: 1234567890,
+        homePhone: null,
         emailAddress: 'test@email.com',
       },
     ],


### PR DESCRIPTION
# New schema
- Both numbers for the `contactInfo` object have been updated to support international phone numbers
- The 2 fields to be updated are `contactInfo.homePhone` and `contactInfo.mobilePhone`
- The schema for these fields was updated from `usaPhone` schema to a `string` which allows the country code to be included

- The `package.json` patch version has been incremented to `25.2.10`

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/

## Pull Requests to update the schema in related repositories
- Related repositories to be updated
- https://github.com/department-of-veterans-affairs/vets-api/pull/
- https://github.com/department-of-veterans-affairs/vets-website/pull/
