### PR TITLE
FDF template fix

### DIFF
--- a/dist/21-686C-V2-template.json
+++ b/dist/21-686C-V2-template.json
@@ -609,7 +609,9 @@
               "fields": [
                 {
                   "fieldLabel": "Is this child permanently unable to support themselves because they developed a permanent mental or physical disability before they turned 18 years old?",
-                  "fieldValue": "{{formatBool doesChildHavePermanentDisability 'Yes' 'No'}}"
+                  "fieldValue": "{{formatBool doesChildHavePermanentDisability 'Yes' 'No'}}",
+                  "showIf": "doesChildHavePermanentDisability",
+                  "showIfCondition": "defined"
                 }
               ]
             },

--- a/dist/21-686C-V2-template.json
+++ b/dist/21-686C-V2-template.json
@@ -606,12 +606,12 @@
             },
             {
               "blockLabel": "Child's disability details",
+              "showIf": "doesChildHavePermanentDisability",
+              "showIfCondition": "defined",
               "fields": [
                 {
                   "fieldLabel": "Is this child permanently unable to support themselves because they developed a permanent mental or physical disability before they turned 18 years old?",
-                  "fieldValue": "{{formatBool doesChildHavePermanentDisability 'Yes' 'No'}}",
-                  "showIf": "doesChildHavePermanentDisability",
-                  "showIfCondition": "defined"
+                  "fieldValue": "{{formatBool doesChildHavePermanentDisability 'Yes' 'No'}}"
                 }
               ]
             },


### PR DESCRIPTION
This PR is part of the Fully Digital Forms (see [super-epic](https://github.com/department-of-veterans-affairs/va.gov-team/issues/117360)), an initiative to replace VA.gov-generated PDFs with structured JSON that can be rendered in VBMS and VA.gov.

As part of an initial March 2026 pilot focused on form 21-686c, we are hosting the existing 21-686c schema along with a new corresponding **21-686c renderer template** in this repo, `vets-json-schema`.

- This PR, and the presence of `dist/21-686C-V2-template.json`, will have **no direct impact on VA.gov**, frontend or backend. Therefore, `package.json` is unchanged, as Fully Digital Forms does not consume this repo as a package.
- The intention is to host FDF schemas and templates elsewhere after the initial March pilot.

# What's new in this PR?

This PR has small changes to the 21-686c renderer template, included adding new showIf values for the "Child's disability details" section