### PR TITLE
feat: allow L1839 id for bdd sha docs

### DIFF
--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -1292,7 +1292,7 @@
               "VA Form 21-674 - Request for Approval of School Attendance",
               "VA Form 21-686c - Declaration of Status of Dependents",
               "VA Form 21-8940 - Veterans Application for Increased Compensation Based on Un-employability",
-              "Separation Health Assessment (SHA)"
+              "Separation Health Assessment (SHA) - Part A"
             ]
           }
         }

--- a/dist/21-526EZ-ALLCLAIMS-schema.json
+++ b/dist/21-526EZ-ALLCLAIMS-schema.json
@@ -1263,7 +1263,8 @@
               "L159",
               "L133",
               "L139",
-              "L149"
+              "L149",
+              "L1839"
             ],
             "enumNames": [
               "Buddy/Lay Statement",
@@ -1290,7 +1291,8 @@
               "VA Form 26-4555 - Application in Acquiring Specially Adapted Housing or Special Home Adaptation Grant",
               "VA Form 21-674 - Request for Approval of School Attendance",
               "VA Form 21-686c - Declaration of Status of Dependents",
-              "VA Form 21-8940 - Veterans Application for Increased Compensation Based on Un-employability"
+              "VA Form 21-8940 - Veterans Application for Increased Compensation Based on Un-employability",
+              "Separation Health Assessment (SHA)"
             ]
           }
         }

--- a/dist/constants.json
+++ b/dist/constants.json
@@ -1549,7 +1549,7 @@
     },
     {
       "value": "L1839",
-      "label": "Separation Health Assessment (SHA)"
+      "label": "Separation Health Assessment (SHA) - Part A"
     }
   ],
   "genders": [

--- a/dist/constants.json
+++ b/dist/constants.json
@@ -1546,6 +1546,10 @@
     {
       "value": "L149",
       "label": "VA Form 21-8940 - Veterans Application for Increased Compensation Based on Un-employability"
+    },
+    {
+      "value": "L1839",
+      "label": "Separation Health Assessment (SHA)"
     }
   ],
   "genders": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vets-json-schema",
-  "version": "25.2.62",
+  "version": "25.3.62",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -247,7 +247,7 @@ const documentTypes526 = [
     value: 'L149',
     label: 'VA Form 21-8940 - Veterans Application for Increased Compensation Based on Un-employability',
   },
-  { value: 'L1839', label: 'Separation Health Assessment (SHA)' },
+  { value: 'L1839', label: 'Separation Health Assessment (SHA) - Part A' },
 ];
 
 // These definitions match caseflow:

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -220,11 +220,7 @@ const documentTypes526 = [
     value: 'L222',
     label: 'VA Form 21-0779 - Request for Nursing Home Information in Connection with Claim for Aid & Attendance',
   },
-  {
-    value: 'L228',
-    label:
-      'VA Form 21-0781 - Statement in Support of Claimed Mental Health Disorder(s) Due to an In-Service Traumatic Event(s)',
-  },
+  { value: 'L228', label: 'VA Form 21-0781 - Statement in Support of Claimed Mental Health Disorder(s) Due to an In-Service Traumatic Event(s)' },
   { value: 'L229', label: 'VA Form 21-0781a - Statement in Support of Claim for PTSD Secondary to Personal Assault' },
   {
     value: 'L102',

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -220,7 +220,11 @@ const documentTypes526 = [
     value: 'L222',
     label: 'VA Form 21-0779 - Request for Nursing Home Information in Connection with Claim for Aid & Attendance',
   },
-  { value: 'L228', label: 'VA Form 21-0781 - Statement in Support of Claimed Mental Health Disorder(s) Due to an In-Service Traumatic Event(s)' },
+  {
+    value: 'L228',
+    label:
+      'VA Form 21-0781 - Statement in Support of Claimed Mental Health Disorder(s) Due to an In-Service Traumatic Event(s)',
+  },
   { value: 'L229', label: 'VA Form 21-0781a - Statement in Support of Claim for PTSD Secondary to Personal Assault' },
   {
     value: 'L102',
@@ -247,6 +251,7 @@ const documentTypes526 = [
     value: 'L149',
     label: 'VA Form 21-8940 - Veterans Application for Increased Compensation Based on Un-employability',
   },
+  { value: 'L1839', label: 'Separation Health Assessment (SHA)' },
 ];
 
 // These definitions match caseflow:


### PR DESCRIPTION
Adding L1839 as an allowed value for use when users upload a separation health assessment document in the 526ez form. This is to enable better categorization of these as they are currently lumped together with L702 document types.

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/138463
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/138444

## Screenshots

### No attachment id while filling out form

<img width="2256" height="1134" alt="image" src="https://github.com/user-attachments/assets/5efb7bce-db9e-469f-bf64-ab8ad150324c" />

### Attachment id set to L1839 on submission and goes through successfully

<img width="2235" height="1127" alt="image" src="https://github.com/user-attachments/assets/a49421c2-dfb2-4717-b40e-8303b215b466" />

## Pull Requests to update the schema in related repositories

- https://github.com/department-of-veterans-affairs/vets-api/pull/27643
- https://github.com/department-of-veterans-affairs/vets-website/pull/43878
