### PR TITLE
Add JSON Schema for VA Form PIPE-TEST

### DIFF
--- a/src/schemas/PIPE-TEST-schema.json
+++ b/src/schemas/PIPE-TEST-schema.json
@@ -1,0 +1,327 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "VA Form PIPE-TEST Schema",
+  "type": "object",
+  "additionalProperties": false,
+  "definitions": {
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
+    "fullName": {
+      "type": "object",
+      "properties": {
+        "first": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 30
+        },
+        "middle": {
+          "type": "string",
+          "maxLength": 30
+        },
+        "last": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 30
+        },
+        "suffix": {
+          "type": "string",
+          "enum": ["Jr.", "Sr.", "II", "III", "IV"]
+        }
+      },
+      "required": ["first", "last"]
+    },
+    "address": {
+      "type": "object",
+      "properties": {
+        "addressLine1": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 50
+        },
+        "addressLine2": {
+          "type": "string",
+          "maxLength": 50
+        },
+        "addressLine3": {
+          "type": "string",
+          "maxLength": 50
+        },
+        "city": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 51
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "AL", "AK", "AS", "AZ", "AR", "CA", "CO", "CT", "DE", "DC", "FM", "FL", "GA",
+            "GU", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MH", "MD", "MA",
+            "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC", "ND",
+            "MP", "OH", "OK", "OR", "PW", "PA", "PR", "RI", "SC", "SD", "TN", "TX", "UT",
+            "VT", "VI", "VA", "WA", "WV", "WI", "WY"
+          ]
+        },
+        "postalCode": {
+          "type": "string",
+          "pattern": "^[0-9]{5}(-[0-9]{4})?$"
+        },
+        "country": {
+          "type": "string",
+          "enum": ["USA", "AFG", "ALB", "DZA", "AND", "AGO", "ATG", "ARG", "ARM", "AUS", "AUT", "AZE", "BHS", "BHR", "BGD", "BRB", "BLR", "BEL", "BLZ", "BEN", "BTN", "BOL", "BIH", "BWA", "BRA", "BRN", "BGR", "BFA", "BDI", "KHM", "CMR", "CAN", "CPV", "CAF", "TCD", "CHL", "CHN", "COL", "COM", "COG", "COD", "CRI", "CIV", "HRV", "CUB", "CYP", "CZE", "DNK", "DJI", "DMA", "DOM", "ECU", "EGY", "SLV", "GNQ", "ERI", "EST", "ETH", "FJI", "FIN", "FRA", "GAB", "GMB", "GEO", "DEU", "GHA", "GRC", "GRD", "GTM", "GIN", "GNB", "GUY", "HTI", "HND", "HUN", "ISL", "IND", "IDN", "IRN", "IRQ", "IRL", "ISR", "ITA", "JAM", "JPN", "JOR", "KAZ", "KEN", "KIR", "PRK", "KOR", "KWT", "KGZ", "LAO", "LVA", "LBN", "LSO", "LBR", "LBY", "LIE", "LTU", "LUX", "MKD", "MDG", "MWI", "MYS", "MDV", "MLI", "MLT", "MHL", "MRT", "MUS", "MEX", "FSM", "MDA", "MCO", "MNG", "MNE", "MAR", "MOZ", "MMR", "NAM", "NRU", "NPL", "NLD", "NZL", "NIC", "NER", "NGA", "NOR", "OMN", "PAK", "PLW", "PAN", "PNG", "PRY", "PER", "PHL", "POL", "PRT", "QAT", "ROU", "RUS", "RWA", "KNA", "LCA", "VCT", "WSM", "SMR", "STP", "SAU", "SEN", "SRB", "SYC", "SLE", "SGP", "SVK", "SVN", "SLB", "SOM", "ZAF", "ESP", "LKA", "SDN", "SUR", "SWZ", "SWE", "CHE", "SYR", "TWN", "TJK", "TZA", "THA", "TLS", "TGO", "TON", "TTO", "TUN", "TUR", "TKM", "TUV", "UGA", "UKR", "ARE", "GBR", "URY", "UZB", "VUT", "VEN", "VNM", "YEM", "ZMB", "ZWE"]
+        }
+      },
+      "required": ["addressLine1", "city", "state", "postalCode", "country"]
+    },
+    "phone": {
+      "type": "string",
+      "pattern": "^[0-9]{10}$"
+    },
+    "ssn": {
+      "type": "string",
+      "pattern": "^[0-9]{9}$"
+    },
+    "email": {
+      "type": "string",
+      "format": "email",
+      "maxLength": 256
+    }
+  },
+  "properties": {
+    "formVerificationStatus": {
+      "type": "string",
+      "enum": ["verified", "not-found", "pending"],
+      "default": "not-found"
+    },
+    "personalInformation": {
+      "type": "object",
+      "properties": {
+        "fullName": {
+          "$ref": "#/definitions/fullName"
+        },
+        "socialSecurityNumber": {
+          "$ref": "#/definitions/ssn"
+        },
+        "dateOfBirth": {
+          "$ref": "#/definitions/date"
+        },
+        "gender": {
+          "type": "string",
+          "enum": ["M", "F"]
+        },
+        "maritalStatus": {
+          "type": "string",
+          "enum": ["Single", "Married", "Divorced", "Widowed", "Separated"]
+        }
+      },
+      "required": ["fullName", "socialSecurityNumber", "dateOfBirth"]
+    },
+    "contactInformation": {
+      "type": "object",
+      "properties": {
+        "mailingAddress": {
+          "$ref": "#/definitions/address"
+        },
+        "homeAddress": {
+          "$ref": "#/definitions/address"
+        },
+        "sameMailingAndHomeAddress": {
+          "type": "boolean"
+        },
+        "primaryPhone": {
+          "$ref": "#/definitions/phone"
+        },
+        "secondaryPhone": {
+          "$ref": "#/definitions/phone"
+        },
+        "emailAddress": {
+          "$ref": "#/definitions/email"
+        },
+        "preferredContactMethod": {
+          "type": "string",
+          "enum": ["mail", "phone", "email"]
+        }
+      },
+      "required": ["mailingAddress", "primaryPhone", "emailAddress"]
+    },
+    "serviceInformation": {
+      "type": "object",
+      "properties": {
+        "hasServiceHistory": {
+          "type": "boolean"
+        },
+        "servicePeriods": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "serviceBranch": {
+                "type": "string",
+                "enum": ["Army", "Navy", "Air Force", "Marines", "Coast Guard", "Space Force"]
+              },
+              "dateRange": {
+                "type": "object",
+                "properties": {
+                  "from": {
+                    "$ref": "#/definitions/date"
+                  },
+                  "to": {
+                    "$ref": "#/definitions/date"
+                  }
+                },
+                "required": ["from", "to"]
+              },
+              "serviceCharacter": {
+                "type": "string",
+                "enum": ["Honorable", "Under Honorable Conditions", "Dishonorable", "Bad Conduct", "Other Than Honorable", "Uncharacterized"]
+              },
+              "activeDutyStatus": {
+                "type": "string",
+                "enum": ["Active", "Reserve", "National Guard"]
+              }
+            },
+            "required": ["serviceBranch", "dateRange", "serviceCharacter"]
+          },
+          "maxItems": 10
+        },
+        "currentlyServing": {
+          "type": "boolean"
+        },
+        "separationDate": {
+          "$ref": "#/definitions/date"
+        }
+      },
+      "required": ["hasServiceHistory"]
+    },
+    "applicationDetails": {
+      "type": "object",
+      "properties": {
+        "applicationPurpose": {
+          "type": "string",
+          "enum": ["benefit-enrollment", "status-update", "information-request", "claim-submission", "other"]
+        },
+        "priorityProcessing": {
+          "type": "boolean"
+        },
+        "urgencyReason": {
+          "type": "string",
+          "enum": ["financial-hardship", "medical-emergency", "homeless", "terminal-illness", "other"]
+        },
+        "hasRepresentative": {
+          "type": "boolean"
+        },
+        "representativeInfo": {
+          "type": "object",
+          "properties": {
+            "fullName": {
+              "$ref": "#/definitions/fullName"
+            },
+            "organizationName": {
+              "type": "string",
+              "maxLength": 100
+            },
+            "contactInfo": {
+              "type": "object",
+              "properties": {
+                "phone": {
+                  "$ref": "#/definitions/phone"
+                },
+                "email": {
+                  "$ref": "#/definitions/email"
+                },
+                "address": {
+                  "$ref": "#/definitions/address"
+                }
+              },
+              "required": ["phone"]
+            }
+          },
+          "required": ["fullName", "contactInfo"]
+        },
+        "previousApplications": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "applicationDate": {
+                "$ref": "#/definitions/date"
+              },
+              "applicationNumber": {
+                "type": "string",
+                "pattern": "^[A-Z0-9]{8,12}$"
+              },
+              "applicationStatus": {
+                "type": "string",
+                "enum": ["approved", "denied", "pending", "withdrawn"]
+              }
+            },
+            "required": ["applicationDate"]
+          },
+          "maxItems": 5
+        }
+      },
+      "required": ["applicationPurpose"]
+    },
+    "supportingDocuments": {
+      "type": "object",
+      "properties": {
+        "hasDocuments": {
+          "type": "boolean"
+        },
+        "documentTypes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "dd214",
+              "medical-records",
+              "financial-statements",
+              "identification",
+              "marriage-certificate",
+              "divorce-decree",
+              "death-certificate",
+              "other"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "additionalDocumentDescription": {
+          "type": "string",
+          "maxLength": 500
+        },
+        "documentsSubmittedSeparately": {
+          "type": "boolean"
+        }
+      },
+      "required": ["hasDocuments"]
+    },
+    "certificationAndSignature": {
+      "type": "object",
+      "properties": {
+        "certifyTruthfulness": {
+          "type": "boolean",
+          "enum": [true]
+        },
+        "agreeToTerms": {
+          "type": "boolean",
+          "enum": [true]
+        },
+        "signature": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "signatureDate": {
+          "$ref": "#/definitions/date"
+        },
+        "privacyAgreementAccepted": {
+          "type": "boolean",
+          "enum": [true]
+        }
+      },
+      "required": ["certifyTruthfulness", "agreeToTerms", "signature", "signatureDate", "privacyAgreementAccepted"]
+    }
+  },
+  "required": ["formVerificationStatus", "personalInformation", "contactInformation", "certificationAndSignature"]
+}


### PR DESCRIPTION
This pull request adds a JSON Schema for VA Form PIPE-TEST.

**Note:** This schema was auto-generated by Optimus and requires engineer review before merging.

The schema includes standard VA form fields and validation patterns, but several field definitions are based on common VA form patterns rather than actual PIPE-TEST requirements since this form doesn't exist in the official inventory. Please review and update the following areas:

- Application purpose enum values
- Document types supported
- Service information requirements
- Urgency reason categories
- Form verification status field (should be removed once form is verified)
- Maximum array lengths for service periods and previous applications

All field definitions follow vets-json-schema conventions with proper validation patterns and required field structures.